### PR TITLE
upload response bug fix

### DIFF
--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -102,9 +102,6 @@ public class GcpBlobStore extends AbstractBlobStore<GcpBlobStore> {
             throw new SubstrateSdkException("Request failed while uploading from input stream", e);
         }
         Blob blob = storage.get(getBucket(), uploadRequest.getKey());
-        if(blob == null) {
-            throw new SubstrateSdkException("Could not locate newly uploaded blob");
-        }
         return transformer.toUploadResponse(blob);
     }
 


### PR DESCRIPTION
Fixes bug where UploadResponse was incorrect due to incomplete data upload. Ensures ByteStreams.copy writes to the correct channel before fetching the blob