### PR TITLE
blobstore: add an option to supply quota project id in bucket client

### DIFF
--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
@@ -711,6 +711,18 @@ public class BucketClient implements AutoCloseable {
     }
 
     /**
+     * Method to supply a quota project ID. This method is not applicable
+     * to all providers
+     *
+     * @param quotaProjectId The project ID to use for quota and billing
+     * @return An instance of self
+     */
+    public BlobBuilder withQuotaProjectId(String quotaProjectId) {
+      this.blobStoreBuilder.withQuotaProjectId(quotaProjectId);
+      return this;
+    }
+
+    /**
      * Builds and returns an instance of BucketClient.
      *
      * @return An instance of BucketClient.

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStoreBuilder.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStoreBuilder.java
@@ -38,6 +38,7 @@ public abstract class BlobStoreBuilder<T extends SdkService> implements SdkProvi
   private RetryConfig retryConfig;
   private Boolean useSystemPropertyProxyValues;
   private Boolean useEnvironmentVariableProxyValues;
+  private String quotaProjectId;
 
   public BlobStoreBuilder<T> providerId(String providerId) {
     this.providerId = providerId;
@@ -318,6 +319,18 @@ public abstract class BlobStoreBuilder<T extends SdkService> implements SdkProvi
   public BlobStoreBuilder<T> withUseEnvironmentVariableProxyValues(
       Boolean useEnvironmentVariableProxyValues) {
     this.useEnvironmentVariableProxyValues = useEnvironmentVariableProxyValues;
+    return this;
+  }
+
+  /**
+   * Method to supply a quota project ID. For GCP, this is the project ID used for billing and quota
+   * attribution. Other providers may ignore this setting.
+   *
+   * @param quotaProjectId The project ID to use for quota and billing
+   * @return An instance of self
+   */
+  public BlobStoreBuilder<T> withQuotaProjectId(String quotaProjectId) {
+    this.quotaProjectId = quotaProjectId;
     return this;
   }
 }

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/BucketClientTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/BucketClientTest.java
@@ -699,6 +699,29 @@ public class BucketClientTest {
   }
 
   @Test
+  void testBucketClientBuilderWithQuotaProjectId() {
+    AbstractBlobStore.Builder mockBuilder2 = mock(AbstractBlobStore.Builder.class);
+    when(mockBuilder2.withBucket(any())).thenReturn(mockBuilder2);
+    when(mockBuilder2.withRegion(any())).thenReturn(mockBuilder2);
+    when(mockBuilder2.withQuotaProjectId(any())).thenReturn(mockBuilder2);
+    when(mockBuilder2.build()).thenReturn(mockBlobStore);
+
+    providerSupplier
+        .when(() -> ProviderSupplier.findProviderBuilder("test6"))
+        .thenReturn(mockBuilder2);
+
+    BucketClient testClient =
+        BucketClient.builder("test6")
+            .withBucket("test-bucket")
+            .withRegion("us-east-1")
+            .withQuotaProjectId("my-quota-project")
+            .build();
+
+    verify(mockBuilder2, times(1)).withQuotaProjectId("my-quota-project");
+    assertNotNull(testClient);
+  }
+
+  @Test
   void testClose() throws Exception {
     // Test that close() calls blobStore.close()
     client.close();

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -1092,6 +1092,10 @@ public class GcpBlobStore extends AbstractBlobStore {
             transformer.toGcpRetrySettings(builder.getRetryConfig()));
       }
 
+      if (builder.getQuotaProjectId() != null) {
+        storageOptionsBuilder.setQuotaProjectId(builder.getQuotaProjectId());
+      }
+
       return MultipartUploadClient.create(
           MultipartUploadSettings.of(storageOptionsBuilder.build()));
     }

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -3666,4 +3666,30 @@ class GcpBlobStoreTest {
     assertNotNull(store);
     assertEquals(TEST_BUCKET, store.getBucket());
   }
+
+  @Test
+  void testBuild_WithQuotaProjectId() {
+    GcpBlobStore.Builder builder =
+        (GcpBlobStore.Builder)
+            new GcpBlobStore.Builder()
+                .withBucket(TEST_BUCKET)
+                .withQuotaProjectId("my-quota-project");
+
+    assertEquals("my-quota-project", builder.getQuotaProjectId());
+
+    GcpBlobStore store = builder.build();
+    assertNotNull(store);
+    assertEquals(TEST_BUCKET, store.getBucket());
+  }
+
+  @Test
+  void testBuild_WithoutQuotaProjectId() {
+    GcpBlobStore.Builder builder =
+        (GcpBlobStore.Builder) new GcpBlobStore.Builder().withBucket(TEST_BUCKET);
+
+    assertNull(builder.getQuotaProjectId());
+
+    GcpBlobStore store = builder.build();
+    assertNotNull(store);
+  }
 }


### PR DESCRIPTION
## Summary

< Provide a brief description of the changes in this PR >

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
