### PR TITLE
blobstore: onboarding the aws basic credentials in aws creds overider

### DIFF
--- a/multicloudj-common-aws/src/main/java/com/salesforce/multicloudj/common/aws/CredentialsProvider.java
+++ b/multicloudj-common-aws/src/main/java/com/salesforce/multicloudj/common/aws/CredentialsProvider.java
@@ -2,7 +2,9 @@ package com.salesforce.multicloudj.common.aws;
 
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
+import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -22,6 +24,13 @@ public class CredentialsProvider {
       case SESSION:
         {
           StsCredentials stsCredentials = overrider.getSessionCredentials();
+          if (StringUtils.isBlank(stsCredentials.getSecurityToken())) {
+            return StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(
+                    stsCredentials.getAccessKeyId(),
+                    stsCredentials.getAccessKeySecret())
+            );
+          }
           AwsSessionCredentials sessionCredentials =
               AwsSessionCredentials.create(
                   stsCredentials.getAccessKeyId(),

--- a/multicloudj-common-aws/src/test/java/com/salesforce/multicloudj/common/aws/CredentialsProviderTest.java
+++ b/multicloudj-common-aws/src/test/java/com/salesforce/multicloudj/common/aws/CredentialsProviderTest.java
@@ -5,6 +5,7 @@ import com.salesforce.multicloudj.sts.model.CredentialsType;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -20,6 +21,18 @@ public class CredentialsProviderTest {
         CredentialsProvider.getCredentialsProvider(credentialsOverrider, Region.AF_SOUTH_1);
     Assertions.assertNotNull(awsCredsProvider);
     Assertions.assertInstanceOf(StsAssumeRoleCredentialsProvider.class, awsCredsProvider);
+  }
+
+  @Test
+  public void testBasicCredentialsProvider() {
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(new StsCredentials("a", "b", null))
+            .build();
+    AwsCredentialsProvider awsCredsProvider =
+        CredentialsProvider.getCredentialsProvider(credentialsOverrider, Region.AF_SOUTH_1);
+    Assertions.assertNotNull(awsCredsProvider);
+    Assertions.assertInstanceOf(AwsBasicCredentials.class, awsCredsProvider.resolveCredentials());
   }
 
   @Test


### PR DESCRIPTION
## Summary

< Provide a brief description of the changes in this PR >

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
