### PR TITLE
test: fix transform logic and relax usage conditions

### DIFF
--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/util/MultipartBoundaryTransformer.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/util/MultipartBoundaryTransformer.java
@@ -32,11 +32,6 @@ public class MultipartBoundaryTransformer extends StubMappingTransformer {
 
   @Override
   public StubMapping transform(StubMapping stubMapping, FileSource files, Parameters parameters) {
-    String url = stubMapping.getRequest().getUrl();
-    if (url == null || !url.contains("uploadType=multipart")) {
-      return stubMapping;
-    }
-
     List<ContentPattern<?>> bodyPatterns = stubMapping.getRequest().getBodyPatterns();
     if (bodyPatterns == null || bodyPatterns.isEmpty()) {
       return stubMapping;
@@ -54,13 +49,16 @@ public class MultipartBoundaryTransformer extends StubMappingTransformer {
         Matcher matcher = BOUNDARY_PATTERN.matcher(textContent);
         if (matcher.find()) {
           String boundaryLiteral = "--" + matcher.group(1);
-          String escapedEntireBody = Pattern.quote(textContent);
-          String boundaryToReplace = Pattern.quote(boundaryLiteral);
-          String regex =
-              "(?s)"
-                  + escapedEntireBody.replace(
-                      boundaryToReplace, "\\E" + BOUNDARY_REGEX + "\\Q");
-          newPatterns.add(new RegexPattern(regex));
+          // Replace boundary with wildcard, then quote the remaining literal parts
+          String[] parts = textContent.split(Pattern.quote(boundaryLiteral), -1);
+          StringBuilder regex = new StringBuilder("(?s)");
+          for (int i = 0; i < parts.length; i++) {
+            if (i > 0) {
+              regex.append(BOUNDARY_REGEX);
+            }
+            regex.append(Pattern.quote(parts[i]));
+          }
+          newPatterns.add(new RegexPattern(regex.toString()));
           modified = true;
           continue;
         }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "0e11e32b-1cf0-41ca-b165-f59d3dc0add1",
+  "id" : "1c748aed-bf9c-4925-a69d-bdfabea21edd",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-DELETE-0",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG0fq3-vLGDfiTE61huDR6F2s5Cgrs65bmi0qASRpNPOFY6VyO8OLnwQsPWubv8I2kuOA5jhQA",
+      "X-GUploader-UploadID" : "AMNfjG1CiSxuopWfF2Bk-6IyD8Jf5EzHs7qbtkSTeYox5iW1GX3H27YVD6G2i1i55TQ-KhtdXYbYFSg",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:58 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:24 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "0e11e32b-1cf0-41ca-b165-f59d3dc0add1",
+  "uuid" : "1c748aed-bf9c-4925-a69d-bdfabea21edd",
   "persistent" : true,
-  "insertionIndex" : 1113
+  "insertionIndex" : 1170
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-12.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-12.json
@@ -1,5 +1,5 @@
 {
-  "id" : "f1d4a2f0-d011-4218-9b22-58fd57862600",
+  "id" : "88410310-038e-46c6-ac07-0f9b88df1b1a",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-DELETE-12",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG3t3jUmIqQezkqbm1J4aKNfFzVBeGf4ZKTLjJV3VDCdoXqrShxGKQ5cV5tM9DUIY0B9JTX2DA",
+      "X-GUploader-UploadID" : "AMNfjG0fFhsifBB75sWm07veA7TiZSKzfBhPZ21JXRO3mHy4CO_2uhWyVBpXqN6DUe3cmfEBYnrSDXg",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:55 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:20 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "f1d4a2f0-d011-4218-9b22-58fd57862600",
+  "uuid" : "88410310-038e-46c6-ac07-0f9b88df1b1a",
   "persistent" : true,
-  "insertionIndex" : 1125
+  "insertionIndex" : 1182
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-17.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-17.json
@@ -1,5 +1,5 @@
 {
-  "id" : "3d77c9df-fae5-4b2a-afb9-8b45ea18266a",
+  "id" : "a2e3c7eb-5b9b-495e-9ba1-fc0cf6b08a0b",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-DELETE-17",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG18pgekCzwo5dbo5iQue_KHJEEhEmesG1awcrwG4AERzh2ol8p6rfUjb29UjVApd6pkcLqlJw",
+      "X-GUploader-UploadID" : "AMNfjG0lEOr3Da6yr68RfbkrjWTxPUP-BwiLEXwvz2nfIepyJ2ww3ZUgmQoMKjnC5ZvXnp1WwuYjGhM",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:53 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:19 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "3d77c9df-fae5-4b2a-afb9-8b45ea18266a",
+  "uuid" : "a2e3c7eb-5b9b-495e-9ba1-fc0cf6b08a0b",
   "persistent" : true,
-  "insertionIndex" : 1130
+  "insertionIndex" : 1187
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-24.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-24.json
@@ -1,5 +1,5 @@
 {
-  "id" : "275a8264-613c-4839-a9dd-f9d1925c7877",
+  "id" : "2e403938-f72e-4dec-87f1-bd222dcd2cbf",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-DELETE-24",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG3RIYgAM7OjChpow6QDlAUQJFthkddMquEC5u_w8Ue74NWPIc9L960QKspouBuR4x04201G",
+      "X-GUploader-UploadID" : "AMNfjG0D0ugdkXh78m-u2wUCHaEdLtNfEtFhNdoM6_riglfl220lobWG4JAK2tx1tFraaHC7oxh3-xw",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:51 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:17 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "275a8264-613c-4839-a9dd-f9d1925c7877",
+  "uuid" : "2e403938-f72e-4dec-87f1-bd222dcd2cbf",
   "persistent" : true,
-  "insertionIndex" : 1137
+  "insertionIndex" : 1194
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-30.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-30.json
@@ -1,5 +1,5 @@
 {
-  "id" : "82d3fe2e-b4db-4266-b3ec-eb34a0bbbd67",
+  "id" : "9dd31719-e0ec-400c-9fb2-d06bcd1758fa",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-DELETE-30",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG1D1xOLx5KElCpyE60CcGMfC2Bw9kQmJkRwslXLbmitJH1TTJXLx-bhbMmWSbPyGbrWJC6A",
+      "X-GUploader-UploadID" : "AMNfjG3h_7saGismArMONSyosyftZUHnunmzNhryb1SD1jqvTSWAO0A61PMBSt0FCa6A2WJs8_obs5w",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:49 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:15 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "82d3fe2e-b4db-4266-b3ec-eb34a0bbbd67",
+  "uuid" : "9dd31719-e0ec-400c-9fb2-d06bcd1758fa",
   "persistent" : true,
-  "insertionIndex" : 1143
+  "insertionIndex" : 1200
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-36.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-36.json
@@ -1,5 +1,5 @@
 {
-  "id" : "a38a00e1-40cf-4b34-9e73-35f207471be1",
+  "id" : "35a777b5-86b5-4164-8c36-7c0e1e9efbc1",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-DELETE-36",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG0Ak4WIOjPW_raA17UnuY5uWEUfwPfJ2iTXK2r2CY4UeZrKDUrt_qkp1Kk1yPTmt_tnmjKm_g",
+      "X-GUploader-UploadID" : "AMNfjG1PBN-9mzTKeZKzb8uTQIInUWs0ZGhnPrnUNJ_jI00gZ4TUNgB9IcjDZDwy1VEQSbvy7OofZs0",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:47 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:13 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "a38a00e1-40cf-4b34-9e73-35f207471be1",
+  "uuid" : "35a777b5-86b5-4164-8c36-7c0e1e9efbc1",
   "persistent" : true,
-  "insertionIndex" : 1149
+  "insertionIndex" : 1206
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-41.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-41.json
@@ -1,5 +1,5 @@
 {
-  "id" : "fa4218f8-28d8-47af-8cb6-a6f9410984e5",
+  "id" : "7d40c71b-8d0f-4923-94f6-b011055352a6",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-DELETE-41",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG17jAvHUfsL6vd6UqZyWgNS8dFwI4l-hgHVawZlesZ9c46dB7iKRujqYefTZCyUp6dDMuPPAQ",
+      "X-GUploader-UploadID" : "AMNfjG0qOyZTuML1-5Xy5jpkd6jEo67Sq9tdlSncCCuGd0uh4ERfSfnkrQYtZy2Oi3fmwKk15slrabQ",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:46 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:11 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "fa4218f8-28d8-47af-8cb6-a6f9410984e5",
+  "uuid" : "7d40c71b-8d0f-4923-94f6-b011055352a6",
   "persistent" : true,
-  "insertionIndex" : 1154
+  "insertionIndex" : 1211
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-delete-6.json
@@ -1,5 +1,5 @@
 {
-  "id" : "e2b5bfc4-ee5b-4273-bdaa-41e4dfffa0e2",
+  "id" : "62339b0f-4194-4d7f-82d0-59e35e4d1515",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-DELETE-6",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG0CVkbs2Q3ujpNemwAdXvMyoqcYtFqU1uS2wSrbVQSn_iZwYOie2E2NGAQqgJDNHbO-aga6oQ",
+      "X-GUploader-UploadID" : "AMNfjG3WL1lYYkb_zoXF1VR1IqTvxBH8c0XTPaRLBQg1IjHaxeKRRiXTB_v6i_-D0lMccpIwi-1_0jI",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:57 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:22 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "e2b5bfc4-ee5b-4273-bdaa-41e4dfffa0e2",
+  "uuid" : "62339b0f-4194-4d7f-82d0-59e35e4d1515",
   "persistent" : true,
-  "insertionIndex" : 1119
+  "insertionIndex" : 1176
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-1.json
@@ -1,9 +1,26 @@
 {
-  "id" : "6917c5f2-7d46-4abe-b391-6b99f6fc394f",
+  "id" : "bee5865e-3a03-41ab-b956-f3aacdf772e3",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-1",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?maxResults=1&projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -12,16 +29,16 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AMNfjG0NdXeuJ16pvdQPlqhXBBuTg1YxOOtc02D2ApfMeW1DVJ3EalU6eKraXszukpTUqescCnoZ1jtvDfe1",
+      "X-GUploader-UploadID" : "AMNfjG0A1zBs_ycUXhAWr7C6VYIB1I2w4w9FcQ6YPWe8T5rkmXSKdo37e4Z-O72n7A2QBOKOdiaehhA",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:58 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:58 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:24 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:24 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "6917c5f2-7d46-4abe-b391-6b99f6fc394f",
+  "uuid" : "bee5865e-3a03-41ab-b956-f3aacdf772e3",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-4",
-  "insertionIndex" : 1114
+  "insertionIndex" : 1171
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-13.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-13.json
@@ -1,9 +1,26 @@
 {
-  "id" : "301e52fc-8af5-4a1e-9864-a16cc3002b99",
+  "id" : "6561dec3-0365-40db-8310-dec7a6d43a64",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-13",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?maxResults=1&projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -12,17 +29,17 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AMNfjG1cfQlDZLGbJ-5VjGAaW41k1SM1WBE57b99HBSknSKEzZLPqF5_ygZX1LL1_sqgSRIWs4aROQ",
+      "X-GUploader-UploadID" : "AMNfjG03r12HKK-RhRI16LDqn3Wt3YnPrM4dXRFah3jp1l_0CHSHyDprZrxuttnBdfxUlQ288b06gPo",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:55 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:55 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:20 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:20 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "301e52fc-8af5-4a1e-9864-a16cc3002b99",
+  "uuid" : "6561dec3-0365-40db-8310-dec7a6d43a64",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-2",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-3",
-  "insertionIndex" : 1126
+  "insertionIndex" : 1183
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-14.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-14.json
@@ -1,9 +1,21 @@
 {
-  "id" : "63459236-5608-4976-9d91-cf6d0a3c01e7",
+  "id" : "65e9a70d-64c9-4d45-a018-47a09876f20b",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-14",
   "request" : {
-    "url" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray?alt=media",
-    "method" : "GET"
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -11,25 +23,25 @@
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
-      "X-Goog-Generation" : "1775853594225398",
+      "X-Goog-Generation" : "1776212599820955",
       "Pragma" : "no-cache",
-      "Last-Modified" : "Fri, 10 Apr 2026 20:39:54 GMT",
+      "Last-Modified" : "Wed, 15 Apr 2026 00:23:19 GMT",
       "X-Goog-Metageneration" : "1",
-      "Date" : "Fri, 10 Apr 2026 20:39:54 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:20 GMT",
       "X-Goog-Stored-Content-Encoding" : "identity",
       "X-Goog-Hash" : "crc32c=E30mnQ==,md5=cBu9S94e4E47BZb2OZTrrg==",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CPbVoJWS5JMDEAE=",
+      "ETag" : "CJulu8jL7pMDEAE=",
       "Content-Disposition" : "attachment",
       "X-Goog-Storage-Class" : "STANDARD",
-      "X-GUploader-UploadID" : "AMNfjG0Q5W-Sb_lyX1JybkDfpLXEPwv-s5HZ0rjCJc9H7x6Oiyc4vVq7S-5OS5GJWotmIYjX4nx62A",
+      "X-GUploader-UploadID" : "AMNfjG1sObfkKoTg0HdYfxMOiCwanlIJlNjNEpRDwLBoJ2eSDlvks8ZnMNOL3Qo7MXAh4vcAXwBP_sg",
       "Vary" : [ "Origin", "X-Origin" ],
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
       "X-Goog-Stored-Content-Length" : "17",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "63459236-5608-4976-9d91-cf6d0a3c01e7",
+  "uuid" : "65e9a70d-64c9-4d45-a018-47a09876f20b",
   "persistent" : true,
-  "insertionIndex" : 1127
+  "insertionIndex" : 1184
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-15.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-15.json
@@ -1,26 +1,38 @@
 {
-  "id" : "ecdadf83-4e7d-402e-8d43-f36f69384ee7",
+  "id" : "5e53cb89-a3a8-4032-b9e7-af1d75f75cca",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-15",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray?projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_ByteArray/1775853594225398\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray?generation=1775853594225398&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_ByteArray\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1775853594225398\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CPbVoJWS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:54.278Z\",\n  \"updated\": \"2026-04-10T20:39:54.278Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:54.278Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:54.278Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_ByteArray/1776212599820955\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray?generation=1776212599820955&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_ByteArray\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776212599820955\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CJulu8jL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:19.873Z\",\n  \"updated\": \"2026-04-15T00:23:19.873Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:19.873Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:19.873Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CPbVoJWS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG3l2ZYzRkBdhQddIl1q7Cah8304iKBkon3K4dYWpudDrY3LCB-d1U0jZLpIuWBAEv5CEgY2",
+      "ETag" : "CJulu8jL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG2KD08r48HwkkKvLjXxCFgCkH4MZ6C6nfYgGTBxBBQO7a-WHTWjjY-z10cX6haP1vxlCA6vs90",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:54 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:54 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:20 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:20 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "ecdadf83-4e7d-402e-8d43-f36f69384ee7",
+  "uuid" : "5e53cb89-a3a8-4032-b9e7-af1d75f75cca",
   "persistent" : true,
-  "insertionIndex" : 1128
+  "insertionIndex" : 1185
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-18.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-18.json
@@ -1,9 +1,26 @@
 {
-  "id" : "adcd161f-c2bf-4750-8d8d-452148ed46a8",
+  "id" : "feb46b93-043a-40aa-a448-96171ca528a5",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-18",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?maxResults=1&projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -12,17 +29,17 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AMNfjG1NWKHiG2gE7UqT2NOsSxRxy9XZTtlDv6Q9LQ25Gi4TABGUFVUaO0GbX1OMLHISMfPFTo-3",
+      "X-GUploader-UploadID" : "AMNfjG23rmZjuH_G8lVzlIn2EZHiHXCXJ6OK8MMJ0gt7UZ-3cRfhb8OwYvZkoaLPUyaOdsmBWATgMSs",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:53 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:53 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:19 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:19 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "adcd161f-c2bf-4750-8d8d-452148ed46a8",
+  "uuid" : "feb46b93-043a-40aa-a448-96171ca528a5",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-2",
-  "insertionIndex" : 1131
+  "insertionIndex" : 1188
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-19.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-19.json
@@ -1,9 +1,21 @@
 {
-  "id" : "feec6816-06b7-44df-a487-6772bcee9aeb",
+  "id" : "21e2520e-98b4-420d-82dd-edd42c2d9739",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-19",
   "request" : {
-    "url" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream?alt=media",
-    "method" : "GET"
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -11,25 +23,25 @@
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
-      "X-Goog-Generation" : "1775853592332090",
+      "X-Goog-Generation" : "1776212597984544",
       "Pragma" : "no-cache",
-      "Last-Modified" : "Fri, 10 Apr 2026 20:39:52 GMT",
+      "Last-Modified" : "Wed, 15 Apr 2026 00:23:18 GMT",
       "X-Goog-Metageneration" : "1",
-      "Date" : "Fri, 10 Apr 2026 20:39:53 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:18 GMT",
       "X-Goog-Stored-Content-Encoding" : "identity",
       "X-Goog-Hash" : "crc32c=E30mnQ==,md5=cBu9S94e4E47BZb2OZTrrg==",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CLqOrZSS5JMDEAE=",
+      "ETag" : "CKCay8fL7pMDEAE=",
       "Content-Disposition" : "attachment",
       "X-Goog-Storage-Class" : "STANDARD",
-      "X-GUploader-UploadID" : "AMNfjG0NOvtBk4HGojJheOXBQZK8kd18tGdaYLNi7HqeTfH__ZJ3A1TvkMeFFuAfKIthFF5zsaaT0lAGIqZ4",
+      "X-GUploader-UploadID" : "AMNfjG0QShktiM9YDdjsltJNNjAM_5_5FU2uLgU8aJdig2p6XrRk6Vkc5pdl_i9claLeIiV3fONQLio",
       "Vary" : [ "Origin", "X-Origin" ],
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
       "X-Goog-Stored-Content-Length" : "17",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "feec6816-06b7-44df-a487-6772bcee9aeb",
+  "uuid" : "21e2520e-98b4-420d-82dd-edd42c2d9739",
   "persistent" : true,
-  "insertionIndex" : 1132
+  "insertionIndex" : 1189
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-2.json
@@ -1,9 +1,21 @@
 {
-  "id" : "87001ce4-7ad8-425e-b5a4-267a03898824",
+  "id" : "fbff1e90-4427-4f3b-a73d-9bcbcf7d1069",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-2",
   "request" : {
-    "url" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path?alt=media",
-    "method" : "GET"
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -11,25 +23,25 @@
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
-      "X-Goog-Generation" : "1775853597832062",
+      "X-Goog-Generation" : "1776212603433481",
       "Pragma" : "no-cache",
-      "Last-Modified" : "Fri, 10 Apr 2026 20:39:57 GMT",
+      "Last-Modified" : "Wed, 15 Apr 2026 00:23:23 GMT",
       "X-Goog-Metageneration" : "1",
-      "Date" : "Fri, 10 Apr 2026 20:39:58 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:23 GMT",
       "X-Goog-Stored-Content-Encoding" : "identity",
       "X-Goog-Hash" : "crc32c=E30mnQ==,md5=cBu9S94e4E47BZb2OZTrrg==",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CP7m/JaS5JMDEAE=",
+      "ETag" : "CInkl8rL7pMDEAE=",
       "Content-Disposition" : "attachment",
       "X-Goog-Storage-Class" : "STANDARD",
-      "X-GUploader-UploadID" : "AMNfjG1dLTQTpZHz7PQimwp9__lA7u2Ma1Nb9sRvxuvI9PcPc9YWCbrTH40ph2F1n6fFdb7-kENX6Q",
+      "X-GUploader-UploadID" : "AMNfjG1TdvQ8W2GhjL08RFL_NbacfAgcxxHXTIZI03cbQlWhiuH9BaqNcZbMyne2Zf83QxYhFLffRio",
       "Vary" : [ "Origin", "X-Origin" ],
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
       "X-Goog-Stored-Content-Length" : "17",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "87001ce4-7ad8-425e-b5a4-267a03898824",
+  "uuid" : "fbff1e90-4427-4f3b-a73d-9bcbcf7d1069",
   "persistent" : true,
-  "insertionIndex" : 1115
+  "insertionIndex" : 1172
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-20.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-20.json
@@ -1,28 +1,40 @@
 {
-  "id" : "29271166-c3db-4928-a539-914a1ea8f392",
+  "id" : "79ee3a62-ac00-4d88-b0a5-7b389ae65a7a",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-20",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream?projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_InputStream/1775853592332090\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream?generation=1775853592332090&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1775853592332090\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CLqOrZSS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:52.378Z\",\n  \"updated\": \"2026-04-10T20:39:52.378Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:52.378Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:52.378Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_InputStream/1776212597984544\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream?generation=1776212597984544&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776212597984544\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CKCay8fL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:18.038Z\",\n  \"updated\": \"2026-04-15T00:23:18.038Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:18.038Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:18.038Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CLqOrZSS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG0Uu2eOz1Za9o3ZanZuRH1qxqMKOUZlXRFwlb9csbxpJWuw28pKX4jd1Pj2IbGQXsvS32zK",
+      "ETag" : "CKCay8fL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG1osTBv-2E5I2WigmwiqFc05zGlq8tKNAcTbtvbvNHQra7CghL3xsbofkPgaiRCKK24k4v8jiA",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:52 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:52 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:18 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:18 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "29271166-c3db-4928-a539-914a1ea8f392",
+  "uuid" : "79ee3a62-ac00-4d88-b0a5-7b389ae65a7a",
   "persistent" : true,
   "scenarioName" : "scenario-2-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-upload-happyPath_versioned_InputStream",
   "requiredScenarioState" : "scenario-2-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-upload-happyPath_versioned_InputStream-2",
-  "insertionIndex" : 1133
+  "insertionIndex" : 1190
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-21.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-21.json
@@ -1,29 +1,41 @@
 {
-  "id" : "c55b936a-8371-47a5-97f2-9e874515cc82",
+  "id" : "227f10c1-de88-499e-8067-d463609a3b36",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-21",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream?projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_InputStream/1775853592332090\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream?generation=1775853592332090&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1775853592332090\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CLqOrZSS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:52.378Z\",\n  \"updated\": \"2026-04-10T20:39:52.378Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:52.378Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:52.378Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_InputStream/1776212597984544\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream?generation=1776212597984544&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776212597984544\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CKCay8fL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:18.038Z\",\n  \"updated\": \"2026-04-15T00:23:18.038Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:18.038Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:18.038Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CLqOrZSS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG1w07Z9yLZHCuK-iuskeYlQSrtoSrWI5uWxFUAlhPt_s6BRr4oveYqFyHtET4aqKIgp0y6hg3EGIelx",
+      "ETag" : "CKCay8fL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG0X5Xze_OtiModqiy7pobUYF9FYt-z8KzEcdPw9-OCdlljOQLINEY-G-a9hq0_WyglE_EP0uP4",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:52 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:52 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:18 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:18 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "c55b936a-8371-47a5-97f2-9e874515cc82",
+  "uuid" : "227f10c1-de88-499e-8067-d463609a3b36",
   "persistent" : true,
   "scenarioName" : "scenario-2-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-upload-happyPath_versioned_InputStream",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-2-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-upload-happyPath_versioned_InputStream-2",
-  "insertionIndex" : 1134
+  "insertionIndex" : 1191
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-25.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-25.json
@@ -1,9 +1,26 @@
 {
-  "id" : "ecaf7933-a8c0-44cd-b2ae-39b31441fdbd",
+  "id" : "ad74ca51-3b5b-4bab-b56b-c1a3ffbcb322",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-25",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?maxResults=1&projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -12,16 +29,16 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AMNfjG3Mu8L52ml-_pd72WNoDO_WsZhy9Aq1ZwYWFGOOznRmfC-e9VLPXrLoagj2g8xZrVpivzo6gQ",
+      "X-GUploader-UploadID" : "AMNfjG1oulqrsV45Xs9ezs9qjwgogs4rokRaaDeuz_p93T1QgtstUh4jAXeRm8Qn3Vhbk3boGKJY3og",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:51 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:51 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:16 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:16 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "ecaf7933-a8c0-44cd-b2ae-39b31441fdbd",
+  "uuid" : "ad74ca51-3b5b-4bab-b56b-c1a3ffbcb322",
   "persistent" : true,
   "scenarioName" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o",
   "requiredScenarioState" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-4",
-  "insertionIndex" : 1138
+  "insertionIndex" : 1195
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-26.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-26.json
@@ -1,9 +1,21 @@
 {
-  "id" : "b2f9548d-da1b-460a-9818-bce0fdf9a5f2",
+  "id" : "59ea5720-bd0e-4cdd-806d-918b409138ed",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-26",
   "request" : {
-    "url" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path?alt=media",
-    "method" : "GET"
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -11,25 +23,25 @@
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
-      "X-Goog-Generation" : "1775853590294221",
+      "X-Goog-Generation" : "1776212596059480",
       "Pragma" : "no-cache",
-      "Last-Modified" : "Fri, 10 Apr 2026 20:39:50 GMT",
+      "Last-Modified" : "Wed, 15 Apr 2026 00:23:16 GMT",
       "X-Goog-Metageneration" : "1",
-      "Date" : "Fri, 10 Apr 2026 20:39:50 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:16 GMT",
       "X-Goog-Stored-Content-Encoding" : "identity",
       "X-Goog-Hash" : "crc32c=E30mnQ==,md5=cBu9S94e4E47BZb2OZTrrg==",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CM3dsJOS5JMDEAE=",
+      "ETag" : "CNja1cbL7pMDEAE=",
       "Content-Disposition" : "attachment",
       "X-Goog-Storage-Class" : "STANDARD",
-      "X-GUploader-UploadID" : "AMNfjG3dySPWQdP5QLaAUtdB7ebsg-GOapWuqm2QFV05LgiPihHqSGSavdbZ9ZayomBKKO8ldFu3Yg",
+      "X-GUploader-UploadID" : "AMNfjG0-O17-J7mY0GThjQAoBim1Mg1X7gjMf-NCGPylI8PErReDg7htJiuTOhkliRXCgLfcG6dUuZE",
       "Vary" : [ "Origin", "X-Origin" ],
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
       "X-Goog-Stored-Content-Length" : "17",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "b2f9548d-da1b-460a-9818-bce0fdf9a5f2",
+  "uuid" : "59ea5720-bd0e-4cdd-806d-918b409138ed",
   "persistent" : true,
-  "insertionIndex" : 1139
+  "insertionIndex" : 1196
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-27.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-27.json
@@ -1,26 +1,38 @@
 {
-  "id" : "32cbdd7f-e61a-4905-8117-a8bceceac4f3",
+  "id" : "1000597a-eb38-4f48-acf6-33d81fc75d83",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-27",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path?projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_Path/1775853590294221\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path?generation=1775853590294221&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_Path\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1775853590294221\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CM3dsJOS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:50.340Z\",\n  \"updated\": \"2026-04-10T20:39:50.340Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:50.340Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:50.340Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_Path/1776212596059480\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path?generation=1776212596059480&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_Path\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776212596059480\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CNja1cbL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:16.111Z\",\n  \"updated\": \"2026-04-15T00:23:16.111Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:16.111Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:16.111Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CM3dsJOS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG0HpuyeVF3U5C1XI361a_Qdgv4iFE24JtoOOYOQB7IhSH3OnXT1D7KcXP1dBYcoT7efSsvg",
+      "ETag" : "CNja1cbL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG3mN5dWoVqVyHGXZX2jsl32Fr0r9LH0hRe7YhYzjYckB6hZHbvWVCAkNcVPrIDJDOy9cmg5xGY",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:50 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:50 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:16 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:16 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "32cbdd7f-e61a-4905-8117-a8bceceac4f3",
+  "uuid" : "1000597a-eb38-4f48-acf6-33d81fc75d83",
   "persistent" : true,
-  "insertionIndex" : 1140
+  "insertionIndex" : 1197
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-3.json
@@ -1,26 +1,38 @@
 {
-  "id" : "8fe79cd5-90ff-41a8-87da-41d6910f4a2f",
+  "id" : "89c18770-fe10-4f94-ab1a-769221f7fbf4",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-3",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path?projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_Path/1775853597832062\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path?generation=1775853597832062&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_Path\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1775853597832062\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CP7m/JaS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:57.877Z\",\n  \"updated\": \"2026-04-10T20:39:57.877Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:57.877Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:57.877Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_Path/1776212603433481\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path?generation=1776212603433481&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_Path\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776212603433481\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CInkl8rL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:23.486Z\",\n  \"updated\": \"2026-04-15T00:23:23.486Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:23.486Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:23.486Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CP7m/JaS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG1p0B5QTWw3DSSVt3UqQwPSdisWDpz2cm2WMaNpd_Q0FH1psHoJ-A3NSShrmi3l6GTHQnk",
+      "ETag" : "CInkl8rL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG2BUvw8nl0sbFoJ8cpsnO62kRyJquPWfnR-GmNuujjG8wFqHxOeCPYeGvRAKONaIg6W9BOZwe8",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:58 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:58 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:23 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:23 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "8fe79cd5-90ff-41a8-87da-41d6910f4a2f",
+  "uuid" : "89c18770-fe10-4f94-ab1a-769221f7fbf4",
   "persistent" : true,
-  "insertionIndex" : 1116
+  "insertionIndex" : 1173
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-31.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-31.json
@@ -1,9 +1,26 @@
 {
-  "id" : "6df8fef7-ced8-4f39-bf96-a1b8ca78e8ee",
+  "id" : "091d7b5c-9c6c-46fe-a44e-0ea766276c45",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-31",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?maxResults=1&projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -12,17 +29,17 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AMNfjG17RdtbSp5Dcn28zbzy4bEoErZq2EwjZZffDG0rVQplu6R4rEleFRsx_h_GeD_2EcOa-DyOrG3dCLvA",
+      "X-GUploader-UploadID" : "AMNfjG2Evv6UaiPvcE-zCR-7A3mNxTRkdAN8ZZtuuNQvURn_9I5ylBE5FK2_GgMnrju6gFIy_R4Cg6c",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:49 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:49 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:15 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:15 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "6df8fef7-ced8-4f39-bf96-a1b8ca78e8ee",
+  "uuid" : "091d7b5c-9c6c-46fe-a44e-0ea766276c45",
   "persistent" : true,
   "scenarioName" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o",
   "requiredScenarioState" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-3",
   "newScenarioState" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-4",
-  "insertionIndex" : 1144
+  "insertionIndex" : 1201
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-32.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-32.json
@@ -1,9 +1,21 @@
 {
-  "id" : "7593a52f-fc14-4cf5-854e-cea3bef42ce1",
+  "id" : "3d18e2c9-9c90-4acf-9d61-10a965f040d0",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-32",
   "request" : {
-    "url" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File?alt=media",
-    "method" : "GET"
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -11,25 +23,25 @@
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
-      "X-Goog-Generation" : "1775853588579015",
+      "X-Goog-Generation" : "1776212594249837",
       "Pragma" : "no-cache",
-      "Last-Modified" : "Fri, 10 Apr 2026 20:39:48 GMT",
+      "Last-Modified" : "Wed, 15 Apr 2026 00:23:14 GMT",
       "X-Goog-Metageneration" : "1",
-      "Date" : "Fri, 10 Apr 2026 20:39:49 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:14 GMT",
       "X-Goog-Stored-Content-Encoding" : "identity",
       "X-Goog-Hash" : "crc32c=E30mnQ==,md5=cBu9S94e4E47BZb2OZTrrg==",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CMeFyJKS5JMDEAE=",
+      "ETag" : "CO2g58XL7pMDEAE=",
       "Content-Disposition" : "attachment",
       "X-Goog-Storage-Class" : "STANDARD",
-      "X-GUploader-UploadID" : "AMNfjG242LgrUkrMvZHwDAePy8Mgm0aWegTRk6ZbyZuCIA3VB2pL8iX9O_hP4dXj5bjoeolTga0gEQ",
+      "X-GUploader-UploadID" : "AMNfjG06mj6qZiGOlz1owEGWFSlmvv8NWxvn2YGnfpPzWr8iLSV5UG6_AL4bT2xuxHuLIbfZgZZJGhk",
       "Vary" : [ "Origin", "X-Origin" ],
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
       "X-Goog-Stored-Content-Length" : "17",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "7593a52f-fc14-4cf5-854e-cea3bef42ce1",
+  "uuid" : "3d18e2c9-9c90-4acf-9d61-10a965f040d0",
   "persistent" : true,
-  "insertionIndex" : 1145
+  "insertionIndex" : 1202
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-33.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-33.json
@@ -1,26 +1,38 @@
 {
-  "id" : "2be74ce3-3ac5-4d16-b683-381c661a3764",
+  "id" : "074db6ef-128a-416c-99e0-2b1287dad16c",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-33",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File?projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_File/1775853588579015\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File?generation=1775853588579015&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_File\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1775853588579015\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CMeFyJKS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:48.625Z\",\n  \"updated\": \"2026-04-10T20:39:48.625Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:48.625Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:48.625Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_File/1776212594249837\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File?generation=1776212594249837&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_File\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776212594249837\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CO2g58XL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:14.320Z\",\n  \"updated\": \"2026-04-15T00:23:14.320Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:14.320Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:14.320Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CMeFyJKS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG3GYESJ3o-GODwnTFUyFGBzVSL9cnuGfeAte_p4dUsD3CPsFaje6aa7cnFSOF8_C8smbryuLyh_7eWy",
+      "ETag" : "CO2g58XL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG0ASxed13HpRwxxKCEkaLBTQhpQRuxkLsnnFkQ6F3hvuvX7iGY-F4xiMX9oG4dhZzuF8T_9C4E",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:48 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:48 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:14 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:14 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "2be74ce3-3ac5-4d16-b683-381c661a3764",
+  "uuid" : "074db6ef-128a-416c-99e0-2b1287dad16c",
   "persistent" : true,
-  "insertionIndex" : 1146
+  "insertionIndex" : 1203
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-37.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-37.json
@@ -1,9 +1,26 @@
 {
-  "id" : "a3d9422d-efce-4e98-8b3e-d25f93b446df",
+  "id" : "651633f2-dad9-4756-ac62-e7eae6f95389",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-37",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?maxResults=1&projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -12,17 +29,17 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AMNfjG0OGJzFIpP7uuf5MbBuWF3GkUikFUHbUFyypqi9A2WA2ryjTEgu4Og7WW6MZ9uspen3mMvpuZLhCGnM",
+      "X-GUploader-UploadID" : "AMNfjG0SAp0bto2Kul2Ng9HImnrNDrZMofFxeaa7ubkmbp1401MJu67gMnqMktmCYv1d-hAkVpDgUp4",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:47 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:47 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:13 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:13 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "a3d9422d-efce-4e98-8b3e-d25f93b446df",
+  "uuid" : "651633f2-dad9-4756-ac62-e7eae6f95389",
   "persistent" : true,
   "scenarioName" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o",
   "requiredScenarioState" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-2",
   "newScenarioState" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-3",
-  "insertionIndex" : 1150
+  "insertionIndex" : 1207
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-38.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-38.json
@@ -1,9 +1,21 @@
 {
-  "id" : "5d20cb23-d439-401a-8c8e-27747478c1e8",
+  "id" : "584bc714-524e-402d-ae60-f0347a13e6c8",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-38",
   "request" : {
-    "url" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray?alt=media",
-    "method" : "GET"
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -11,25 +23,25 @@
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
-      "X-Goog-Generation" : "1775853586892861",
+      "X-Goog-Generation" : "1776212592332142",
       "Pragma" : "no-cache",
-      "Last-Modified" : "Fri, 10 Apr 2026 20:39:46 GMT",
+      "Last-Modified" : "Wed, 15 Apr 2026 00:23:12 GMT",
       "X-Goog-Metageneration" : "1",
-      "Date" : "Fri, 10 Apr 2026 20:39:47 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:12 GMT",
       "X-Goog-Stored-Content-Encoding" : "identity",
       "X-Goog-Hash" : "crc32c=E30mnQ==,md5=cBu9S94e4E47BZb2OZTrrg==",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CL2Q4ZGS5JMDEAE=",
+      "ETag" : "CO6a8sTL7pMDEAE=",
       "Content-Disposition" : "attachment",
       "X-Goog-Storage-Class" : "STANDARD",
-      "X-GUploader-UploadID" : "AMNfjG1-vFx8LluvQ_UmE2p_VOGpHRhaqOO_FNRZ1id2QDkKUqhyO4_sHmTUv7BuaDx2reoSDT7AxA",
+      "X-GUploader-UploadID" : "AMNfjG3obrRx9fpKVat4vW2XX_0YMtQOqEYGbeV8_hzm9ncIyCPQeqXChDt1xcelksPZEVGkV0U0Wp0",
       "Vary" : [ "Origin", "X-Origin" ],
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
       "X-Goog-Stored-Content-Length" : "17",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "5d20cb23-d439-401a-8c8e-27747478c1e8",
+  "uuid" : "584bc714-524e-402d-ae60-f0347a13e6c8",
   "persistent" : true,
-  "insertionIndex" : 1151
+  "insertionIndex" : 1208
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-39.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-39.json
@@ -1,26 +1,38 @@
 {
-  "id" : "2272f24d-a228-4c4e-ae12-90d40a4ceda7",
+  "id" : "5e80bf0e-398e-49ec-aa89-a95840f3e09c",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-39",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray?projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_ByteArray/1775853586892861\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray?generation=1775853586892861&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_ByteArray\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1775853586892861\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CL2Q4ZGS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:46.938Z\",\n  \"updated\": \"2026-04-10T20:39:46.938Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:46.938Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:46.938Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_ByteArray/1776212592332142\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray?generation=1776212592332142&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_ByteArray\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776212592332142\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CO6a8sTL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:12.384Z\",\n  \"updated\": \"2026-04-15T00:23:12.384Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:12.384Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:12.384Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CL2Q4ZGS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG2efWrpyT8zgYL7NKq3w7GGmzww5yimNXnvGGQgdxdwS6zg-7-of_Wt_c-m9DFeTbJxrrPp3FeV5ig9",
+      "ETag" : "CO6a8sTL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG3TzQQUYDHllHot8zCT1-foLuyFZLCyxfPy5CNDIrwNkxFl0gd6wYFI5Phd_f6ZQh_pHDSRHP8",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:47 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:47 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:12 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:12 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "2272f24d-a228-4c4e-ae12-90d40a4ceda7",
+  "uuid" : "5e80bf0e-398e-49ec-aa89-a95840f3e09c",
   "persistent" : true,
-  "insertionIndex" : 1152
+  "insertionIndex" : 1209
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-42.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-42.json
@@ -1,9 +1,26 @@
 {
-  "id" : "4374e60b-cdcd-4610-84ec-ed7b7083bd7a",
+  "id" : "c1cb64b5-949c-482e-b8a2-69748f907cc8",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-42",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?maxResults=1&projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -12,17 +29,17 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AMNfjG3bDW61u_SLudKb8iUwbcQm2LoswuEL4tC1KtjJAmGaNtIb0ibcYCSvIrCXh8r1PCvC0xAObQ",
+      "X-GUploader-UploadID" : "AMNfjG3rUt6-QE1uN3RYLnt5QCt8m4pNWW_CQ1MrAozzthp53PvrVoJGPU6poqPnErTr35lSqAwFEMg",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:46 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:46 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:11 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:11 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "4374e60b-cdcd-4610-84ec-ed7b7083bd7a",
+  "uuid" : "c1cb64b5-949c-482e-b8a2-69748f907cc8",
   "persistent" : true,
   "scenarioName" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-2",
-  "insertionIndex" : 1155
+  "insertionIndex" : 1212
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-43.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-43.json
@@ -1,9 +1,21 @@
 {
-  "id" : "5ba691cb-eaae-4d01-b605-8b72957d3f04",
+  "id" : "71959fa5-40d9-4990-ac54-dd34cf964e7d",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-43",
   "request" : {
-    "url" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream?alt=media",
-    "method" : "GET"
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -11,25 +23,25 @@
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
-      "X-Goog-Generation" : "1775853585071659",
+      "X-Goog-Generation" : "1776212590464008",
       "Pragma" : "no-cache",
-      "Last-Modified" : "Fri, 10 Apr 2026 20:39:45 GMT",
+      "Last-Modified" : "Wed, 15 Apr 2026 00:23:10 GMT",
       "X-Goog-Metageneration" : "1",
-      "Date" : "Fri, 10 Apr 2026 20:39:45 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:11 GMT",
       "X-Goog-Stored-Content-Encoding" : "identity",
       "X-Goog-Hash" : "crc32c=E30mnQ==,md5=cBu9S94e4E47BZb2OZTrrg==",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CKv88ZCS5JMDEAE=",
+      "ETag" : "CIiYgMTL7pMDEAE=",
       "Content-Disposition" : "attachment",
       "X-Goog-Storage-Class" : "STANDARD",
-      "X-GUploader-UploadID" : "AMNfjG3a5Q1LvqdsCUewAsU-tKgD_7hOH0S9fzHbmW1dQdRRqAJz6iMcvMCvEPX2RG6UAOgiqXUY_w",
+      "X-GUploader-UploadID" : "AMNfjG2vBxCberbOTGJ9lcCHL9MQg5bUzruFqDm5EQ1tWsdNWYhsUPtdabn19zmUws2bqb_zXZ-HJEE",
       "Vary" : [ "Origin", "X-Origin" ],
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
       "X-Goog-Stored-Content-Length" : "17",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "5ba691cb-eaae-4d01-b605-8b72957d3f04",
+  "uuid" : "71959fa5-40d9-4990-ac54-dd34cf964e7d",
   "persistent" : true,
-  "insertionIndex" : 1156
+  "insertionIndex" : 1213
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-44.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-44.json
@@ -1,28 +1,40 @@
 {
-  "id" : "a536bc55-aa7a-4297-9f92-7cb935903cec",
+  "id" : "6fab0601-6b23-44f5-a992-c5de3ba458e7",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-44",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream?projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_InputStream/1775853585071659\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream?generation=1775853585071659&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1775853585071659\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CKv88ZCS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:45.118Z\",\n  \"updated\": \"2026-04-10T20:39:45.118Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:45.118Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:45.118Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_InputStream/1776212590464008\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream?generation=1776212590464008&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776212590464008\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CIiYgMTL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:10.517Z\",\n  \"updated\": \"2026-04-15T00:23:10.517Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:10.517Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:10.517Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CKv88ZCS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG1odB3AGZAS6M0-lBjOsD6-Ze2lrg1cXLLE-T6qiFeP0xKOJDR80_l4EE7qYNZYq43Y4v_SOmAo3UnT",
+      "ETag" : "CIiYgMTL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG0Bc5BGCmksxIY6U9CtmiLeJUrDBM17-I7rQL97VO7Snit3Q2XSNgIFF9U5l260TAPwcYA0umU",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:45 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:45 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:11 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:11 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "a536bc55-aa7a-4297-9f92-7cb935903cec",
+  "uuid" : "6fab0601-6b23-44f5-a992-c5de3ba458e7",
   "persistent" : true,
   "scenarioName" : "scenario-4-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-conformance-tests-upload-happyPath_InputStream",
   "requiredScenarioState" : "scenario-4-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-conformance-tests-upload-happyPath_InputStream-2",
-  "insertionIndex" : 1157
+  "insertionIndex" : 1214
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-45.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-45.json
@@ -1,29 +1,41 @@
 {
-  "id" : "f9f89699-ba71-4ed5-92f8-5e8534900003",
+  "id" : "5c826558-f4df-41ce-aa51-1cec8d5615ef",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-45",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream?projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_InputStream/1775853585071659\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream?generation=1775853585071659&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1775853585071659\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CKv88ZCS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:45.118Z\",\n  \"updated\": \"2026-04-10T20:39:45.118Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:45.118Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:45.118Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_InputStream/1776212590464008\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream?generation=1776212590464008&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776212590464008\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CIiYgMTL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:10.517Z\",\n  \"updated\": \"2026-04-15T00:23:10.517Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:10.517Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:10.517Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CKv88ZCS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG2eEX7JQYxuqbbgN-qoKBkCwbvUR7EwthFTOoXNiJ0QuJ4M-Da0L8mXXkOQi6_P9l1gwNHmmQ",
+      "ETag" : "CIiYgMTL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG1QhKfxc2lsJjNwOJKRjfIZs8Tp19KMvDEZmRP9Csq4SMNmqnYV2YwXvu-hi4o9Wwau6GMAIo4",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:45 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:45 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:10 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:10 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "f9f89699-ba71-4ed5-92f8-5e8534900003",
+  "uuid" : "5c826558-f4df-41ce-aa51-1cec8d5615ef",
   "persistent" : true,
   "scenarioName" : "scenario-4-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-conformance-tests-upload-happyPath_InputStream",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-4-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-conformance-tests-upload-happyPath_InputStream-2",
-  "insertionIndex" : 1158
+  "insertionIndex" : 1215
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-7.json
@@ -1,9 +1,26 @@
 {
-  "id" : "8ab71dda-a343-441a-80ff-a2237ab1f29e",
+  "id" : "b380e530-4f3e-4ab3-ad69-e69ae6d45f8d",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-7",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?maxResults=1&projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -12,17 +29,17 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AMNfjG0QfzSOqfwDp9k3GIlRfbN1qAh9i-Fz_0sK6e04wMqW0Lf6hRmkm_vFHjPSz3OlZllmIrmyXIWFE1FC",
+      "X-GUploader-UploadID" : "AMNfjG0PdcqX58zBDtxBNnRP7j_q--F8JohDqmFNZ6EoNHfLqt4JNOUIqxp6RDMT9wyZFWms24Dp4wQ",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:56 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:56 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:22 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:22 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "8ab71dda-a343-441a-80ff-a2237ab1f29e",
+  "uuid" : "b380e530-4f3e-4ab3-ad69-e69ae6d45f8d",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-3",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-4",
-  "insertionIndex" : 1120
+  "insertionIndex" : 1177
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-8.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-8.json
@@ -1,9 +1,21 @@
 {
-  "id" : "f0ea68af-2e05-4b1d-8a12-b6952ffb6535",
+  "id" : "87b095db-fb44-4f04-bdf5-9d5c9f962e09",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-8",
   "request" : {
-    "url" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File?alt=media",
-    "method" : "GET"
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
@@ -11,25 +23,25 @@
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
-      "X-Goog-Generation" : "1775853596092835",
+      "X-Goog-Generation" : "1776212601594520",
       "Pragma" : "no-cache",
-      "Last-Modified" : "Fri, 10 Apr 2026 20:39:56 GMT",
+      "Last-Modified" : "Wed, 15 Apr 2026 00:23:21 GMT",
       "X-Goog-Metageneration" : "1",
-      "Date" : "Fri, 10 Apr 2026 20:39:56 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:22 GMT",
       "X-Goog-Stored-Content-Encoding" : "identity",
       "X-Goog-Hash" : "crc32c=E30mnQ==,md5=cBu9S94e4E47BZb2OZTrrg==",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CKPTkpaS5JMDEAE=",
+      "ETag" : "CJjFp8nL7pMDEAE=",
       "Content-Disposition" : "attachment",
       "X-Goog-Storage-Class" : "STANDARD",
-      "X-GUploader-UploadID" : "AMNfjG2g9o49u8R72UjADceBJdF8eOEFRyTOnEaaPUscH-PMb-tNkdWNFUidH3om1XSUrx-7lrNu5w",
+      "X-GUploader-UploadID" : "AMNfjG1N4_ENaxeV3jXmdoIu8KnK0HxAU7AR0wR9l3mBHqKySlCVNGKgV26xrO-09xGIDLSRqudNdLo",
       "Vary" : [ "Origin", "X-Origin" ],
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
       "X-Goog-Stored-Content-Length" : "17",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "f0ea68af-2e05-4b1d-8a12-b6952ffb6535",
+  "uuid" : "87b095db-fb44-4f04-bdf5-9d5c9f962e09",
   "persistent" : true,
-  "insertionIndex" : 1121
+  "insertionIndex" : 1178
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-9.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-get-9.json
@@ -1,26 +1,38 @@
 {
-  "id" : "f0ed389f-ee99-4f15-8fcb-bd01446c0421",
+  "id" : "45959099-07cd-492c-90a1-064d77cdc5cc",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-GET-9",
   "request" : {
-    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File?projection=full",
-    "method" : "GET"
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_File/1775853596092835\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File?generation=1775853596092835&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_File\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1775853596092835\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CKPTkpaS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:56.137Z\",\n  \"updated\": \"2026-04-10T20:39:56.137Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:56.137Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:56.137Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_File/1776212601594520\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File?generation=1776212601594520&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_File\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776212601594520\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CJjFp8nL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:21.646Z\",\n  \"updated\": \"2026-04-15T00:23:21.646Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:21.646Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:21.646Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CKPTkpaS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG2ZUOafaJUQllnJlHFeCP4JAGXgX_W9wV7UiLouNlalpJpxL39Lx8wjGCSLThVsgVemf1fE",
+      "ETag" : "CJjFp8nL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG1iMfkP_a23A-s2fpruZH1h_mBy87wcmK2sWmzuZSnMoO8fzd6MmDX70UAo4c7OrLlcojeL6Kk",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Fri, 10 Apr 2026 20:39:56 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:56 GMT",
+      "Expires" : "Wed, 15 Apr 2026 00:23:21 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:21 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "f0ed389f-ee99-4f15-8fcb-bd01446c0421",
+  "uuid" : "45959099-07cd-492c-90a1-064d77cdc5cc",
   "persistent" : true,
-  "insertionIndex" : 1122
+  "insertionIndex" : 1179
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-11.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-11.json
@@ -1,9 +1,26 @@
 {
-  "id" : "2ac92581-3c67-4136-b8c9-fa699b3d4257",
+  "id" : "bcd0b5f6-0241-434c-88cb-05b254ebfaee",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-POST-11",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/happyPath_versioned_File&uploadType=resumable",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
     "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/happyPath_versioned_File"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/upload/happyPath_versioned_File\"}",
       "ignoreArrayOrder" : true,
@@ -16,16 +33,16 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG1-fCi985bqxxFI2AX_eac1g-s6eZzudx7E742tZQbPQfmLFK3LgKielZF0BMZSsSgHaEJQXQsbtUfwpeKwLPYnFXjiQ-gcbt9J9hFSmw",
+      "X-GUploader-UploadID" : "AMNfjG19Yxhg6u4wV28MQQLliCybhUdGzLqMUqDaTd2Yqkbh1yJmRwBUQkhqMDyM0sLUIZ0E3EIqJuqRA7pQt5UO-JO9d_bJaM5jTMdLRd3GuA",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:55 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/happyPath_versioned_File&uploadType=resumable&upload_id=AMNfjG1-fCi985bqxxFI2AX_eac1g-s6eZzudx7E742tZQbPQfmLFK3LgKielZF0BMZSsSgHaEJQXQsbtUfwpeKwLPYnFXjiQ-gcbt9J9hFSmw",
+      "Date" : "Wed, 15 Apr 2026 00:23:21 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/happyPath_versioned_File&uploadType=resumable&upload_id=AMNfjG19Yxhg6u4wV28MQQLliCybhUdGzLqMUqDaTd2Yqkbh1yJmRwBUQkhqMDyM0sLUIZ0E3EIqJuqRA7pQt5UO-JO9d_bJaM5jTMdLRd3GuA",
       "Content-Type" : "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "2ac92581-3c67-4136-b8c9-fa699b3d4257",
+  "uuid" : "bcd0b5f6-0241-434c-88cb-05b254ebfaee",
   "persistent" : true,
-  "insertionIndex" : 1124
+  "insertionIndex" : 1181
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-16.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-16.json
@@ -1,30 +1,47 @@
 {
-  "id" : "eb41e0cd-6f46-4e2d-ba7c-c46ec0db76c9",
+  "id" : "0282b43e-4137-4ce4-bc2f-e386de959f39",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-POST-16",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?projection=full&uploadType=multipart",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
     "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "multipart"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "matches" : "(?s)\\Q\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Length: 155\r\nContent-Type: application/json; charset=UTF-8\r\ncontent-transfer-encoding: binary\r\n\r\n{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"crc32c\":\"E30mnQ==\",\"metadata\":{},\"name\":\"conformance-tests/upload/happyPath_versioned_ByteArray\"}\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Type: application/octet-stream\r\ncontent-transfer-encoding: binary\r\n\r\nThis is test data\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q--\r\n\\E"
     } ]
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_ByteArray/1775853594225398\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray?generation=1775853594225398&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_ByteArray\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1775853594225398\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CPbVoJWS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:54.278Z\",\n  \"updated\": \"2026-04-10T20:39:54.278Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:54.278Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:54.278Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_ByteArray/1776212599820955\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_ByteArray?generation=1776212599820955&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_ByteArray\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776212599820955\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CJulu8jL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:19.873Z\",\n  \"updated\": \"2026-04-15T00:23:19.873Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:19.873Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:19.873Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CPbVoJWS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG3BO8KvknBQe1IxpFejoLzwgv6fRVk4rjI2Bnh13t7gpJUYPJtew_AyOx62QWmpl95tTXpG",
+      "ETag" : "CJulu8jL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG3CiGBIOrg6M0DbgOWnxjpiEuhCtmNF9GyQazw98MKI0JP2I15YpQGt9Ri2NfsfcM9Rb7y0G_w",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:54 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:19 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "eb41e0cd-6f46-4e2d-ba7c-c46ec0db76c9",
+  "uuid" : "0282b43e-4137-4ce4-bc2f-e386de959f39",
   "persistent" : true,
-  "insertionIndex" : 1129
+  "insertionIndex" : 1186
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-23.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-23.json
@@ -1,9 +1,26 @@
 {
-  "id" : "3e848c0c-d149-432e-80d8-2474347b414e",
+  "id" : "02d411e0-f15b-472b-bbd3-f9f000f60bfd",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-POST-23",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/happyPath_versioned_InputStream&uploadType=resumable",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
     "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/happyPath_versioned_InputStream"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/upload/happyPath_versioned_InputStream\"}",
       "ignoreArrayOrder" : true,
@@ -16,16 +33,16 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG3i3P5-bjOENhXiXOqjL8GsFE-2Zm1RpBcjWBDf5zq5e6D8sVEDBg063CglQ67H19pcZCKkyQizV61Ku3KURB9Lrih3XL8eMRk2pFrOJFs",
+      "X-GUploader-UploadID" : "AMNfjG0CVNgyz2Z3yOfXZ0hAmKD5hueSP8pOylU9M9pLo-xFFOkCYxs1lVM4UvxcK9UO1YhVHZ99BbfRbjLQgbKAucZIHkspFBmbF54Hukp0zx4",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:52 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/happyPath_versioned_InputStream&uploadType=resumable&upload_id=AMNfjG3i3P5-bjOENhXiXOqjL8GsFE-2Zm1RpBcjWBDf5zq5e6D8sVEDBg063CglQ67H19pcZCKkyQizV61Ku3KURB9Lrih3XL8eMRk2pFrOJFs",
+      "Date" : "Wed, 15 Apr 2026 00:23:17 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/happyPath_versioned_InputStream&uploadType=resumable&upload_id=AMNfjG0CVNgyz2Z3yOfXZ0hAmKD5hueSP8pOylU9M9pLo-xFFOkCYxs1lVM4UvxcK9UO1YhVHZ99BbfRbjLQgbKAucZIHkspFBmbF54Hukp0zx4",
       "Content-Type" : "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "3e848c0c-d149-432e-80d8-2474347b414e",
+  "uuid" : "02d411e0-f15b-472b-bbd3-f9f000f60bfd",
   "persistent" : true,
-  "insertionIndex" : 1136
+  "insertionIndex" : 1193
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-29.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-29.json
@@ -1,9 +1,26 @@
 {
-  "id" : "99b68653-fd9b-4889-aa99-43787084d60d",
+  "id" : "a4dad150-39e0-4a93-8f1a-d0b65e57e54d",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-POST-29",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/happyPath_Path&uploadType=resumable",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
     "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/happyPath_Path"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket\",\"metadata\":{},\"name\":\"conformance-tests/upload/happyPath_Path\"}",
       "ignoreArrayOrder" : true,
@@ -16,16 +33,16 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG28msIcrzCjGAp1EkvgrDlWHoMX8pDSJsBi9Ykr6ScTWvN1TJBkLOyRzdG2qiTkC0_QESJ63eGeHtHpbOizxeqkUxNTFw3UltCwBIE6s9Y",
+      "X-GUploader-UploadID" : "AMNfjG1V3gSxsxDMMWqwUjjxQyKgAu6c6JAXAsZ4JzHQPyxpOTJapJwEO0m_LYL13J0T0GU020UyR2KZATaRjC10vUzdR9GExGap0Q_nH7dwdw",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:50 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/happyPath_Path&uploadType=resumable&upload_id=AMNfjG28msIcrzCjGAp1EkvgrDlWHoMX8pDSJsBi9Ykr6ScTWvN1TJBkLOyRzdG2qiTkC0_QESJ63eGeHtHpbOizxeqkUxNTFw3UltCwBIE6s9Y",
+      "Date" : "Wed, 15 Apr 2026 00:23:15 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/happyPath_Path&uploadType=resumable&upload_id=AMNfjG1V3gSxsxDMMWqwUjjxQyKgAu6c6JAXAsZ4JzHQPyxpOTJapJwEO0m_LYL13J0T0GU020UyR2KZATaRjC10vUzdR9GExGap0Q_nH7dwdw",
       "Content-Type" : "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "99b68653-fd9b-4889-aa99-43787084d60d",
+  "uuid" : "a4dad150-39e0-4a93-8f1a-d0b65e57e54d",
   "persistent" : true,
-  "insertionIndex" : 1142
+  "insertionIndex" : 1199
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-35.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-35.json
@@ -1,9 +1,26 @@
 {
-  "id" : "551c90fc-aacb-4f7a-a3f7-49bd73970b92",
+  "id" : "f4b88e53-b5d1-4613-9e29-eaec43ec34fb",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-POST-35",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/happyPath_File&uploadType=resumable",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
     "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/happyPath_File"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket\",\"metadata\":{},\"name\":\"conformance-tests/upload/happyPath_File\"}",
       "ignoreArrayOrder" : true,
@@ -16,16 +33,16 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG3WdnRBNEo_H7955-6Ii0PDg6tIyp5_5CWKjPKNvSIVysZCxOxxAmTSZj23vhj_L1uSnLuMmp-FAHNq5XEkcIWnn1LGlJgHuyUANZctf-M",
+      "X-GUploader-UploadID" : "AMNfjG3OcACm8iu-W1zrdTPX3jhcFfbJ0rNGTvGeV8TRtlMOgkllQ9EqJ_cMbQVinTcbVd_mLY8BzaIELGTNi4XH7jMvEd1zsZgw_-U89jdwTZ8",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:48 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/happyPath_File&uploadType=resumable&upload_id=AMNfjG3WdnRBNEo_H7955-6Ii0PDg6tIyp5_5CWKjPKNvSIVysZCxOxxAmTSZj23vhj_L1uSnLuMmp-FAHNq5XEkcIWnn1LGlJgHuyUANZctf-M",
+      "Date" : "Wed, 15 Apr 2026 00:23:13 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/happyPath_File&uploadType=resumable&upload_id=AMNfjG3OcACm8iu-W1zrdTPX3jhcFfbJ0rNGTvGeV8TRtlMOgkllQ9EqJ_cMbQVinTcbVd_mLY8BzaIELGTNi4XH7jMvEd1zsZgw_-U89jdwTZ8",
       "Content-Type" : "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "551c90fc-aacb-4f7a-a3f7-49bd73970b92",
+  "uuid" : "f4b88e53-b5d1-4613-9e29-eaec43ec34fb",
   "persistent" : true,
-  "insertionIndex" : 1148
+  "insertionIndex" : 1205
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-40.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-40.json
@@ -1,30 +1,47 @@
 {
-  "id" : "350d90db-4630-4a52-8f7e-4c80cb9c9f9f",
+  "id" : "e8fa80b9-955c-4032-a989-706389274e45",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-POST-40",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?projection=full&uploadType=multipart",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
     "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "multipart"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "matches" : "(?s)\\Q\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Length: 135\r\nContent-Type: application/json; charset=UTF-8\r\ncontent-transfer-encoding: binary\r\n\r\n{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket\",\"crc32c\":\"E30mnQ==\",\"metadata\":{},\"name\":\"conformance-tests/upload/happyPath_ByteArray\"}\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Type: application/octet-stream\r\ncontent-transfer-encoding: binary\r\n\r\nThis is test data\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q--\r\n\\E"
     } ]
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_ByteArray/1775853586892861\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray?generation=1775853586892861&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_ByteArray\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1775853586892861\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CL2Q4ZGS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:46.938Z\",\n  \"updated\": \"2026-04-10T20:39:46.938Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:46.938Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:46.938Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_ByteArray/1776212592332142\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_ByteArray?generation=1776212592332142&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_ByteArray\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776212592332142\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CO6a8sTL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:12.384Z\",\n  \"updated\": \"2026-04-15T00:23:12.384Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:12.384Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:12.384Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CL2Q4ZGS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG2HoTP9hf9N_K7kqPBfMBe4bJfCaFOQZEaPvqveIO6JVCztsGzPwNaQk_yINgboakx1d1njGg",
+      "ETag" : "CO6a8sTL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG1D2zx_fBetOxk1kZ4MyjamvS8_ck7Po9__DDtzUlR0byU8EcA7XSyeUa4GE5kWxcj5YGIT0JA",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:46 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:12 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "350d90db-4630-4a52-8f7e-4c80cb9c9f9f",
+  "uuid" : "e8fa80b9-955c-4032-a989-706389274e45",
   "persistent" : true,
-  "insertionIndex" : 1153
+  "insertionIndex" : 1210
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-47.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-47.json
@@ -1,9 +1,26 @@
 {
-  "id" : "3d4cb0d9-d7f1-4130-bb3c-6d8e2139d19c",
+  "id" : "6307a9f1-5190-4583-a4d6-1461e540cbd2",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-POST-47",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/happyPath_InputStream&uploadType=resumable",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
     "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/happyPath_InputStream"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket\",\"metadata\":{},\"name\":\"conformance-tests/upload/happyPath_InputStream\"}",
       "ignoreArrayOrder" : true,
@@ -16,16 +33,16 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG1406DYMDmGD5D9HG-DejfksYKGJfZ6GG3gsoaqpBAp1-TUGspN9-EBbxDk93noaft4iyBAcSoEQOt35N36ERuqnNVxFQ4zzvs9gy7zGw",
+      "X-GUploader-UploadID" : "AMNfjG2dEnkRbwIV0-UmNvlgpD7cxEo2Y8nYJUFiQc1Wc9311zyMs3Onh65re3CIWRmQr7ivqrCqB2u3iCNlzNUwZC_LSwaJRTpA5KjXYQk_uQ",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:44 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/happyPath_InputStream&uploadType=resumable&upload_id=AMNfjG1406DYMDmGD5D9HG-DejfksYKGJfZ6GG3gsoaqpBAp1-TUGspN9-EBbxDk93noaft4iyBAcSoEQOt35N36ERuqnNVxFQ4zzvs9gy7zGw",
+      "Date" : "Wed, 15 Apr 2026 00:23:10 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/happyPath_InputStream&uploadType=resumable&upload_id=AMNfjG2dEnkRbwIV0-UmNvlgpD7cxEo2Y8nYJUFiQc1Wc9311zyMs3Onh65re3CIWRmQr7ivqrCqB2u3iCNlzNUwZC_LSwaJRTpA5KjXYQk_uQ",
       "Content-Type" : "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "3d4cb0d9-d7f1-4130-bb3c-6d8e2139d19c",
+  "uuid" : "6307a9f1-5190-4583-a4d6-1461e540cbd2",
   "persistent" : true,
-  "insertionIndex" : 1160
+  "insertionIndex" : 1217
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-post-5.json
@@ -1,9 +1,26 @@
 {
-  "id" : "dcf6d8df-d0ce-428c-bc3b-eb5bfb2ce9d6",
+  "id" : "247bf546-28cc-4a84-a037-eb9b0f71e679",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-POST-5",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/happyPath_versioned_Path&uploadType=resumable",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
     "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/happyPath_versioned_Path"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/upload/happyPath_versioned_Path\"}",
       "ignoreArrayOrder" : true,
@@ -16,16 +33,16 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AMNfjG1mmeHOxEzvkJTV_tcstjQLD8xlI9yvP_SF-dzWSKQ98rOjSYYC5-cto4TR5nPIgp7ZNLxtVaxRkjxO6Ky7LfBZyD-1NCBjiAvR8NIoeE8",
+      "X-GUploader-UploadID" : "AMNfjG1l6xndB0ixOx-e2IQbLdrpvUAUwDBJ-nEZzULkTyclqCSrhXVTAeWxFaKLFd3TFh7WtVNDfNOyTcFAuxObWRDxuTishpL1v-oGMaLnPbM",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:57 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/happyPath_versioned_Path&uploadType=resumable&upload_id=AMNfjG1mmeHOxEzvkJTV_tcstjQLD8xlI9yvP_SF-dzWSKQ98rOjSYYC5-cto4TR5nPIgp7ZNLxtVaxRkjxO6Ky7LfBZyD-1NCBjiAvR8NIoeE8",
+      "Date" : "Wed, 15 Apr 2026 00:23:23 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/happyPath_versioned_Path&uploadType=resumable&upload_id=AMNfjG1l6xndB0ixOx-e2IQbLdrpvUAUwDBJ-nEZzULkTyclqCSrhXVTAeWxFaKLFd3TFh7WtVNDfNOyTcFAuxObWRDxuTishpL1v-oGMaLnPbM",
       "Content-Type" : "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "dcf6d8df-d0ce-428c-bc3b-eb5bfb2ce9d6",
+  "uuid" : "247bf546-28cc-4a84-a037-eb9b0f71e679",
   "persistent" : true,
-  "insertionIndex" : 1118
+  "insertionIndex" : 1175
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-put-10.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-put-10.json
@@ -1,9 +1,31 @@
 {
-  "id" : "3cffbebc-5fe1-4e9e-9dfd-64443a98b357",
+  "id" : "f02647b1-c7a6-40bc-85df-32d46768973f",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-PUT-10",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/happyPath_versioned_File&uploadType=resumable&upload_id=AMNfjG1-fCi985bqxxFI2AX_eac1g-s6eZzudx7E742tZQbPQfmLFK3LgKielZF0BMZSsSgHaEJQXQsbtUfwpeKwLPYnFXjiQ-gcbt9J9hFSmw",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
     "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/happyPath_versioned_File"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AMNfjG19Yxhg6u4wV28MQQLliCybhUdGzLqMUqDaTd2Yqkbh1yJmRwBUQkhqMDyM0sLUIZ0E3EIqJuqRA7pQt5UO-JO9d_bJaM5jTMdLRd3GuA"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "equalTo" : "This is test data",
       "caseInsensitive" : false
@@ -11,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_File/1775853596092835\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File?generation=1775853596092835&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_File\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1775853596092835\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CKPTkpaS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:56.137Z\",\n  \"updated\": \"2026-04-10T20:39:56.137Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:56.137Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:56.137Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_File/1776212601594520\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_File?generation=1776212601594520&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_File\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776212601594520\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CJjFp8nL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:21.646Z\",\n  \"updated\": \"2026-04-15T00:23:21.646Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:21.646Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:21.646Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CKPTkpaS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG1-fCi985bqxxFI2AX_eac1g-s6eZzudx7E742tZQbPQfmLFK3LgKielZF0BMZSsSgHaEJQXQsbtUfwpeKwLPYnFXjiQ-gcbt9J9hFSmw",
+      "ETag" : "CJjFp8nL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG19Yxhg6u4wV28MQQLliCybhUdGzLqMUqDaTd2Yqkbh1yJmRwBUQkhqMDyM0sLUIZ0E3EIqJuqRA7pQt5UO-JO9d_bJaM5jTMdLRd3GuA",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:56 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:21 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "3cffbebc-5fe1-4e9e-9dfd-64443a98b357",
+  "uuid" : "f02647b1-c7a6-40bc-85df-32d46768973f",
   "persistent" : true,
-  "insertionIndex" : 1123
+  "insertionIndex" : 1180
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-put-22.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-put-22.json
@@ -1,9 +1,31 @@
 {
-  "id" : "7fe5a8d2-b41d-4cb7-bec0-2d055f2df41b",
+  "id" : "f036e058-54b1-4cdd-b7c4-eab23a6d9dca",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-PUT-22",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/happyPath_versioned_InputStream&uploadType=resumable&upload_id=AMNfjG3i3P5-bjOENhXiXOqjL8GsFE-2Zm1RpBcjWBDf5zq5e6D8sVEDBg063CglQ67H19pcZCKkyQizV61Ku3KURB9Lrih3XL8eMRk2pFrOJFs",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
     "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/happyPath_versioned_InputStream"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AMNfjG0CVNgyz2Z3yOfXZ0hAmKD5hueSP8pOylU9M9pLo-xFFOkCYxs1lVM4UvxcK9UO1YhVHZ99BbfRbjLQgbKAucZIHkspFBmbF54Hukp0zx4"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "equalTo" : "This is test data",
       "caseInsensitive" : false
@@ -11,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_InputStream/1775853592332090\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream?generation=1775853592332090&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1775853592332090\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CLqOrZSS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:52.378Z\",\n  \"updated\": \"2026-04-10T20:39:52.378Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:52.378Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:52.378Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_InputStream/1776212597984544\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_InputStream?generation=1776212597984544&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776212597984544\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CKCay8fL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:18.038Z\",\n  \"updated\": \"2026-04-15T00:23:18.038Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:18.038Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:18.038Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CLqOrZSS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG3i3P5-bjOENhXiXOqjL8GsFE-2Zm1RpBcjWBDf5zq5e6D8sVEDBg063CglQ67H19pcZCKkyQizV61Ku3KURB9Lrih3XL8eMRk2pFrOJFs",
+      "ETag" : "CKCay8fL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG0CVNgyz2Z3yOfXZ0hAmKD5hueSP8pOylU9M9pLo-xFFOkCYxs1lVM4UvxcK9UO1YhVHZ99BbfRbjLQgbKAucZIHkspFBmbF54Hukp0zx4",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:52 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:18 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "7fe5a8d2-b41d-4cb7-bec0-2d055f2df41b",
+  "uuid" : "f036e058-54b1-4cdd-b7c4-eab23a6d9dca",
   "persistent" : true,
-  "insertionIndex" : 1135
+  "insertionIndex" : 1192
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-put-28.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-put-28.json
@@ -1,9 +1,31 @@
 {
-  "id" : "facf1e7f-cc95-4950-a7a0-08fb8b9e7215",
+  "id" : "1130fbd7-904c-4920-a75e-843470332e75",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-PUT-28",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/happyPath_Path&uploadType=resumable&upload_id=AMNfjG28msIcrzCjGAp1EkvgrDlWHoMX8pDSJsBi9Ykr6ScTWvN1TJBkLOyRzdG2qiTkC0_QESJ63eGeHtHpbOizxeqkUxNTFw3UltCwBIE6s9Y",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
     "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/happyPath_Path"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AMNfjG1V3gSxsxDMMWqwUjjxQyKgAu6c6JAXAsZ4JzHQPyxpOTJapJwEO0m_LYL13J0T0GU020UyR2KZATaRjC10vUzdR9GExGap0Q_nH7dwdw"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "equalTo" : "This is test data",
       "caseInsensitive" : false
@@ -11,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_Path/1775853590294221\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path?generation=1775853590294221&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_Path\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1775853590294221\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CM3dsJOS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:50.340Z\",\n  \"updated\": \"2026-04-10T20:39:50.340Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:50.340Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:50.340Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_Path/1776212596059480\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_Path?generation=1776212596059480&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_Path\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776212596059480\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CNja1cbL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:16.111Z\",\n  \"updated\": \"2026-04-15T00:23:16.111Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:16.111Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:16.111Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CM3dsJOS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG28msIcrzCjGAp1EkvgrDlWHoMX8pDSJsBi9Ykr6ScTWvN1TJBkLOyRzdG2qiTkC0_QESJ63eGeHtHpbOizxeqkUxNTFw3UltCwBIE6s9Y",
+      "ETag" : "CNja1cbL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG1V3gSxsxDMMWqwUjjxQyKgAu6c6JAXAsZ4JzHQPyxpOTJapJwEO0m_LYL13J0T0GU020UyR2KZATaRjC10vUzdR9GExGap0Q_nH7dwdw",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:50 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:16 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "facf1e7f-cc95-4950-a7a0-08fb8b9e7215",
+  "uuid" : "1130fbd7-904c-4920-a75e-843470332e75",
   "persistent" : true,
-  "insertionIndex" : 1141
+  "insertionIndex" : 1198
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-put-34.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-put-34.json
@@ -1,9 +1,31 @@
 {
-  "id" : "e3058bf8-a84f-4cdb-963b-fcbeb38f5357",
+  "id" : "e985702e-bac9-424c-8c6a-c7c4e83628f0",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-PUT-34",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/happyPath_File&uploadType=resumable&upload_id=AMNfjG3WdnRBNEo_H7955-6Ii0PDg6tIyp5_5CWKjPKNvSIVysZCxOxxAmTSZj23vhj_L1uSnLuMmp-FAHNq5XEkcIWnn1LGlJgHuyUANZctf-M",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
     "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/happyPath_File"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AMNfjG3OcACm8iu-W1zrdTPX3jhcFfbJ0rNGTvGeV8TRtlMOgkllQ9EqJ_cMbQVinTcbVd_mLY8BzaIELGTNi4XH7jMvEd1zsZgw_-U89jdwTZ8"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "equalTo" : "This is test data",
       "caseInsensitive" : false
@@ -11,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_File/1775853588579015\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File?generation=1775853588579015&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_File\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1775853588579015\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CMeFyJKS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:48.625Z\",\n  \"updated\": \"2026-04-10T20:39:48.625Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:48.625Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:48.625Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_File/1776212594249837\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_File?generation=1776212594249837&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_File\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776212594249837\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CO2g58XL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:14.320Z\",\n  \"updated\": \"2026-04-15T00:23:14.320Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:14.320Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:14.320Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CMeFyJKS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG3WdnRBNEo_H7955-6Ii0PDg6tIyp5_5CWKjPKNvSIVysZCxOxxAmTSZj23vhj_L1uSnLuMmp-FAHNq5XEkcIWnn1LGlJgHuyUANZctf-M",
+      "ETag" : "CO2g58XL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG3OcACm8iu-W1zrdTPX3jhcFfbJ0rNGTvGeV8TRtlMOgkllQ9EqJ_cMbQVinTcbVd_mLY8BzaIELGTNi4XH7jMvEd1zsZgw_-U89jdwTZ8",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:48 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:14 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "e3058bf8-a84f-4cdb-963b-fcbeb38f5357",
+  "uuid" : "e985702e-bac9-424c-8c6a-c7c4e83628f0",
   "persistent" : true,
-  "insertionIndex" : 1147
+  "insertionIndex" : 1204
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-put-4.json
@@ -1,9 +1,31 @@
 {
-  "id" : "d81cf66d-361f-4bf6-a2fb-baafdd668ec8",
+  "id" : "3fe0e941-b1e7-4d56-b27a-147b9856db1f",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-PUT-4",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/happyPath_versioned_Path&uploadType=resumable&upload_id=AMNfjG1mmeHOxEzvkJTV_tcstjQLD8xlI9yvP_SF-dzWSKQ98rOjSYYC5-cto4TR5nPIgp7ZNLxtVaxRkjxO6Ky7LfBZyD-1NCBjiAvR8NIoeE8",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
     "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/happyPath_versioned_Path"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AMNfjG1l6xndB0ixOx-e2IQbLdrpvUAUwDBJ-nEZzULkTyclqCSrhXVTAeWxFaKLFd3TFh7WtVNDfNOyTcFAuxObWRDxuTishpL1v-oGMaLnPbM"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "equalTo" : "This is test data",
       "caseInsensitive" : false
@@ -11,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_Path/1775853597832062\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path?generation=1775853597832062&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_Path\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1775853597832062\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CP7m/JaS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:57.877Z\",\n  \"updated\": \"2026-04-10T20:39:57.877Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:57.877Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:57.877Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/happyPath_versioned_Path/1776212603433481\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FhappyPath_versioned_Path?generation=1776212603433481&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_versioned_Path\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776212603433481\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CInkl8rL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:23.486Z\",\n  \"updated\": \"2026-04-15T00:23:23.486Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:23.486Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:23.486Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CP7m/JaS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG1mmeHOxEzvkJTV_tcstjQLD8xlI9yvP_SF-dzWSKQ98rOjSYYC5-cto4TR5nPIgp7ZNLxtVaxRkjxO6Ky7LfBZyD-1NCBjiAvR8NIoeE8",
+      "ETag" : "CInkl8rL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG1l6xndB0ixOx-e2IQbLdrpvUAUwDBJ-nEZzULkTyclqCSrhXVTAeWxFaKLFd3TFh7WtVNDfNOyTcFAuxObWRDxuTishpL1v-oGMaLnPbM",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:57 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:23 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "d81cf66d-361f-4bf6-a2fb-baafdd668ec8",
+  "uuid" : "3fe0e941-b1e7-4d56-b27a-147b9856db1f",
   "persistent" : true,
-  "insertionIndex" : 1117
+  "insertionIndex" : 1174
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-put-46.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_happypath-put-46.json
@@ -1,9 +1,31 @@
 {
-  "id" : "957bdb2f-8e2a-431b-b96d-192a33a8eb20",
+  "id" : "f28acb95-ac47-43ef-aac2-0318e90877d1",
   "name" : "GcpBlobStoreIT_testUpload_happyPath-PUT-46",
   "request" : {
-    "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/happyPath_InputStream&uploadType=resumable&upload_id=AMNfjG1406DYMDmGD5D9HG-DejfksYKGJfZ6GG3gsoaqpBAp1-TUGspN9-EBbxDk93noaft4iyBAcSoEQOt35N36ERuqnNVxFQ4zzvs9gy7zGw",
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
     "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/happyPath_InputStream"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AMNfjG2dEnkRbwIV0-UmNvlgpD7cxEo2Y8nYJUFiQc1Wc9311zyMs3Onh65re3CIWRmQr7ivqrCqB2u3iCNlzNUwZC_LSwaJRTpA5KjXYQk_uQ"
+        } ]
+      }
+    },
     "bodyPatterns" : [ {
       "equalTo" : "This is test data",
       "caseInsensitive" : false
@@ -11,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_InputStream/1775853585071659\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream?generation=1775853585071659&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1775853585071659\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CKv88ZCS5JMDEAE=\",\n  \"timeCreated\": \"2026-04-10T20:39:45.118Z\",\n  \"updated\": \"2026-04-10T20:39:45.118Z\",\n  \"timeStorageClassUpdated\": \"2026-04-10T20:39:45.118Z\",\n  \"timeFinalized\": \"2026-04-10T20:39:45.118Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/happyPath_InputStream/1776212590464008\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FhappyPath_InputStream?generation=1776212590464008&alt=media\",\n  \"name\": \"conformance-tests/upload/happyPath_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776212590464008\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"17\",\n  \"md5Hash\": \"cBu9S94e4E47BZb2OZTrrg==\",\n  \"crc32c\": \"E30mnQ==\",\n  \"etag\": \"CIiYgMTL7pMDEAE=\",\n  \"timeCreated\": \"2026-04-15T00:23:10.517Z\",\n  \"updated\": \"2026-04-15T00:23:10.517Z\",\n  \"timeStorageClassUpdated\": \"2026-04-15T00:23:10.517Z\",\n  \"timeFinalized\": \"2026-04-15T00:23:10.517Z\"\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CKv88ZCS5JMDEAE=",
-      "X-GUploader-UploadID" : "AMNfjG1406DYMDmGD5D9HG-DejfksYKGJfZ6GG3gsoaqpBAp1-TUGspN9-EBbxDk93noaft4iyBAcSoEQOt35N36ERuqnNVxFQ4zzvs9gy7zGw",
+      "ETag" : "CIiYgMTL7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG2dEnkRbwIV0-UmNvlgpD7cxEo2Y8nYJUFiQc1Wc9311zyMs3Onh65re3CIWRmQr7ivqrCqB2u3iCNlzNUwZC_LSwaJRTpA5KjXYQk_uQ",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Fri, 10 Apr 2026 20:39:45 GMT",
+      "Date" : "Wed, 15 Apr 2026 00:23:10 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "957bdb2f-8e2a-431b-b96d-192a33a8eb20",
+  "uuid" : "f28acb95-ac47-43ef-aac2-0318e90877d1",
   "persistent" : true,
-  "insertionIndex" : 1159
+  "insertionIndex" : 1216
 }


### PR DESCRIPTION
## Summary

After the WireMock upgrade(3.12.1 -> 3.13.2), the URL check no longer worked because WireMock switched its recording format from url to urlPath, and the regex construction was updated to be more robust.

                                                                                                                                                                               
## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
