### PR TITLE
test: Enable testUpload_emptyContent conformance test for GCP

### DIFF
--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -420,7 +420,6 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testUpload_emptyContent() {
-    Assumptions.assumeFalse(GCP_PROVIDER_ID.equals(harness.getProviderId()));
     runUploadTests(
         "testUpload_emptyContent", "conformance-tests/upload/emptyContent", new byte[] {}, false);
   }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "b37cd839-af7f-4fbd-bcdf-ea7a29962861",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_Path",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AMNfjG1ItJDY5Kk3q6BlVgnntEWbKPt1P6eNTus3KR_wwLsccmvrfHj7yDgSlYc_SjQ5Ag0KYYzxGAMI5iRyKQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:16 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "b37cd839-af7f-4fbd-bcdf-ea7a29962861",
+  "persistent" : true,
+  "insertionIndex" : 1170
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-10.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-10.json
@@ -1,0 +1,25 @@
+{
+  "id" : "62e5f186-ec0b-46cb-84ce-61951d27055f",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-DELETE-10",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_ByteArray",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AMNfjG1I6_T0Nk2k8bRA2ByRhY5kbcGxRwlzD9IAjXFMAvJe4QD12yBf3g08FwvZMmrGfOFCW9LhG2zneZ5rEw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:13 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "62e5f186-ec0b-46cb-84ce-61951d27055f",
+  "persistent" : true,
+  "insertionIndex" : 1180
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-15.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-15.json
@@ -1,0 +1,25 @@
+{
+  "id" : "ff79f1eb-c5c0-4d6a-b133-4f9652fef6c3",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-DELETE-15",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_InputStream",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AMNfjG07IEIR-nseBKhY28T-OzAWwRoijcir_2SnliD8eRjkjUfotTi12_TQyJWG3Y460DqDnZtiGMFxi7XAHw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:11 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "ff79f1eb-c5c0-4d6a-b133-4f9652fef6c3",
+  "persistent" : true,
+  "insertionIndex" : 1185
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-22.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-22.json
@@ -1,0 +1,25 @@
+{
+  "id" : "18aa6b31-b277-4d3b-b126-dfcb4fe13b34",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-DELETE-22",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_Path",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AMNfjG3fBIvQP9iHZ5dsGCYm1SJYD3kjEVVK8MfYTIKzK0-8cLwhP6Gb_8gNo8SOHDOvZZ9BSZFffzbqziaJFA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:09 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "18aa6b31-b277-4d3b-b126-dfcb4fe13b34",
+  "persistent" : true,
+  "insertionIndex" : 1192
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-27.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-27.json
@@ -1,0 +1,25 @@
+{
+  "id" : "a41aa9db-5c52-4780-a264-741a6e52dc15",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-DELETE-27",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_File",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AMNfjG2_-8nNoPBhrz4Fe85ZDpkBtXU3KZchluOMxoPxK4snRAbekFllPmJ27htUdel_l7Ewc1HzqVflIpirww",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:07 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "a41aa9db-5c52-4780-a264-741a6e52dc15",
+  "persistent" : true,
+  "insertionIndex" : 1197
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-32.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-32.json
@@ -1,0 +1,25 @@
+{
+  "id" : "e6a2d6a2-c219-4153-be10-0978a5abf401",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-DELETE-32",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_ByteArray",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AMNfjG3eAd-qNWKT6UaEruHvBrZ5fwLny_-8KOh1WqiHLL799R7kR3kcf-D3i_OUQBrRQrsc8gWehV9iLqidwA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:05 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "e6a2d6a2-c219-4153-be10-0978a5abf401",
+  "persistent" : true,
+  "insertionIndex" : 1202
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-37.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-37.json
@@ -1,0 +1,25 @@
+{
+  "id" : "6a2ecac2-bb88-4010-89fb-ac5d3a5071c3",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-DELETE-37",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_InputStream",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AMNfjG1u6Oy_5ppAdr6lXFBQlnIVGa7OeIRCFIoZzQWoj6_UoXkMj89sfYPDw4cME-aMN3w_4uzgsnLcUJ770A",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:04 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "6a2ecac2-bb88-4010-89fb-ac5d3a5071c3",
+  "persistent" : true,
+  "insertionIndex" : 1207
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-delete-5.json
@@ -1,0 +1,25 @@
+{
+  "id" : "bf9c8699-7c27-49d7-924a-4cc27a7f227d",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-DELETE-5",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_File",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AMNfjG0VF4LU480nZbxcEpGgkcIDhmNDW7A43thYp920_oL0b7qRZBae0iixQbM-7TrTufnayAcfBylgnVgy_Q",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:14 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "bf9c8699-7c27-49d7-924a-4cc27a7f227d",
+  "persistent" : true,
+  "insertionIndex" : 1175
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-1.json
@@ -1,0 +1,44 @@
+{
+  "id" : "e0b51e9d-7699-4055-8f03-1df48cf10b0c",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Cidjb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL2xlZ2FsLWhvbGQ=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/legal-hold/1770354569251017\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Flegal-hold\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Flegal-hold?generation=1770354569251017&alt=media\",\n      \"name\": \"conformance-tests/objectlock/legal-hold\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1770354569251017\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"27\",\n      \"md5Hash\": \"TRQZ8WSU+pMmjJZKRHoHBw==\",\n      \"crc32c\": \"8r/jMg==\",\n      \"etag\": \"CMmR6NmMxJIDEAE=\",\n      \"temporaryHold\": true,\n      \"timeCreated\": \"2026-02-06T05:09:29.301Z\",\n      \"updated\": \"2026-02-06T05:09:29.301Z\",\n      \"timeStorageClassUpdated\": \"2026-02-06T05:09:29.301Z\",\n      \"timeFinalized\": \"2026-02-06T05:09:29.301Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AMNfjG1fFTPW-0vzsXC0W04EM_uR26zeZS0y4j_0OyespF6AXJeu7p6GB4LJBrxei7IYwSRnqkAq458TLsEqaw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:15 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:15 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "e0b51e9d-7699-4055-8f03-1df48cf10b0c",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-4",
+  "insertionIndex" : 1171
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-11.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-11.json
@@ -1,0 +1,45 @@
+{
+  "id" : "a978f07b-e223-4e8f-aa60-e7b4cbf3c3b9",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-11",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Cidjb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL2xlZ2FsLWhvbGQ=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/legal-hold/1770354569251017\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Flegal-hold\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Flegal-hold?generation=1770354569251017&alt=media\",\n      \"name\": \"conformance-tests/objectlock/legal-hold\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1770354569251017\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"27\",\n      \"md5Hash\": \"TRQZ8WSU+pMmjJZKRHoHBw==\",\n      \"crc32c\": \"8r/jMg==\",\n      \"etag\": \"CMmR6NmMxJIDEAE=\",\n      \"temporaryHold\": true,\n      \"timeCreated\": \"2026-02-06T05:09:29.301Z\",\n      \"updated\": \"2026-02-06T05:09:29.301Z\",\n      \"timeStorageClassUpdated\": \"2026-02-06T05:09:29.301Z\",\n      \"timeFinalized\": \"2026-02-06T05:09:29.301Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AMNfjG0icX20zBYrzwMYmEg4KwavuboHDcaMwP_XVrBQBuGJxGVZZbapwzarU_MKYgUReeuttx2Wd4TI0WwCuQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:12 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:12 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "a978f07b-e223-4e8f-aa60-e7b4cbf3c3b9",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-2",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-3",
+  "insertionIndex" : 1181
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-12.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-12.json
@@ -1,0 +1,46 @@
+{
+  "id" : "e1c5f319-9007-490e-9605-40d3b6d8119a",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-12",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_ByteArray",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1776210791770080",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Tue, 14 Apr 2026 23:53:11 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Tue, 14 Apr 2026 23:53:12 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=AAAAAA==,md5=1B2M2Y8AsgTpgAmY7PhCfg==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CODPqOrE7pMDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AMNfjG0tbaHHHIC613iF3i2cCMmemoUjSoaK2i_Q6Mu1PHGGp9Gr5fT5ye2hlf-fdacGeq0Hw6BA5NvTbZMT3w",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "0",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "e1c5f319-9007-490e-9605-40d3b6d8119a",
+  "persistent" : true,
+  "insertionIndex" : 1182
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-13.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-13.json
@@ -1,0 +1,38 @@
+{
+  "id" : "fe60fe2e-50fb-44c8-94b4-e23b858110b9",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-13",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_ByteArray",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/emptyContent_versioned_ByteArray/1776210791770080\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_ByteArray\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_ByteArray?generation=1776210791770080&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_versioned_ByteArray\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776210791770080\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CODPqOrE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:11.814Z\",\n  \"updated\": \"2026-04-14T23:53:11.814Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:11.814Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:11.814Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CODPqOrE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG2eRy6ewjCYTCrMP4edlGnHl60z0hleICGoUjCEhTkfUM_qiyAzuUMxazTGamfplO43J76M5cq0F_rRBA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:12 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:12 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "fe60fe2e-50fb-44c8-94b4-e23b858110b9",
+  "persistent" : true,
+  "insertionIndex" : 1183
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-16.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-16.json
@@ -1,0 +1,45 @@
+{
+  "id" : "d95f8908-2dff-46db-a380-bce053c03ff1",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-16",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Cidjb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL2xlZ2FsLWhvbGQ=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/legal-hold/1770354569251017\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Flegal-hold\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Flegal-hold?generation=1770354569251017&alt=media\",\n      \"name\": \"conformance-tests/objectlock/legal-hold\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1770354569251017\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"27\",\n      \"md5Hash\": \"TRQZ8WSU+pMmjJZKRHoHBw==\",\n      \"crc32c\": \"8r/jMg==\",\n      \"etag\": \"CMmR6NmMxJIDEAE=\",\n      \"temporaryHold\": true,\n      \"timeCreated\": \"2026-02-06T05:09:29.301Z\",\n      \"updated\": \"2026-02-06T05:09:29.301Z\",\n      \"timeStorageClassUpdated\": \"2026-02-06T05:09:29.301Z\",\n      \"timeFinalized\": \"2026-02-06T05:09:29.301Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AMNfjG2HVnPdi-TYOsJ57z3RaEiZjSL2EM7HD62Wwl9mTx9OdJfksL42EbMHQJp0x-wUvg6xJ8LTQv6uYJyfSQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:11 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:11 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "d95f8908-2dff-46db-a380-bce053c03ff1",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-2",
+  "insertionIndex" : 1186
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-17.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-17.json
@@ -1,0 +1,46 @@
+{
+  "id" : "2fe7b79b-9060-4015-84db-b2ef4abd76fc",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-17",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_InputStream",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1776210789785499",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Tue, 14 Apr 2026 23:53:09 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Tue, 14 Apr 2026 23:53:10 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=AAAAAA==,md5=1B2M2Y8AsgTpgAmY7PhCfg==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CJu/r+nE7pMDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AMNfjG2l2KmqVzu7gwDn5fgOWXb2Pozfeu8GBqAwNgvIRIBlA8MXNrDKsuwY9ABwL_Qxpxxgp1YUbfOdbWOraw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "0",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "2fe7b79b-9060-4015-84db-b2ef4abd76fc",
+  "persistent" : true,
+  "insertionIndex" : 1187
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-18.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-18.json
@@ -1,0 +1,40 @@
+{
+  "id" : "60ab4918-4f21-414d-add6-3b0171682733",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-18",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_InputStream",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/emptyContent_versioned_InputStream/1776210789785499\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_InputStream?generation=1776210789785499&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_versioned_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776210789785499\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CJu/r+nE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:09.831Z\",\n  \"updated\": \"2026-04-14T23:53:09.831Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:09.831Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:09.831Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CJu/r+nE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG2RGxYxkBMSNtrPoROm47fJhOC6-UxfDPsh9-rrgCWTw9Il_avC90PVcG-N-m0nzsoLTASJ-Z2GGJA2og",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:10 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:10 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "60ab4918-4f21-414d-add6-3b0171682733",
+  "persistent" : true,
+  "scenarioName" : "scenario-2-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-upload-emptyContent_versioned_InputStream",
+  "requiredScenarioState" : "scenario-2-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-upload-emptyContent_versioned_InputStream-2",
+  "insertionIndex" : 1188
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-19.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-19.json
@@ -1,0 +1,41 @@
+{
+  "id" : "48ab8057-9d5e-4f06-999a-3fa720c9a5a8",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-19",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_InputStream",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/emptyContent_versioned_InputStream/1776210789785499\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_InputStream?generation=1776210789785499&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_versioned_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776210789785499\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CJu/r+nE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:09.831Z\",\n  \"updated\": \"2026-04-14T23:53:09.831Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:09.831Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:09.831Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CJu/r+nE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG15i7zBaSbhL2mWkGaGStR_m5MPFU4SulZxbiipHUSIolnOT0xgZZ8UCdQb46GbTlndxUq8t8v-uKsBtw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:10 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:10 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "48ab8057-9d5e-4f06-999a-3fa720c9a5a8",
+  "persistent" : true,
+  "scenarioName" : "scenario-2-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-upload-emptyContent_versioned_InputStream",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-2-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-upload-emptyContent_versioned_InputStream-2",
+  "insertionIndex" : 1189
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-2.json
@@ -1,0 +1,46 @@
+{
+  "id" : "6b9e09ee-e78b-4304-bfe2-62a74857c077",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-2",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_Path",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1776210795033264",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Tue, 14 Apr 2026 23:53:15 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Tue, 14 Apr 2026 23:53:15 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=AAAAAA==,md5=1B2M2Y8AsgTpgAmY7PhCfg==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CLDl7+vE7pMDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AMNfjG38RU1rnc7a-gZzo6bv1P28LNqP6P6uiIEaa9BbryREzUr0c-PJQiLOVJYRurEQEQaVCo-3Q8XTZHcZDg",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "0",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "6b9e09ee-e78b-4304-bfe2-62a74857c077",
+  "persistent" : true,
+  "insertionIndex" : 1172
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-23.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-23.json
@@ -1,0 +1,44 @@
+{
+  "id" : "176c4192-652f-4d31-ab91-c937cad1b35a",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-23",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CiRjb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1tZXRhZGF0YTM=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-metadata3/1775494921891632\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-metadata3\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-metadata3?generation=1775494921891632&alt=media\",\n      \"name\": \"conformance-tests/blob-for-metadata3\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1775494921891632\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"43\",\n      \"md5Hash\": \"cJNvqBbhpGaIyrO3jHSozA==\",\n      \"crc32c\": \"7+lREg==\",\n      \"etag\": \"CLDe+oDa2ZMDEAE=\",\n      \"timeCreated\": \"2026-04-06T17:02:01.992Z\",\n      \"updated\": \"2026-04-06T17:02:01.992Z\",\n      \"timeStorageClassUpdated\": \"2026-04-06T17:02:01.992Z\",\n      \"timeFinalized\": \"2026-04-06T17:02:01.992Z\",\n      \"metadata\": {\n        \"def\": \"bar\",\n        \"abc\": \"foo\"\n      }\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AMNfjG1NgA44lM4PXjZCnwxoN0RSs9_uBsYVKZX3dTK2BcXBGOD0-UmivRpidcxInK0KzGk04SjOMBT7X4WLRQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:08 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:08 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "176c4192-652f-4d31-ab91-c937cad1b35a",
+  "persistent" : true,
+  "scenarioName" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o",
+  "requiredScenarioState" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-4",
+  "insertionIndex" : 1193
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-24.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-24.json
@@ -1,0 +1,46 @@
+{
+  "id" : "66225605-7a15-45f7-9a59-ad8e58d56a16",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-24",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_Path",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1776210787837748",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Tue, 14 Apr 2026 23:53:07 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Tue, 14 Apr 2026 23:53:08 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=AAAAAA==,md5=1B2M2Y8AsgTpgAmY7PhCfg==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CLTOuOjE7pMDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AMNfjG1icnOFWzVcEvDsxdyQtJrCyIJmlaqSsZACODdiqfGTxdwFJZqRyJEV_dlfoURoQfS_tDyQdcC5mNpr2A",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "0",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "66225605-7a15-45f7-9a59-ad8e58d56a16",
+  "persistent" : true,
+  "insertionIndex" : 1194
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-25.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-25.json
@@ -1,0 +1,38 @@
+{
+  "id" : "f62271c4-335c-4100-9575-f6232455e784",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-25",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_Path",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/emptyContent_Path/1776210787837748\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_Path\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_Path?generation=1776210787837748&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_Path\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776210787837748\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CLTOuOjE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:07.890Z\",\n  \"updated\": \"2026-04-14T23:53:07.890Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:07.890Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:07.890Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CLTOuOjE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG2xpCXHDV6Tg2_CnHAPs_L--n7plsWvHaL9dFgweM7OQD_dr8KIZwSFhRVAkQHKeD_FD9QycGR1tkAnOw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:08 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:08 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "f62271c4-335c-4100-9575-f6232455e784",
+  "persistent" : true,
+  "insertionIndex" : 1195
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-28.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-28.json
@@ -1,0 +1,45 @@
+{
+  "id" : "ebc2fa06-4c0a-4534-9825-bf9aa6c1d049",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-28",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CiRjb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1tZXRhZGF0YTM=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-metadata3/1775494921891632\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-metadata3\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-metadata3?generation=1775494921891632&alt=media\",\n      \"name\": \"conformance-tests/blob-for-metadata3\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1775494921891632\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"43\",\n      \"md5Hash\": \"cJNvqBbhpGaIyrO3jHSozA==\",\n      \"crc32c\": \"7+lREg==\",\n      \"etag\": \"CLDe+oDa2ZMDEAE=\",\n      \"timeCreated\": \"2026-04-06T17:02:01.992Z\",\n      \"updated\": \"2026-04-06T17:02:01.992Z\",\n      \"timeStorageClassUpdated\": \"2026-04-06T17:02:01.992Z\",\n      \"timeFinalized\": \"2026-04-06T17:02:01.992Z\",\n      \"metadata\": {\n        \"def\": \"bar\",\n        \"abc\": \"foo\"\n      }\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AMNfjG0nIhDZqqvboMaiz8M_3WKhY-GGIyO4xUjOhhbhM-NpGBdo3qx1aYoaVxlUDd25zWQe2FW6cW4c1sxngQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:07 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:07 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "ebc2fa06-4c0a-4534-9825-bf9aa6c1d049",
+  "persistent" : true,
+  "scenarioName" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o",
+  "requiredScenarioState" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-3",
+  "newScenarioState" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-4",
+  "insertionIndex" : 1198
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-29.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-29.json
@@ -1,0 +1,46 @@
+{
+  "id" : "06a8e1e6-012a-4166-adce-907942fca696",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-29",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_File",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1776210786192607",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Tue, 14 Apr 2026 23:53:06 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Tue, 14 Apr 2026 23:53:06 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=AAAAAA==,md5=1B2M2Y8AsgTpgAmY7PhCfg==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CN+Z1OfE7pMDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AMNfjG0rgUAAEWTC7b-y8Nf9Lqhkue8Bqm5weGLYcnPbvcGbEEXxYC3Kc9DMt_Lr8C1XxO4FkmTm2ZePzZqbng",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "0",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "06a8e1e6-012a-4166-adce-907942fca696",
+  "persistent" : true,
+  "insertionIndex" : 1199
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-3.json
@@ -1,0 +1,38 @@
+{
+  "id" : "15ed3984-fef3-4fcb-b687-24f8c0149faf",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_Path",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/emptyContent_versioned_Path/1776210795033264\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_Path\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_Path?generation=1776210795033264&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_versioned_Path\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776210795033264\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CLDl7+vE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:15.077Z\",\n  \"updated\": \"2026-04-14T23:53:15.077Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:15.077Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:15.077Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CLDl7+vE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG3a1b-79gwwUTvNb25YL5FSiHjzonn8kJN9joaBJ84hi7snuQpTNfol_Rg7wf1Wser5SOxFAUkZ6yupsQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:15 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:15 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "15ed3984-fef3-4fcb-b687-24f8c0149faf",
+  "persistent" : true,
+  "insertionIndex" : 1173
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-30.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-30.json
@@ -1,0 +1,38 @@
+{
+  "id" : "a223abd3-dd77-42fe-957d-a4be00422f20",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-30",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_File",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/emptyContent_File/1776210786192607\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_File\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_File?generation=1776210786192607&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_File\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776210786192607\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CN+Z1OfE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:06.244Z\",\n  \"updated\": \"2026-04-14T23:53:06.244Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:06.244Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:06.244Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CN+Z1OfE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG1hKHkEUsVmV-_Ia73xI2r0ML3nJu1cEdNNmJBYbN6A4cLoIJYLau1xdUVG4yC5VpzSdbKvoQKisHfkuA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:06 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:06 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "a223abd3-dd77-42fe-957d-a4be00422f20",
+  "persistent" : true,
+  "insertionIndex" : 1200
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-33.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-33.json
@@ -1,0 +1,45 @@
+{
+  "id" : "9d399136-46d2-4457-9c3a-abdd906de6b1",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-33",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CiRjb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1tZXRhZGF0YTM=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-metadata3/1775494921891632\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-metadata3\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-metadata3?generation=1775494921891632&alt=media\",\n      \"name\": \"conformance-tests/blob-for-metadata3\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1775494921891632\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"43\",\n      \"md5Hash\": \"cJNvqBbhpGaIyrO3jHSozA==\",\n      \"crc32c\": \"7+lREg==\",\n      \"etag\": \"CLDe+oDa2ZMDEAE=\",\n      \"timeCreated\": \"2026-04-06T17:02:01.992Z\",\n      \"updated\": \"2026-04-06T17:02:01.992Z\",\n      \"timeStorageClassUpdated\": \"2026-04-06T17:02:01.992Z\",\n      \"timeFinalized\": \"2026-04-06T17:02:01.992Z\",\n      \"metadata\": {\n        \"def\": \"bar\",\n        \"abc\": \"foo\"\n      }\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AMNfjG1872Rgf1wxSnljqW6PQjpV6yHqOlvSIeLt0kqXuunNmaFx3AUZIqipw1w69QgCnnYu3mOl23ePY94BMA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:05 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:05 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "9d399136-46d2-4457-9c3a-abdd906de6b1",
+  "persistent" : true,
+  "scenarioName" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o",
+  "requiredScenarioState" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-2",
+  "newScenarioState" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-3",
+  "insertionIndex" : 1203
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-34.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-34.json
@@ -1,0 +1,46 @@
+{
+  "id" : "b62df3d0-b105-413c-aca8-a9aeb24138d4",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-34",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_ByteArray",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1776210784468700",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Tue, 14 Apr 2026 23:53:04 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Tue, 14 Apr 2026 23:53:05 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=AAAAAA==,md5=1B2M2Y8AsgTpgAmY7PhCfg==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CNz96ubE7pMDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AMNfjG1Vl5hwUEz-TpSEl9UYAbrkNxzZUZachHx_Ej8qPPT4HRgkddw5Th_hkJGnbeXfVdzJbp8HoAft9N1v7g",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "0",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "b62df3d0-b105-413c-aca8-a9aeb24138d4",
+  "persistent" : true,
+  "insertionIndex" : 1204
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-35.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-35.json
@@ -1,0 +1,38 @@
+{
+  "id" : "6872b00b-02e4-41e4-b323-f309154f0a44",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-35",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_ByteArray",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/emptyContent_ByteArray/1776210784468700\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_ByteArray\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_ByteArray?generation=1776210784468700&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_ByteArray\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776210784468700\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CNz96ubE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:04.520Z\",\n  \"updated\": \"2026-04-14T23:53:04.520Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:04.520Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:04.520Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CNz96ubE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG3IDCHVcJIOug-MCHtazD3tJ54_72AHv0qH3cW2ZedkRnE1eQ20Gxtv6ttxZkYn5wfFPVXiCgGjDyUjMA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:04 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:04 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "6872b00b-02e4-41e4-b323-f309154f0a44",
+  "persistent" : true,
+  "insertionIndex" : 1205
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-38.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-38.json
@@ -1,0 +1,45 @@
+{
+  "id" : "d81da384-33cb-4581-90a2-3eb797a17374",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-38",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CiRjb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1tZXRhZGF0YTM=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-metadata3/1775494921891632\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-metadata3\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-metadata3?generation=1775494921891632&alt=media\",\n      \"name\": \"conformance-tests/blob-for-metadata3\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1775494921891632\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"43\",\n      \"md5Hash\": \"cJNvqBbhpGaIyrO3jHSozA==\",\n      \"crc32c\": \"7+lREg==\",\n      \"etag\": \"CLDe+oDa2ZMDEAE=\",\n      \"timeCreated\": \"2026-04-06T17:02:01.992Z\",\n      \"updated\": \"2026-04-06T17:02:01.992Z\",\n      \"timeStorageClassUpdated\": \"2026-04-06T17:02:01.992Z\",\n      \"timeFinalized\": \"2026-04-06T17:02:01.992Z\",\n      \"metadata\": {\n        \"def\": \"bar\",\n        \"abc\": \"foo\"\n      }\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AMNfjG1trE36gHL_3Ku-1KrZ-Dz5NEmzksrF2JSmnU78QBzexADlwl2wRsOBhhG_fQQw3A8WmvctVCDYMr5Ong",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:03 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:03 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "d81da384-33cb-4581-90a2-3eb797a17374",
+  "persistent" : true,
+  "scenarioName" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-3-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-2",
+  "insertionIndex" : 1208
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-39.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-39.json
@@ -1,0 +1,46 @@
+{
+  "id" : "450ab0dc-5f26-4a00-9eb1-f5bcd0104d59",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-39",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_InputStream",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1776210782473610",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Tue, 14 Apr 2026 23:53:02 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Tue, 14 Apr 2026 23:53:03 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=AAAAAA==,md5=1B2M2Y8AsgTpgAmY7PhCfg==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CIqb8eXE7pMDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AMNfjG06onsZd-8uerCRLWnAdWlZUzwdgW0_nQcOfVPJDqQd49q3CJyTUPsuJjq3WiVWG1nDNzjdChKacHUOUQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "0",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "450ab0dc-5f26-4a00-9eb1-f5bcd0104d59",
+  "persistent" : true,
+  "insertionIndex" : 1209
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-40.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-40.json
@@ -1,0 +1,40 @@
+{
+  "id" : "bf780a06-a59e-41da-9344-d0e5c3f4247f",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-40",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_InputStream",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/emptyContent_InputStream/1776210782473610\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_InputStream?generation=1776210782473610&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776210782473610\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CIqb8eXE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:02.526Z\",\n  \"updated\": \"2026-04-14T23:53:02.526Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:02.526Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:02.526Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CIqb8eXE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG2qFwF2_ObV6kGmixmlCTsdmI57OwuZHAlG2AFwmxEy4mnjC2PO4czS3-Q130RmqO97mne898Y-39tKOQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:03 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:03 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "bf780a06-a59e-41da-9344-d0e5c3f4247f",
+  "persistent" : true,
+  "scenarioName" : "scenario-4-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-conformance-tests-upload-emptyContent_InputStream",
+  "requiredScenarioState" : "scenario-4-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-conformance-tests-upload-emptyContent_InputStream-2",
+  "insertionIndex" : 1210
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-41.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-41.json
@@ -1,0 +1,41 @@
+{
+  "id" : "908f40b6-e3e6-47e6-b252-f2191d688f3c",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-41",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_InputStream",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/emptyContent_InputStream/1776210782473610\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_InputStream?generation=1776210782473610&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776210782473610\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CIqb8eXE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:02.526Z\",\n  \"updated\": \"2026-04-14T23:53:02.526Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:02.526Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:02.526Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CIqb8eXE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG1om_hi1aOQwVJf_3iLivIwWS3378w9HSNxB3u8jNKEE138FA5RddDuL_yudBSsGKDEhS-jp0OphG-O3Q",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:02 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:02 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "908f40b6-e3e6-47e6-b252-f2191d688f3c",
+  "persistent" : true,
+  "scenarioName" : "scenario-4-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-conformance-tests-upload-emptyContent_InputStream",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-4-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-o-conformance-tests-upload-emptyContent_InputStream-2",
+  "insertionIndex" : 1211
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-6.json
@@ -1,0 +1,45 @@
+{
+  "id" : "37286b81-a638-4ed5-abe0-8e7ecf6e51b3",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-6",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Cidjb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL2xlZ2FsLWhvbGQ=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/legal-hold/1770354569251017\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Flegal-hold\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Flegal-hold?generation=1770354569251017&alt=media\",\n      \"name\": \"conformance-tests/objectlock/legal-hold\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1770354569251017\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"27\",\n      \"md5Hash\": \"TRQZ8WSU+pMmjJZKRHoHBw==\",\n      \"crc32c\": \"8r/jMg==\",\n      \"etag\": \"CMmR6NmMxJIDEAE=\",\n      \"temporaryHold\": true,\n      \"timeCreated\": \"2026-02-06T05:09:29.301Z\",\n      \"updated\": \"2026-02-06T05:09:29.301Z\",\n      \"timeStorageClassUpdated\": \"2026-02-06T05:09:29.301Z\",\n      \"timeFinalized\": \"2026-02-06T05:09:29.301Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AMNfjG0W-J3jfHhs68xBOzlvghCFXgoB_ftYFhv5Bh23y6mo4v13ifwI9Thn-TzaMYcFKWaoAdtWqnt0Rrpi9A",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:14 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:14 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "37286b81-a638-4ed5-abe0-8e7ecf6e51b3",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-3",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-4",
+  "insertionIndex" : 1176
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-7.json
@@ -1,0 +1,46 @@
+{
+  "id" : "b96200f6-880d-4783-b17a-e88e59e1253b",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-7",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_File",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1776210793404683",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Tue, 14 Apr 2026 23:53:13 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Tue, 14 Apr 2026 23:53:13 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=AAAAAA==,md5=1B2M2Y8AsgTpgAmY7PhCfg==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CIuyjOvE7pMDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AMNfjG08KhMoQzbZpX9IBkOMCScJmqk-UQqQlHDvbD79X4xQ_C815-4DkM1yWmkBTFj7P4DEjgRc6QtlJIbgVA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "0",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "b96200f6-880d-4783-b17a-e88e59e1253b",
+  "persistent" : true,
+  "insertionIndex" : 1177
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-8.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-get-8.json
@@ -1,0 +1,38 @@
+{
+  "id" : "9e822339-93a0-4d8a-ab77-910d84789a21",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-GET-8",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_File",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/emptyContent_versioned_File/1776210793404683\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_File\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_File?generation=1776210793404683&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_versioned_File\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776210793404683\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CIuyjOvE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:13.448Z\",\n  \"updated\": \"2026-04-14T23:53:13.448Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:13.448Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:13.448Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CIuyjOvE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG2ikZ5F7FElUiy2Vbh187KauSDeH4QPoYpDNRbpGn7hKLpol3OHaS4zC4lpwPzm02CIwfRXN5_U56gB8w",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 14 Apr 2026 23:53:13 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:13 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "9e822339-93a0-4d8a-ab77-910d84789a21",
+  "persistent" : true,
+  "insertionIndex" : 1178
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-14.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-14.json
@@ -1,0 +1,47 @@
+{
+  "id" : "95f58bc6-8864-4f61-8a31-9c44ff45dad9",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-POST-14",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "multipart"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "matches" : "(?s)\\Q\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Length: 158\r\nContent-Type: application/json; charset=UTF-8\r\ncontent-transfer-encoding: binary\r\n\r\n{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"crc32c\":\"AAAAAA==\",\"metadata\":{},\"name\":\"conformance-tests/upload/emptyContent_versioned_ByteArray\"}\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Type: application/octet-stream\r\ncontent-transfer-encoding: binary\r\n\r\n\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q--\r\n\\E"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/emptyContent_versioned_ByteArray/1776210791770080\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_ByteArray\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_ByteArray?generation=1776210791770080&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_versioned_ByteArray\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776210791770080\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CODPqOrE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:11.814Z\",\n  \"updated\": \"2026-04-14T23:53:11.814Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:11.814Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:11.814Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CODPqOrE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG1dbkZsYp6Ot_Hj1TLoX7j5O_nr4N5BtekMdr9oYKqS_oXzKjNC2-oCOF6fzAen9Br-7WClettkHx14EA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:11 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "95f58bc6-8864-4f61-8a31-9c44ff45dad9",
+  "persistent" : true,
+  "insertionIndex" : 1184
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-21.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-21.json
@@ -1,0 +1,48 @@
+{
+  "id" : "2d3dd09c-7257-4813-b495-0d7c8d5a04fa",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-POST-21",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/emptyContent_versioned_InputStream"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/upload/emptyContent_versioned_InputStream\"}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AMNfjG1axigNCj6RtVLetoZPrAtQF04qbQitRbb37egXiwhSuohVyzFliZXc_UsfU2wV-aSg0f_o_003uKS6GNGiyvlGaDn-dstZ5fyJ9KQdAiI",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:09 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/upload/emptyContent_versioned_InputStream&uploadType=resumable&upload_id=AMNfjG1axigNCj6RtVLetoZPrAtQF04qbQitRbb37egXiwhSuohVyzFliZXc_UsfU2wV-aSg0f_o_003uKS6GNGiyvlGaDn-dstZ5fyJ9KQdAiI",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "2d3dd09c-7257-4813-b495-0d7c8d5a04fa",
+  "persistent" : true,
+  "insertionIndex" : 1191
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-26.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-26.json
@@ -1,0 +1,47 @@
+{
+  "id" : "69f396a4-8469-4f22-a629-ecf02f590955",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-POST-26",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "multipart"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "matches" : "(?s)\\Q\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Length: 113\r\nContent-Type: application/json; charset=UTF-8\r\ncontent-transfer-encoding: binary\r\n\r\n{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket\",\"metadata\":{},\"name\":\"conformance-tests/upload/emptyContent_Path\"}\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Type: application/octet-stream\r\ncontent-transfer-encoding: binary\r\n\r\n\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q--\r\n\\E"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/emptyContent_Path/1776210787837748\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_Path\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_Path?generation=1776210787837748&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_Path\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776210787837748\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CLTOuOjE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:07.890Z\",\n  \"updated\": \"2026-04-14T23:53:07.890Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:07.890Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:07.890Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CLTOuOjE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG0cFTBCdh4AeFqNO57pVQCx07VFzC-HOr-pHDZacX7JmCb6t6g8nPmuhfrBal7WIxpCZrZKqTKJdYbbjA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:07 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "69f396a4-8469-4f22-a629-ecf02f590955",
+  "persistent" : true,
+  "insertionIndex" : 1196
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-31.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-31.json
@@ -1,0 +1,47 @@
+{
+  "id" : "79460f4f-2d62-4016-9cce-629fcd9daf03",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-POST-31",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "multipart"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "matches" : "(?s)\\Q\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Length: 113\r\nContent-Type: application/json; charset=UTF-8\r\ncontent-transfer-encoding: binary\r\n\r\n{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket\",\"metadata\":{},\"name\":\"conformance-tests/upload/emptyContent_File\"}\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Type: application/octet-stream\r\ncontent-transfer-encoding: binary\r\n\r\n\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q--\r\n\\E"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/emptyContent_File/1776210786192607\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_File\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_File?generation=1776210786192607&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_File\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776210786192607\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CN+Z1OfE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:06.244Z\",\n  \"updated\": \"2026-04-14T23:53:06.244Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:06.244Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:06.244Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CN+Z1OfE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG2XKiW36b-6q1X7j51k8axs6V0GYVOeAxhzsWhsIJ28-cc2NL7bUijRhyeAQfuyrr94wn5WZOMql-Ch-A",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:06 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "79460f4f-2d62-4016-9cce-629fcd9daf03",
+  "persistent" : true,
+  "insertionIndex" : 1201
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-36.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-36.json
@@ -1,0 +1,47 @@
+{
+  "id" : "6485ead5-f6a8-46af-96d7-4b436bf22af0",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-POST-36",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "multipart"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "matches" : "(?s)\\Q\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Length: 138\r\nContent-Type: application/json; charset=UTF-8\r\ncontent-transfer-encoding: binary\r\n\r\n{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket\",\"crc32c\":\"AAAAAA==\",\"metadata\":{},\"name\":\"conformance-tests/upload/emptyContent_ByteArray\"}\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Type: application/octet-stream\r\ncontent-transfer-encoding: binary\r\n\r\n\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q--\r\n\\E"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/emptyContent_ByteArray/1776210784468700\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_ByteArray\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_ByteArray?generation=1776210784468700&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_ByteArray\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776210784468700\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CNz96ubE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:04.520Z\",\n  \"updated\": \"2026-04-14T23:53:04.520Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:04.520Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:04.520Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CNz96ubE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG1XDTwxHwbUdQrhwLyGjtsQ07zcqfHz-YvhdXqSiBaNxuvCtcqInbMvOLgkOsYyq05h3GenIzn9AiJCDw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:04 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "6485ead5-f6a8-46af-96d7-4b436bf22af0",
+  "persistent" : true,
+  "insertionIndex" : 1206
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-4.json
@@ -1,0 +1,47 @@
+{
+  "id" : "2324f0c2-2abd-4b9a-9d20-1111d0cfb8c0",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-POST-4",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "multipart"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "matches" : "(?s)\\Q\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Length: 133\r\nContent-Type: application/json; charset=UTF-8\r\ncontent-transfer-encoding: binary\r\n\r\n{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/upload/emptyContent_versioned_Path\"}\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Type: application/octet-stream\r\ncontent-transfer-encoding: binary\r\n\r\n\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q--\r\n\\E"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/emptyContent_versioned_Path/1776210795033264\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_Path\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_Path?generation=1776210795033264&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_versioned_Path\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776210795033264\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CLDl7+vE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:15.077Z\",\n  \"updated\": \"2026-04-14T23:53:15.077Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:15.077Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:15.077Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CLDl7+vE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG18urq_wsDicA0TBaNcouQzBJDqbYaQPmuuqr1w0cerC_Kt4GfV1_leOi4wK274svrVsfgeO_aYRGcdVA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:15 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "2324f0c2-2abd-4b9a-9d20-1111d0cfb8c0",
+  "persistent" : true,
+  "insertionIndex" : 1174
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-43.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-43.json
@@ -1,0 +1,48 @@
+{
+  "id" : "d0f41f5e-d499-461e-b196-067c9e5926e5",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-POST-43",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/emptyContent_InputStream"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket\",\"metadata\":{},\"name\":\"conformance-tests/upload/emptyContent_InputStream\"}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AMNfjG1f7ohySsZHKwLgEc2CFjeweTfqL7XamWI_97sk6N3JnG34OthccIBpXAkBgo2D5U3h-78IRBOq3S9q6zYheYvRvbkZ25HfvYrigs3Sxg",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:02 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/upload/emptyContent_InputStream&uploadType=resumable&upload_id=AMNfjG1f7ohySsZHKwLgEc2CFjeweTfqL7XamWI_97sk6N3JnG34OthccIBpXAkBgo2D5U3h-78IRBOq3S9q6zYheYvRvbkZ25HfvYrigs3Sxg",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "d0f41f5e-d499-461e-b196-067c9e5926e5",
+  "persistent" : true,
+  "insertionIndex" : 1213
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-9.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-post-9.json
@@ -1,0 +1,47 @@
+{
+  "id" : "6d729fab-5afb-44ff-b81b-da0781c2c175",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-POST-9",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "multipart"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "matches" : "(?s)\\Q\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Length: 133\r\nContent-Type: application/json; charset=UTF-8\r\ncontent-transfer-encoding: binary\r\n\r\n{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/upload/emptyContent_versioned_File\"}\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Type: application/octet-stream\r\ncontent-transfer-encoding: binary\r\n\r\n\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q--\r\n\\E"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/emptyContent_versioned_File/1776210793404683\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_File\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_File?generation=1776210793404683&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_versioned_File\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776210793404683\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CIuyjOvE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:13.448Z\",\n  \"updated\": \"2026-04-14T23:53:13.448Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:13.448Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:13.448Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CIuyjOvE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG39s6l69uWs_MZyzZohRtqxe4gI1WDMahQo_buyaPl0dM2jQOoTDVBIl6C0t0lwcSYA5EC5t5V1n6dBbg",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:13 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "6d729fab-5afb-44ff-b81b-da0781c2c175",
+  "persistent" : true,
+  "insertionIndex" : 1179
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-put-20.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-put-20.json
@@ -1,0 +1,49 @@
+{
+  "id" : "8884c934-5704-483d-9cee-700aa319d3c9",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-PUT-20",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/emptyContent_versioned_InputStream"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AMNfjG1axigNCj6RtVLetoZPrAtQF04qbQitRbb37egXiwhSuohVyzFliZXc_UsfU2wV-aSg0f_o_003uKS6GNGiyvlGaDn-dstZ5fyJ9KQdAiI"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/upload/emptyContent_versioned_InputStream/1776210789785499\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fupload%2FemptyContent_versioned_InputStream?generation=1776210789785499&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_versioned_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1776210789785499\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CJu/r+nE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:09.831Z\",\n  \"updated\": \"2026-04-14T23:53:09.831Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:09.831Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:09.831Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CJu/r+nE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG1axigNCj6RtVLetoZPrAtQF04qbQitRbb37egXiwhSuohVyzFliZXc_UsfU2wV-aSg0f_o_003uKS6GNGiyvlGaDn-dstZ5fyJ9KQdAiI",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:09 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "8884c934-5704-483d-9cee-700aa319d3c9",
+  "persistent" : true,
+  "insertionIndex" : 1190
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-put-42.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupload_emptycontent-put-42.json
@@ -1,0 +1,49 @@
+{
+  "id" : "349417d0-0a17-447c-9d53-83e7a508f3bb",
+  "name" : "GcpBlobStoreIT_testUpload_emptyContent-PUT-42",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/upload/emptyContent_InputStream"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AMNfjG1f7ohySsZHKwLgEc2CFjeweTfqL7XamWI_97sk6N3JnG34OthccIBpXAkBgo2D5U3h-78IRBOq3S9q6zYheYvRvbkZ25HfvYrigs3Sxg"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/upload/emptyContent_InputStream/1776210782473610\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_InputStream\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fupload%2FemptyContent_InputStream?generation=1776210782473610&alt=media\",\n  \"name\": \"conformance-tests/upload/emptyContent_InputStream\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1776210782473610\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"0\",\n  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n  \"crc32c\": \"AAAAAA==\",\n  \"etag\": \"CIqb8eXE7pMDEAE=\",\n  \"timeCreated\": \"2026-04-14T23:53:02.526Z\",\n  \"updated\": \"2026-04-14T23:53:02.526Z\",\n  \"timeStorageClassUpdated\": \"2026-04-14T23:53:02.526Z\",\n  \"timeFinalized\": \"2026-04-14T23:53:02.526Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CIqb8eXE7pMDEAE=",
+      "X-GUploader-UploadID" : "AMNfjG1f7ohySsZHKwLgEc2CFjeweTfqL7XamWI_97sk6N3JnG34OthccIBpXAkBgo2D5U3h-78IRBOq3S9q6zYheYvRvbkZ25HfvYrigs3Sxg",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 14 Apr 2026 23:53:02 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "349417d0-0a17-447c-9d53-83e7a508f3bb",
+  "persistent" : true,
+  "insertionIndex" : 1212
+}


### PR DESCRIPTION
## Summary

Enables the testUpload_emptyContent conformance test case against GCP. The recorded files are produced with the following enhancements on multipart file upload requests capturing and matching:

https://github.com/salesforce/multicloudj/pull/379

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
