### PR TITLE
blobstore: add object lock support to multipart uploads

### DIFF
--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -272,8 +272,9 @@ public class AwsTransformer {
     if (lockConfig.getRetainUntilDate() != null) {
       builder.objectLockRetainUntilDate(lockConfig.getRetainUntilDate());
     }
-    builder.objectLockLegalHoldStatus(
-        lockConfig.isLegalHold() ? ObjectLockLegalHoldStatus.ON : ObjectLockLegalHoldStatus.OFF);
+    if (lockConfig.isLegalHold()) {
+      builder.objectLockLegalHoldStatus(ObjectLockLegalHoldStatus.ON);
+    }
   }
 
   /** Converts provider SDK ObjectLockMode to SDK RetentionMode */
@@ -493,6 +494,20 @@ public class AwsTransformer {
       ChecksumMethod algo = request.getChecksumAlgorithm() != null
           ? request.getChecksumAlgorithm() : ChecksumMethod.CRC32C;
       builder.checksumAlgorithm(toAwsChecksumAlgorithm(algo));
+    }
+
+    // Set object lock if provided
+    if (request.getObjectLock() != null) {
+      ObjectLockConfiguration lockConfig = request.getObjectLock();
+      if (lockConfig.getMode() != null) {
+        builder.objectLockMode(toAwsObjectLockMode(lockConfig.getMode()));
+      }
+      if (lockConfig.getRetainUntilDate() != null) {
+        builder.objectLockRetainUntilDate(lockConfig.getRetainUntilDate());
+      }
+      if (lockConfig.isLegalHold()) {
+        builder.objectLockLegalHoldStatus(ObjectLockLegalHoldStatus.ON);
+      }
     }
 
     // Set content type if provided
@@ -831,6 +846,7 @@ public class AwsTransformer {
         .kmsKeyId(request.getKmsKeyId())
         .checksumEnabled(request.isChecksumEnabled())
         .checksumAlgorithm(request.getChecksumAlgorithm())
+        .objectLock(request.getObjectLock())
         .contentType(request.getContentType())
         .build();
   }

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreIT.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreIT.java
@@ -134,6 +134,11 @@ public class AwsBlobStoreIT extends AbstractBlobStoreIT {
     }
 
     @Override
+    public boolean isObjectLockSupported() {
+      return true;
+    }
+
+    @Override
     public void close() {
       client.close();
       httpClient.close();

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
@@ -49,11 +49,13 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.CommonPrefix;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectLegalHoldResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRetentionResponse;
@@ -76,6 +78,7 @@ import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 import software.amazon.awssdk.transfer.s3.config.DownloadFilter;
@@ -91,6 +94,13 @@ import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 public class AwsTransformerTest {
 
   private static final String BUCKET = "some-bucket";
+  private static final String SOME_KEY = "some-key";
+  private static final String SOME_VALUE = "some-value";
+  private static final String TEST_OBJECT_KEY = "object-1";
+  private static final String TEST_METADATA_KEY = "key1";
+  private static final String TEST_METADATA_VALUE = "value1";
+  private static final String TEST_METADATA_KEY_2 = "key2";
+  private static final String TEST_METADATA_VALUE_2 = "value2";
   private final AwsTransformer transformer = new AwsTransformer(BUCKET);
 
   @Test
@@ -100,8 +110,8 @@ public class AwsTransformerTest {
 
   @Test
   void testUpload() {
-    var key = "some-key";
-    var metadata = Map.of("some-key", "some-value");
+    var key = SOME_KEY;
+    var metadata = Map.of(SOME_KEY, SOME_VALUE);
     var tags = Map.of("tag-key", "tag-value");
 
     var request =
@@ -486,12 +496,43 @@ public class AwsTransformerTest {
   }
 
   @Test
+  void testToCreateMultipartUploadRequestWithObjectLock() {
+    Map<String, String> metadata = Map.of(TEST_METADATA_KEY, TEST_METADATA_VALUE);
+    Instant retainUntil = Instant.parse("2026-12-31T23:59:59Z");
+    ObjectLockConfiguration objectLock =
+        ObjectLockConfiguration.builder()
+            .mode(RetentionMode.COMPLIANCE)
+            .retainUntilDate(retainUntil)
+            .legalHold(true)
+            .build();
+    MultipartUploadRequest mpuRequest =
+        new MultipartUploadRequest.Builder()
+            .withKey(TEST_OBJECT_KEY)
+            .withMetadata(metadata)
+            .withObjectLock(objectLock)
+            .build();
+    CreateMultipartUploadRequest request = transformer.toCreateMultipartUploadRequest(mpuRequest);
+    assertEquals(TEST_OBJECT_KEY, request.key());
+    assertEquals(BUCKET, request.bucket());
+    assertEquals(metadata, request.metadata());
+    // Verify object lock settings
+    assertEquals(ObjectLockMode.COMPLIANCE, request.objectLockMode());
+    assertEquals(retainUntil, request.objectLockRetainUntilDate());
+    assertEquals(ObjectLockLegalHoldStatus.ON, request.objectLockLegalHoldStatus());
+  }
+
+  @Test
   void testToUploadPartRequest() {
-    Map<String, String> metadata = Map.of("key1", "value1", "key2", "value2");
+    Map<String, String> metadata =
+        Map.of(
+            TEST_METADATA_KEY,
+            TEST_METADATA_VALUE,
+            TEST_METADATA_KEY_2,
+            TEST_METADATA_VALUE_2);
     MultipartUpload multipartUpload =
         MultipartUpload.builder()
             .bucket("bucket-1")
-            .key("object-1")
+            .key(TEST_OBJECT_KEY)
             .id("mpu-id")
             .metadata(metadata)
             .contentType("text/plain")
@@ -499,7 +540,7 @@ public class AwsTransformerTest {
     byte[] content = "This is test data".getBytes();
     MultipartPart multipartPart = new MultipartPart(1, content);
     UploadPartRequest request = transformer.toUploadPartRequest(multipartUpload, multipartPart);
-    assertEquals("object-1", request.key());
+    assertEquals(TEST_OBJECT_KEY, request.key());
     assertEquals(BUCKET, request.bucket());
     assertEquals("mpu-id", request.uploadId());
     assertEquals(content.length, request.contentLength());
@@ -866,7 +907,7 @@ public class AwsTransformerTest {
     PutObjectRequest putRequest = fileBuilder.build().putObjectRequest();
     assertEquals(ObjectLockMode.GOVERNANCE, putRequest.objectLockMode());
     assertEquals(retainUntil, putRequest.objectLockRetainUntilDate());
-    assertEquals(ObjectLockLegalHoldStatus.OFF, putRequest.objectLockLegalHoldStatus());
+    assertNull(putRequest.objectLockLegalHoldStatus());
   }
 
   @Test
@@ -1121,6 +1162,84 @@ public class AwsTransformerTest {
   }
 
   @Test
+  void testToCreateMultipartUploadRequest_WithObjectLockLegalHoldTrue() {
+    Instant retainUntilDate = Instant.now().plusSeconds(3600);
+    MultipartUploadRequest mpuRequest =
+        new MultipartUploadRequest.Builder()
+            .withKey("object-1")
+            .withObjectLock(
+                ObjectLockConfiguration.builder()
+                    .mode(RetentionMode.GOVERNANCE)
+                    .retainUntilDate(retainUntilDate)
+                    .legalHold(true)
+                    .build())
+            .build();
+
+    CreateMultipartUploadRequest request = transformer.toCreateMultipartUploadRequest(mpuRequest);
+
+    assertEquals("object-1", request.key());
+    assertEquals(BUCKET, request.bucket());
+    assertEquals(ObjectLockMode.GOVERNANCE, request.objectLockMode());
+    assertEquals(retainUntilDate, request.objectLockRetainUntilDate());
+    assertEquals(ObjectLockLegalHoldStatus.ON, request.objectLockLegalHoldStatus());
+  }
+
+  @Test
+  void testToCreateMultipartUploadRequest_WithObjectLockLegalHoldFalse_OmitsHeader() {
+    Instant retainUntilDate = Instant.now().plusSeconds(3600);
+    MultipartUploadRequest mpuRequest =
+        new MultipartUploadRequest.Builder()
+            .withKey("object-1")
+            .withObjectLock(
+                ObjectLockConfiguration.builder()
+                    .mode(RetentionMode.GOVERNANCE)
+                    .retainUntilDate(retainUntilDate)
+                    .legalHold(false)
+                    .build())
+            .build();
+
+    CreateMultipartUploadRequest request = transformer.toCreateMultipartUploadRequest(mpuRequest);
+
+    assertEquals("object-1", request.key());
+    assertEquals(BUCKET, request.bucket());
+    assertEquals(ObjectLockMode.GOVERNANCE, request.objectLockMode());
+    assertEquals(retainUntilDate, request.objectLockRetainUntilDate());
+    assertNull(request.objectLockLegalHoldStatus());
+  }
+
+  @Test
+  void testToMultipartUpload_PropagatesObjectLockConfiguration() {
+    Instant retainUntilDate = Instant.now().plusSeconds(7200);
+    ObjectLockConfiguration objectLock =
+        ObjectLockConfiguration.builder()
+            .mode(RetentionMode.COMPLIANCE)
+            .retainUntilDate(retainUntilDate)
+            .legalHold(true)
+            .build();
+    MultipartUploadRequest mpuRequest =
+        new MultipartUploadRequest.Builder()
+            .withKey("object-1")
+            .withObjectLock(objectLock)
+            .build();
+    CreateMultipartUploadResponse response =
+        CreateMultipartUploadResponse.builder()
+            .bucket(BUCKET)
+            .key("object-1")
+            .uploadId("upload-id")
+            .build();
+
+    MultipartUpload mpu = transformer.toMultipartUpload(mpuRequest, response);
+
+    assertEquals(BUCKET, mpu.getBucket());
+    assertEquals("object-1", mpu.getKey());
+    assertEquals("upload-id", mpu.getId());
+    assertNotNull(mpu.getObjectLock());
+    assertEquals(RetentionMode.COMPLIANCE, mpu.getObjectLock().getMode());
+    assertEquals(retainUntilDate, mpu.getObjectLock().getRetainUntilDate());
+    assertTrue(mpu.getObjectLock().isLegalHold());
+  }
+
+  @Test
   void testToAwsRetryStrategyWithExponentialMode() {
     RetryConfig config =
         RetryConfig.builder()
@@ -1322,7 +1441,7 @@ public class AwsTransformerTest {
     var actual = transformer.toRequest(request);
 
     assertEquals(ObjectLockMode.COMPLIANCE, actual.objectLockMode());
-    assertEquals(ObjectLockLegalHoldStatus.OFF, actual.objectLockLegalHoldStatus());
+    assertNull(actual.objectLockLegalHoldStatus());
   }
 
   @Test
@@ -1371,11 +1490,9 @@ public class AwsTransformerTest {
   @Test
   void testToObjectLockInfo_WithNullRetention() {
     var legalHoldResponse =
-        software.amazon.awssdk.services.s3.model.GetObjectLegalHoldResponse.builder()
+        GetObjectLegalHoldResponse.builder()
             .legalHold(
-                software.amazon.awssdk.services.s3.model.ObjectLockLegalHold.builder()
-                    .status(ObjectLockLegalHoldStatus.OFF)
-                    .build())
+                ObjectLockLegalHold.builder().status(ObjectLockLegalHoldStatus.OFF).build())
             .build();
 
     var result = transformer.toObjectLockInfo(null, legalHoldResponse);
@@ -1386,20 +1503,18 @@ public class AwsTransformerTest {
   @Test
   void testToObjectLockInfo_WithComplianceMode() {
     var retentionResponse =
-        software.amazon.awssdk.services.s3.model.GetObjectRetentionResponse.builder()
+        GetObjectRetentionResponse.builder()
             .retention(
-                software.amazon.awssdk.services.s3.model.ObjectLockRetention.builder()
+                ObjectLockRetention.builder()
                     .mode(ObjectLockRetentionMode.COMPLIANCE)
                     .retainUntilDate(Instant.now().plusSeconds(3600))
                     .build())
             .build();
 
     var legalHoldResponse =
-        software.amazon.awssdk.services.s3.model.GetObjectLegalHoldResponse.builder()
+        GetObjectLegalHoldResponse.builder()
             .legalHold(
-                software.amazon.awssdk.services.s3.model.ObjectLockLegalHold.builder()
-                    .status(ObjectLockLegalHoldStatus.OFF)
-                    .build())
+                ObjectLockLegalHold.builder().status(ObjectLockLegalHoldStatus.OFF).build())
             .build();
 
     var result = transformer.toObjectLockInfo(retentionResponse, legalHoldResponse);
@@ -1462,8 +1577,7 @@ public class AwsTransformerTest {
     var actual = transformer.toRequest(request);
 
     assertEquals(
-        software.amazon.awssdk.services.s3.model.ChecksumAlgorithm.SHA256,
-        actual.checksumAlgorithm());
+        ChecksumAlgorithm.SHA256, actual.checksumAlgorithm());
     assertEquals("abc123sha256", actual.checksumSHA256());
   }
 
@@ -1479,8 +1593,7 @@ public class AwsTransformerTest {
     var actual = transformer.toRequest(request);
 
     assertEquals(
-        software.amazon.awssdk.services.s3.model.ChecksumAlgorithm.CRC32_C,
-        actual.checksumAlgorithm());
+        ChecksumAlgorithm.CRC32_C, actual.checksumAlgorithm());
     assertEquals("abc123crc32c", actual.checksumCRC32C());
   }
 
@@ -1498,8 +1611,7 @@ public class AwsTransformerTest {
     assertEquals("object-1", request.key());
     assertEquals(BUCKET, request.bucket());
     assertEquals(
-        software.amazon.awssdk.services.s3.model.ChecksumAlgorithm.SHA256,
-        request.checksumAlgorithm());
+        ChecksumAlgorithm.SHA256, request.checksumAlgorithm());
   }
 
   @Test
@@ -1522,8 +1634,7 @@ public class AwsTransformerTest {
     assertEquals(BUCKET, request.bucket());
     assertEquals("mpu-id", request.uploadId());
     assertEquals(
-        software.amazon.awssdk.services.s3.model.ChecksumAlgorithm.SHA256,
-        request.checksumAlgorithm());
+        ChecksumAlgorithm.SHA256, request.checksumAlgorithm());
     assertEquals("sha256checksum", request.checksumSHA256());
   }
 
@@ -1574,8 +1685,8 @@ public class AwsTransformerTest {
 
   @Test
   void testToUploadPartResponse_WithSha256Checksum() {
-    software.amazon.awssdk.services.s3.model.UploadPartResponse response =
-        software.amazon.awssdk.services.s3.model.UploadPartResponse.builder()
+    UploadPartResponse response =
+        UploadPartResponse.builder()
             .eTag("etag")
             .checksumSHA256("sha256partvalue")
             .build();

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetobjectlock_nonexistentkey_throws-get-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetobjectlock_nonexistentkey_throws-get-0.json
@@ -1,0 +1,34 @@
+{
+  "id" : "fe2b4ecf-23a1-43c1-9614-04924381e99a",
+  "name" : "AwsBlobStoreIT_testGetObjectLock_nonexistentKey_throws-GET-0",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/nonexistent",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>conformance-tests/objectlock/nonexistent</Key><RequestId>STX55VHW1WRAGPM5</RequestId><HostId>IX+LXP2iYGZMHpbNFuNTdwHURb8SiNNqOYVpkK8AA25uHWaQOD6oJgU9Ne9u6YpHbBBSLkg9mlgCEVKMN/kWGGeMujFRA7EpfGlVn76UQ9k=</HostId></Error>",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "STX55VHW1WRAGPM5",
+      "x-amz-id-2" : "IX+LXP2iYGZMHpbNFuNTdwHURb8SiNNqOYVpkK8AA25uHWaQOD6oJgU9Ne9u6YpHbBBSLkg9mlgCEVKMN/kWGGeMujFRA7EpfGlVn76UQ9k=",
+      "Date" : "Tue, 05 May 2026 19:48:46 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "fe2b4ecf-23a1-43c1-9614-04924381e99a",
+  "persistent" : true,
+  "insertionIndex" : 1007
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-delete-6.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-delete-6.json
@@ -1,0 +1,20 @@
+{
+  "id" : "31c020bb-aaad-4f76-b95c-ecca5ed661a2",
+  "name" : "AwsBlobStoreIT_testMultipartUpload_withObjectLock-DELETE-6",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/multipart-withObjectLock",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "OBJECTLOCKMPU0007",
+      "x-amz-id-2" : "objectlock-multipart-upload-delete",
+      "Date" : "Tue, 05 May 2026 20:00:06 GMT"
+    }
+  },
+  "uuid" : "31c020bb-aaad-4f76-b95c-ecca5ed661a2",
+  "persistent" : true,
+  "insertionIndex" : 2007
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-get-4.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-get-4.json
@@ -1,0 +1,21 @@
+{
+  "id" : "a9f00c0d-93d0-4307-bff2-b896c6206b4a",
+  "name" : "AwsBlobStoreIT_testMultipartUpload_withObjectLock-GET-4",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/multipart-withObjectLock?retention",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Retention xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Mode>GOVERNANCE</Mode><RetainUntilDate>2100-01-01T00:00:00Z</RetainUntilDate></Retention>",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "OBJECTLOCKMPU0005",
+      "x-amz-id-2" : "objectlock-multipart-upload-retention",
+      "Date" : "Tue, 05 May 2026 20:00:04 GMT"
+    }
+  },
+  "uuid" : "a9f00c0d-93d0-4307-bff2-b896c6206b4a",
+  "persistent" : true,
+  "insertionIndex" : 2005
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-get-5.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-get-5.json
@@ -1,0 +1,21 @@
+{
+  "id" : "d4ff6905-2cd4-4bd9-8343-d8764f7b0efe",
+  "name" : "AwsBlobStoreIT_testMultipartUpload_withObjectLock-GET-5",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/multipart-withObjectLock?legal-hold",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><LegalHold xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Status>OFF</Status></LegalHold>",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "OBJECTLOCKMPU0006",
+      "x-amz-id-2" : "objectlock-multipart-upload-legalhold",
+      "Date" : "Tue, 05 May 2026 20:00:05 GMT"
+    }
+  },
+  "uuid" : "d4ff6905-2cd4-4bd9-8343-d8764f7b0efe",
+  "persistent" : true,
+  "insertionIndex" : 2006
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-post-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-post-0.json
@@ -1,0 +1,33 @@
+{
+  "id" : "0f4f5de8-3a60-4ff1-9a5f-3f3b5f4f1b10",
+  "name" : "AwsBlobStoreIT_testMultipartUpload_withObjectLock-POST-0",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/multipart-withObjectLock",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><InitiateMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Bucket>chameleon-jcloud-versioned</Bucket><Key>conformance-tests/multipart-withObjectLock</Key><UploadId>withobjectlock-upload-id</UploadId></InitiateMultipartUploadResult>",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "OBJECTLOCKMPU0001",
+      "x-amz-id-2" : "objectlock-multipart-upload-init",
+      "Date" : "Tue, 05 May 2026 20:00:00 GMT"
+    }
+  },
+  "uuid" : "0f4f5de8-3a60-4ff1-9a5f-3f3b5f4f1b10",
+  "persistent" : true,
+  "insertionIndex" : 2001
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-post-3.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-post-3.json
@@ -1,0 +1,34 @@
+{
+  "id" : "d1cc6ddb-ff6b-4b76-85fe-a5d3f11fcb8d",
+  "name" : "AwsBlobStoreIT_testMultipartUpload_withObjectLock-POST-3",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/multipart-withObjectLock",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "withobjectlock-upload-id"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><CompleteMultipartUploadResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Location>https://s3.us-west-2.amazonaws.com/chameleon-jcloud-versioned/conformance-tests%2Fmultipart-withObjectLock</Location><Bucket>chameleon-jcloud-versioned</Bucket><Key>conformance-tests/multipart-withObjectLock</Key><ETag>\"63a814bc1f352d8149b1dd9f3747e89e-2\"</ETag></CompleteMultipartUploadResult>",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "OBJECTLOCKMPU0004",
+      "x-amz-id-2" : "objectlock-multipart-upload-complete",
+      "Date" : "Tue, 05 May 2026 20:00:03 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "d1cc6ddb-ff6b-4b76-85fe-a5d3f11fcb8d",
+  "persistent" : true,
+  "insertionIndex" : 2004
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-put-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-put-1.json
@@ -1,0 +1,38 @@
+{
+  "id" : "9553a78d-fa7a-4a84-95cd-7132b50a8c41",
+  "name" : "AwsBlobStoreIT_testMultipartUpload_withObjectLock-PUT-1",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/multipart-withObjectLock",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "withobjectlock-upload-id"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"2b5c91ad399409ec9b409b66f5bb00fb\"",
+      "x-amz-request-id" : "OBJECTLOCKMPU0002",
+      "x-amz-id-2" : "objectlock-multipart-upload-part-1",
+      "Date" : "Tue, 05 May 2026 20:00:01 GMT"
+    }
+  },
+  "uuid" : "9553a78d-fa7a-4a84-95cd-7132b50a8c41",
+  "persistent" : true,
+  "insertionIndex" : 2002
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-put-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testmultipartupload_withobjectlock-put-2.json
@@ -1,0 +1,38 @@
+{
+  "id" : "b5fb4e37-a60e-4d7c-a312-6fe6e9657f44",
+  "name" : "AwsBlobStoreIT_testMultipartUpload_withObjectLock-PUT-2",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/multipart-withObjectLock",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "withobjectlock-upload-id"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"267c038cc2ec32ffd0ee2512ff5da5a5\"",
+      "x-amz-request-id" : "OBJECTLOCKMPU0003",
+      "x-amz-id-2" : "objectlock-multipart-upload-part-2",
+      "Date" : "Tue, 05 May 2026 20:00:02 GMT"
+    }
+  },
+  "uuid" : "b5fb4e37-a60e-4d7c-a312-6fe6e9657f44",
+  "persistent" : true,
+  "insertionIndex" : 2003
+}

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/MultipartUpload.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/MultipartUpload.java
@@ -19,5 +19,6 @@ public class MultipartUpload {
   private final String kmsKeyId;
   private final boolean checksumEnabled;
   private final ChecksumMethod checksumAlgorithm;
+  private final ObjectLockConfiguration objectLock;
   private final String contentType;
 }

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/MultipartUploadRequest.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/MultipartUploadRequest.java
@@ -17,6 +17,7 @@ public class MultipartUploadRequest {
   private final boolean useKmsManagedKey;
   private final boolean checksumEnabled;
   private final ChecksumMethod checksumAlgorithm;
+  private final ObjectLockConfiguration objectLock;
   private final String contentType;
 
   private MultipartUploadRequest(final Builder builder) {
@@ -29,6 +30,7 @@ public class MultipartUploadRequest {
         ? builder.checksumAlgorithm
         : (builder.checksumEnabled ? ChecksumMethod.CRC32C : null);
     this.checksumEnabled = this.checksumAlgorithm != null;
+    this.objectLock = builder.objectLock;
     this.contentType = builder.contentType;
   }
 
@@ -48,6 +50,7 @@ public class MultipartUploadRequest {
     private boolean useKmsManagedKey;
     private boolean checksumEnabled;
     private ChecksumMethod checksumAlgorithm;
+    private ObjectLockConfiguration objectLock;
     private String contentType;
 
     public Builder withKey(String key) {
@@ -82,6 +85,11 @@ public class MultipartUploadRequest {
 
     public Builder withChecksumAlgorithm(ChecksumMethod checksumAlgorithm) {
       this.checksumAlgorithm = checksumAlgorithm;
+      return this;
+    }
+
+    public Builder withObjectLock(ObjectLockConfiguration objectLock) {
+      this.objectLock = objectLock;
       return this;
     }
 

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -93,10 +93,10 @@ public abstract class AbstractBlobStoreIT {
 
     /**
      * Whether this provider supports object lock (WORM). When false, object lock conformance
-     * tests are skipped.
+     * tests are skipped. Defaults to false — providers must explicitly opt in.
      */
     default boolean isObjectLockSupported() {
-      return true;
+      return false;
     }
 
     /**
@@ -2595,7 +2595,8 @@ public abstract class AbstractBlobStoreIT {
 
     String key = "conformance-tests/objectlock/retention-governance";
     byte[] content = "Object lock retention governance test".getBytes(StandardCharsets.UTF_8);
-    Instant retainUntil = OBJECT_LOCK_RETAIN_UNTIL_GOVERNANCE;
+    // Keep retainUntil in the future so record mode remains valid over time.
+    Instant retainUntil = Instant.parse("2100-01-01T00:00:00Z");
 
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
     BucketClient bucketClient = new BucketClient(blobStore);
@@ -4921,5 +4922,68 @@ public abstract class AbstractBlobStoreIT {
     }
 
     blobStore.close();
+  }
+
+  @Test
+  public void testMultipartUpload_withObjectLock() {
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+
+    String expectedKey = DEFAULT_MULTIPART_KEY_PREFIX + "withObjectLock";
+    // Keep retainUntil in the future so record mode remains valid over time.
+    Instant retainUntil = Instant.parse("2100-01-01T00:00:00Z");
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    MultipartUpload mpu = null;
+    try {
+      // Create object lock configuration
+      ObjectLockConfiguration objectLock =
+          ObjectLockConfiguration.builder()
+              .mode(RetentionMode.GOVERNANCE)
+              .retainUntilDate(retainUntil)
+              .legalHold(false)
+              .build();
+
+      // Initiate multipart upload with object lock
+      MultipartUploadRequest multipartUploadRequest =
+          new MultipartUploadRequest.Builder()
+              .withKey(expectedKey)
+              .withMetadata(Map.of("test-key", "test-value"))
+              .withObjectLock(objectLock)
+              .build();
+      mpu = bucketClient.initiateMultipartUpload(multipartUploadRequest);
+      Assertions.assertNotNull(mpu, "Multipart upload should be initiated");
+
+      // Upload parts
+      UploadPartResponse part1Response =
+          bucketClient.uploadMultipartPart(mpu, new MultipartPart(1, multipartBytes1));
+      UploadPartResponse part2Response =
+          bucketClient.uploadMultipartPart(mpu, new MultipartPart(2, multipartBytes2));
+
+      Assertions.assertNotNull(part1Response, "Part 1 response should not be null");
+      Assertions.assertNotNull(part2Response, "Part 2 response should not be null");
+
+      // Complete multipart upload
+      List<UploadPartResponse> partsToComplete = List.of(part1Response, part2Response);
+      MultipartUploadResponse completeResponse =
+          bucketClient.completeMultipartUpload(mpu, partsToComplete);
+
+      Assertions.assertNotNull(completeResponse, "Complete response should not be null");
+      Assertions.assertNotNull(completeResponse.getEtag(), "ETag should not be null");
+
+      // Verify object lock was applied
+      ObjectLockInfo lockInfo = bucketClient.getObjectLock(expectedKey, null);
+      Assertions.assertNotNull(lockInfo, "Object lock info should not be null");
+      Assertions.assertEquals(
+          RetentionMode.GOVERNANCE, lockInfo.getMode(), "Retention mode should be GOVERNANCE");
+      Assertions.assertFalse(lockInfo.isLegalHold(), "Legal hold should be false");
+      // Note: retainUntilDate comparison may vary slightly by provider, so we just check it exists
+      Assertions.assertNotNull(lockInfo.getRetainUntilDate(), "Retain until date should be set");
+
+    } finally {
+      safeDeleteBlobs(bucketClient, expectedKey);
+    }
   }
 }

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -31,6 +31,7 @@ import com.google.cloud.storage.multipartupload.model.CreateMultipartUploadReque
 import com.google.cloud.storage.multipartupload.model.CreateMultipartUploadResponse;
 import com.google.cloud.storage.multipartupload.model.ListPartsRequest;
 import com.google.cloud.storage.multipartupload.model.ListPartsResponse;
+import com.google.cloud.storage.multipartupload.model.ObjectLockMode;
 import com.google.cloud.storage.multipartupload.model.UploadPartRequest;
 import com.google.cloud.storage.multipartupload.model.UploadPartResponse;
 import com.google.cloud.storage.transfermanager.DownloadJob;
@@ -100,6 +101,9 @@ import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -120,12 +124,15 @@ import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** GCP implementation of BlobStore */
 @AutoService(AbstractBlobStore.class)
 public class GcpBlobStore extends AbstractBlobStore {
 
   private static final String OBJECT_KEY_DIRECTORY_PREFIX_REGEX = "^.*/";
+  private static final Logger logger = LoggerFactory.getLogger(GcpBlobStore.class);
 
   private final Storage storage;
   private final MultipartUploadClient multipartUploadClient;
@@ -567,6 +574,16 @@ public class GcpBlobStore extends AbstractBlobStore {
       createRequestBuilder.contentType(request.getContentType());
     }
 
+    if (request.getObjectLock() != null) {
+      if (request.getObjectLock().getMode() != null) {
+        createRequestBuilder.objectLockMode(toGcpObjectLockMode(request.getObjectLock().getMode()));
+      }
+      if (request.getObjectLock().getRetainUntilDate() != null) {
+        createRequestBuilder.objectLockRetainUntilDate(
+            toOffsetDateTimeUtc(request.getObjectLock().getRetainUntilDate()));
+      }
+    }
+
     CreateMultipartUploadResponse gcpMultipartUpload =
         multipartUploadClient.createMultipartUpload(createRequestBuilder.build());
 
@@ -579,6 +596,7 @@ public class GcpBlobStore extends AbstractBlobStore {
         .kmsKeyId(request.getKmsKeyId())
         .checksumEnabled(request.isChecksumEnabled())
         .checksumAlgorithm(request.getChecksumAlgorithm())
+        .objectLock(request.getObjectLock())
         .contentType(request.getContentType())
         .build();
   }
@@ -641,7 +659,37 @@ public class GcpBlobStore extends AbstractBlobStore {
     CompleteMultipartUploadResponse response =
         multipartUploadClient.completeMultipartUpload(completeRequest);
 
+    applyMultipartLegalHold(mpu);
+
     return new MultipartUploadResponse(response.etag(), response.crc32c());
+  }
+
+  private void applyMultipartLegalHold(MultipartUpload mpu) {
+    ObjectLockConfiguration lockConfig = mpu.getObjectLock();
+    if (lockConfig == null || !lockConfig.isLegalHold()) {
+      return;
+    }
+    try {
+      Blob blob = getRequiredBlob(transformer.toBlobId(bucket, mpu.getKey(), null));
+      BlobInfo.Builder builder = blob.toBuilder();
+      if (Boolean.TRUE.equals(lockConfig.getUseEventBasedHold())) {
+        builder.setEventBasedHold(true);
+        builder.setTemporaryHold(false);
+      } else {
+        builder.setTemporaryHold(true);
+        builder.setEventBasedHold(false);
+      }
+      storage.update(builder.build());
+    } catch (RuntimeException e) {
+      // Multipart completion has already succeeded, so legal hold application is best-effort.
+      logger.warn(
+          "Multipart upload completed but legal hold application failed."
+              + " bucket={}, key={}, uploadId={}",
+          bucket,
+          mpu.getKey(),
+          mpu.getId(),
+          e);
+    }
   }
 
   @Override
@@ -1085,7 +1133,7 @@ public class GcpBlobStore extends AbstractBlobStore {
     }
 
     RetentionMode mode = null;
-    java.time.Instant retainUntilDate = null;
+    Instant retainUntilDate = null;
 
     if (hasRetention) {
       // Map provider retention mode to SDK retention mode
@@ -1119,7 +1167,7 @@ public class GcpBlobStore extends AbstractBlobStore {
    */
   @Override
   public void updateObjectRetention(
-      String key, String versionId, java.time.Instant retainUntilDate) {
+      String key, String versionId, Instant retainUntilDate) {
     Blob blob = getRequiredBlob(transformer.toBlobId(bucket, key, versionId));
 
     Retention currentRetention = blob.getRetention();
@@ -1132,7 +1180,7 @@ public class GcpBlobStore extends AbstractBlobStore {
 
     // Check if trying to shorten retention (not allowed for LOCKED/COMPLIANCE mode)
     if (currentMode == Retention.Mode.LOCKED) {
-      java.time.Instant currentRetainUntil =
+      Instant currentRetainUntil =
           currentRetention.getRetainUntilTime() != null
               ? currentRetention.getRetainUntilTime().toInstant()
               : null;
@@ -1148,7 +1196,7 @@ public class GcpBlobStore extends AbstractBlobStore {
     Retention updatedRetention =
         currentRetention.toBuilder()
             .setRetainUntilTime(
-                java.time.OffsetDateTime.ofInstant(retainUntilDate, java.time.ZoneOffset.UTC))
+                toOffsetDateTimeUtc(retainUntilDate))
             .build();
 
     BlobInfo updatedBlobInfo =
@@ -1156,7 +1204,7 @@ public class GcpBlobStore extends AbstractBlobStore {
 
     // For GOVERNANCE (UNLOCKED) mode, use bypass header if shortening retention
     if (currentMode == Retention.Mode.UNLOCKED) {
-      java.time.Instant currentRetainUntil =
+      Instant currentRetainUntil =
           currentRetention.getRetainUntilTime() != null
               ? currentRetention.getRetainUntilTime().toInstant()
               : null;
@@ -1260,6 +1308,21 @@ public class GcpBlobStore extends AbstractBlobStore {
     }
 
     storage.update(builder.build());
+  }
+
+  private static OffsetDateTime toOffsetDateTimeUtc(Instant instant) {
+    return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+  }
+
+  private static ObjectLockMode toGcpObjectLockMode(RetentionMode mode) {
+    switch (mode) {
+      case COMPLIANCE:
+        return ObjectLockMode.COMPLIANCE;
+      case GOVERNANCE:
+        return ObjectLockMode.GOVERNANCE;
+      default:
+        throw new InvalidArgumentException("Unsupported retention mode: " + mode);
+    }
   }
 
   @Override

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpTransformer.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpTransformer.java
@@ -285,7 +285,7 @@ public class GcpTransformer {
     }
 
     return toBlobInfo(
-        request.getKey(), metadata, null, null, null, request.getContentType());
+        request.getKey(), metadata, null, null, request.getObjectLock(), request.getContentType());
   }
 
   public Storage.BlobListOption[] toBlobListOptions(ListBlobsPageRequest request) {

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreIT.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreIT.java
@@ -198,6 +198,11 @@ public class GcpBlobStoreIT extends AbstractBlobStoreIT {
     }
 
     @Override
+    public boolean isObjectLockSupported() {
+      return true;
+    }
+
+    @Override
     public List<String> getWiremockExtensions() {
       return List.of(MultipartBoundaryTransformer.class.getName());
     }

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -1,6 +1,7 @@
 package com.salesforce.multicloudj.blob.gcp;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -49,6 +50,7 @@ import com.google.cloud.storage.multipartupload.model.CreateMultipartUploadReque
 import com.google.cloud.storage.multipartupload.model.CreateMultipartUploadResponse;
 import com.google.cloud.storage.multipartupload.model.ListPartsRequest;
 import com.google.cloud.storage.multipartupload.model.ListPartsResponse;
+import com.google.cloud.storage.multipartupload.model.ObjectLockMode;
 import com.google.cloud.storage.multipartupload.model.Part;
 import com.google.cloud.storage.multipartupload.model.UploadPartRequest;
 import com.google.cloud.storage.multipartupload.model.UploadPartResponse;
@@ -111,6 +113,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -3227,6 +3231,40 @@ class GcpBlobStoreTest {
   }
 
   @Test
+  void testDoInitiateMultipartUpload_WithObjectLock() {
+    Instant retainUntil = Instant.parse("2030-01-01T00:00:00Z");
+    ObjectLockConfiguration objectLock =
+        ObjectLockConfiguration.builder()
+            .mode(RetentionMode.GOVERNANCE)
+            .retainUntilDate(retainUntil)
+            .legalHold(false)
+            .build();
+
+    MultipartUploadRequest request =
+        new MultipartUploadRequest.Builder().withKey(TEST_KEY).withObjectLock(objectLock).build();
+
+    CreateMultipartUploadResponse mockGcpResponse =
+        CreateMultipartUploadResponse.builder().uploadId("test-upload-id-object-lock").build();
+    when(mpuClient.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+        .thenReturn(mockGcpResponse);
+
+    MultipartUpload result = gcpBlobStore.doInitiateMultipartUpload(request);
+
+    assertNotNull(result);
+    assertEquals("test-upload-id-object-lock", result.getId());
+
+    ArgumentCaptor<CreateMultipartUploadRequest> captor =
+        ArgumentCaptor.forClass(CreateMultipartUploadRequest.class);
+    verify(mpuClient).createMultipartUpload(captor.capture());
+
+    CreateMultipartUploadRequest capturedRequest = captor.getValue();
+    assertEquals(ObjectLockMode.GOVERNANCE, capturedRequest.objectLockMode());
+    assertEquals(
+        OffsetDateTime.ofInstant(retainUntil, ZoneOffset.UTC),
+        capturedRequest.objectLockRetainUntilDate());
+  }
+
+  @Test
   void testDoUploadMultipartPart_Success() throws IOException {
     // Given
     MultipartUpload mpu =
@@ -3614,6 +3652,152 @@ class GcpBlobStoreTest {
     assertTrue(result.isChecksumEnabled());
     assertEquals(
         ChecksumMethod.CRC32C, result.getChecksumAlgorithm());
+  }
+
+  @Test
+  void testDoInitiateMultipartUpload_WithObjectLockConfiguration() {
+    // Given
+    Instant retainUntil = Instant.parse("2100-01-01T00:00:00Z");
+    ObjectLockConfiguration objectLock =
+        ObjectLockConfiguration.builder()
+            .mode(RetentionMode.GOVERNANCE)
+            .retainUntilDate(retainUntil)
+            .legalHold(true)
+            .useEventBasedHold(true)
+            .build();
+    MultipartUploadRequest request =
+        new MultipartUploadRequest.Builder().withKey(TEST_KEY).withObjectLock(objectLock).build();
+
+    CreateMultipartUploadResponse mockGcpResponse =
+        CreateMultipartUploadResponse.builder().uploadId("test-upload-id").build();
+    when(mpuClient.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+        .thenReturn(mockGcpResponse);
+
+    // When
+    MultipartUpload result = gcpBlobStore.doInitiateMultipartUpload(request);
+
+    // Then
+    assertEquals(objectLock, result.getObjectLock());
+
+    ArgumentCaptor<CreateMultipartUploadRequest> captor =
+        ArgumentCaptor.forClass(CreateMultipartUploadRequest.class);
+    verify(mpuClient).createMultipartUpload(captor.capture());
+    CreateMultipartUploadRequest capturedRequest = captor.getValue();
+    assertEquals(ObjectLockMode.GOVERNANCE, capturedRequest.objectLockMode());
+    assertEquals(
+        OffsetDateTime.ofInstant(retainUntil, ZoneOffset.UTC),
+        capturedRequest.objectLockRetainUntilDate());
+  }
+
+  @Test
+  void testDoCompleteMultipartUpload_AppliesEventBasedLegalHold() {
+    // Given
+    ObjectLockConfiguration objectLock =
+        ObjectLockConfiguration.builder().legalHold(true).useEventBasedHold(true).build();
+    MultipartUpload mpu =
+        MultipartUpload.builder()
+            .bucket(TEST_BUCKET)
+            .key(TEST_KEY)
+            .id("test-upload-id")
+            .objectLock(objectLock)
+            .build();
+    List<com.salesforce.multicloudj.blob.driver.UploadPartResponse> parts =
+        List.of(new com.salesforce.multicloudj.blob.driver.UploadPartResponse(1, "etag-1", 1024L));
+
+    CompleteMultipartUploadResponse mockGcpResponse =
+        CompleteMultipartUploadResponse.builder().etag("complete-etag").build();
+    when(mpuClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+        .thenReturn(mockGcpResponse);
+
+    Blob blob = mock(Blob.class);
+    Blob.Builder blobBuilder = mock(Blob.Builder.class);
+    Blob updatedBlobInfo = mock(Blob.class);
+    when(mockTransformer.toBlobId(TEST_BUCKET, TEST_KEY, null)).thenReturn(mockBlobId);
+    when(mockStorage.get(mockBlobId)).thenReturn(blob);
+    when(blob.toBuilder()).thenReturn(blobBuilder);
+    when(blobBuilder.setEventBasedHold(true)).thenReturn(blobBuilder);
+    when(blobBuilder.setTemporaryHold(false)).thenReturn(blobBuilder);
+    when(blobBuilder.build()).thenReturn(updatedBlobInfo);
+    when(mockStorage.update(updatedBlobInfo)).thenReturn(updatedBlobInfo);
+
+    // When
+    gcpBlobStore.doCompleteMultipartUpload(mpu, parts);
+
+    // Then
+    verify(blobBuilder).setEventBasedHold(true);
+    verify(blobBuilder).setTemporaryHold(false);
+    verify(mockStorage).update(updatedBlobInfo);
+  }
+
+  @Test
+  void testDoCompleteMultipartUpload_AppliesTemporaryLegalHoldByDefault() {
+    // Given
+    ObjectLockConfiguration objectLock =
+        ObjectLockConfiguration.builder().legalHold(true).useEventBasedHold(null).build();
+    MultipartUpload mpu =
+        MultipartUpload.builder()
+            .bucket(TEST_BUCKET)
+            .key(TEST_KEY)
+            .id("test-upload-id")
+            .objectLock(objectLock)
+            .build();
+    List<com.salesforce.multicloudj.blob.driver.UploadPartResponse> parts =
+        List.of(new com.salesforce.multicloudj.blob.driver.UploadPartResponse(1, "etag-1", 1024L));
+
+    CompleteMultipartUploadResponse mockGcpResponse =
+        CompleteMultipartUploadResponse.builder().etag("complete-etag").build();
+    when(mpuClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+        .thenReturn(mockGcpResponse);
+
+    Blob blob = mock(Blob.class);
+    Blob.Builder blobBuilder = mock(Blob.Builder.class);
+    Blob updatedBlobInfo = mock(Blob.class);
+    when(mockTransformer.toBlobId(TEST_BUCKET, TEST_KEY, null)).thenReturn(mockBlobId);
+    when(mockStorage.get(mockBlobId)).thenReturn(blob);
+    when(blob.toBuilder()).thenReturn(blobBuilder);
+    when(blobBuilder.setTemporaryHold(true)).thenReturn(blobBuilder);
+    when(blobBuilder.setEventBasedHold(false)).thenReturn(blobBuilder);
+    when(blobBuilder.build()).thenReturn(updatedBlobInfo);
+    when(mockStorage.update(updatedBlobInfo)).thenReturn(updatedBlobInfo);
+
+    // When
+    gcpBlobStore.doCompleteMultipartUpload(mpu, parts);
+
+    // Then
+    verify(blobBuilder).setTemporaryHold(true);
+    verify(blobBuilder).setEventBasedHold(false);
+    verify(mockStorage).update(updatedBlobInfo);
+  }
+
+  @Test
+  void testDoCompleteMultipartUpload_LegalHoldFailureDoesNotFailCompletion() {
+    ObjectLockConfiguration objectLock =
+        ObjectLockConfiguration.builder().legalHold(true).useEventBasedHold(true).build();
+    MultipartUpload mpu =
+        MultipartUpload.builder()
+            .bucket(TEST_BUCKET)
+            .key(TEST_KEY)
+            .id("test-upload-id")
+            .objectLock(objectLock)
+            .build();
+    List<com.salesforce.multicloudj.blob.driver.UploadPartResponse> parts =
+        List.of(new com.salesforce.multicloudj.blob.driver.UploadPartResponse(1, "etag-1", 1024L));
+
+    CompleteMultipartUploadResponse mockGcpResponse =
+        CompleteMultipartUploadResponse.builder().etag("complete-etag").build();
+    when(mpuClient.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+        .thenReturn(mockGcpResponse);
+
+    Blob blob = mock(Blob.class);
+    Blob.Builder blobBuilder = mock(Blob.Builder.class);
+    when(mockTransformer.toBlobId(TEST_BUCKET, TEST_KEY, null)).thenReturn(mockBlobId);
+    when(mockStorage.get(mockBlobId)).thenReturn(blob);
+    when(blob.toBuilder()).thenReturn(blobBuilder);
+    when(blobBuilder.setEventBasedHold(true)).thenReturn(blobBuilder);
+    when(blobBuilder.setTemporaryHold(false)).thenReturn(blobBuilder);
+    when(blobBuilder.build()).thenThrow(new RuntimeException("update failed"));
+
+    assertDoesNotThrow(() -> gcpBlobStore.doCompleteMultipartUpload(mpu, parts));
   }
 
   @Test

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpTransformerTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpTransformerTest.java
@@ -13,6 +13,7 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BlobInfo.Retention;
 import com.google.cloud.storage.Storage;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
@@ -40,6 +41,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -962,6 +964,36 @@ class GcpTransformerTest {
   }
 
   @Test
+  public void testToBlobInfo_multipartUploadRequestWithObjectLock() {
+    Instant retainUntil = Instant.parse("2026-12-31T23:59:59Z");
+    ObjectLockConfiguration objectLock =
+        ObjectLockConfiguration.builder()
+            .mode(RetentionMode.COMPLIANCE)
+            .retainUntilDate(retainUntil)
+            .legalHold(true)
+            .useEventBasedHold(true)
+            .build();
+
+    MultipartUploadRequest request =
+        new MultipartUploadRequest.Builder().withKey(TEST_KEY).withObjectLock(objectLock).build();
+
+    BlobInfo blobInfo = transformer.toBlobInfo(request);
+
+    assertEquals(TEST_BUCKET, blobInfo.getBucket());
+    assertEquals(TEST_KEY, blobInfo.getName());
+    // Verify object lock - retention mode
+    assertNotNull(blobInfo.getRetention());
+    assertEquals(Retention.Mode.LOCKED, blobInfo.getRetention().getMode());
+    assertEquals(
+        OffsetDateTime.ofInstant(retainUntil, ZoneOffset.UTC),
+        blobInfo.getRetention().getRetainUntilTime());
+    // Verify event-based hold is set (not temporary hold)
+    assertTrue(blobInfo.getEventBasedHold());
+    // Temporary hold should not be set
+    assertNull(blobInfo.getTemporaryHold());
+  }
+
+  @Test
   public void testToBlobInfo_uploadRequestWithContentType() {
     UploadRequest request =
         UploadRequest.builder()
@@ -987,6 +1019,44 @@ class GcpTransformerTest {
     assertEquals(TEST_BUCKET, blobInfo.getBucket());
     assertEquals(TEST_KEY, blobInfo.getName());
     assertEquals("application/x-directory", blobInfo.getContentType());
+  }
+
+  @Test
+  public void testToBlobInfo_MultipartUploadRequestWithObjectLockEventBasedHold() {
+    ObjectLockConfiguration lockConfig =
+        ObjectLockConfiguration.builder().legalHold(true).useEventBasedHold(true).build();
+
+    MultipartUploadRequest request =
+        new MultipartUploadRequest.Builder().withKey(TEST_KEY).withObjectLock(lockConfig).build();
+
+    BlobInfo blobInfo = transformer.toBlobInfo(request);
+
+    assertEquals(TEST_BUCKET, blobInfo.getBucket());
+    assertEquals(TEST_KEY, blobInfo.getName());
+    Boolean tempHold = getTemporaryHold(blobInfo);
+    Boolean eventHold = getEventBasedHold(blobInfo);
+    assertTrue(tempHold == null || !tempHold, "Temporary hold should be false or null");
+    assertTrue(eventHold != null && eventHold, "Event-based hold should be set to true");
+  }
+
+  @Test
+  public void testToBlobInfo_MultipartUploadRequestWithObjectLockTemporaryHoldDefault() {
+    ObjectLockConfiguration lockConfig =
+        ObjectLockConfiguration.builder().legalHold(true).useEventBasedHold(null).build();
+
+    MultipartUploadRequest request =
+        new MultipartUploadRequest.Builder().withKey(TEST_KEY).withObjectLock(lockConfig).build();
+
+    BlobInfo blobInfo = transformer.toBlobInfo(request);
+
+    assertEquals(TEST_BUCKET, blobInfo.getBucket());
+    assertEquals(TEST_KEY, blobInfo.getName());
+    Boolean tempHold = getTemporaryHold(blobInfo);
+    Boolean eventHold = getEventBasedHold(blobInfo);
+    assertTrue(
+        tempHold != null && tempHold,
+        "Temporary hold should be set to true (default when useEventBasedHold is null)");
+    assertTrue(eventHold == null || !eventHold, "Event-based hold should be false or null");
   }
 
   @Test

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testgetobjectlock_afteruploadwithretentiongovernance-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testgetobjectlock_afteruploadwithretentiongovernance-post-5.json
@@ -5,7 +5,7 @@
     "url" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/retention-governance&uploadType=resumable",
     "method" : "POST",
     "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/retention-governance\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2026-03-11T15:47:28.252Z\"},\"temporaryHold\":false}",
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"name\":\"conformance-tests/objectlock/retention-governance\",\"retention\":{\"mode\":\"Unlocked\"},\"temporaryHold\":false}",
       "ignoreArrayOrder" : true,
       "ignoreExtraElements" : true
     } ]

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "86971959-7f60-4bb1-9663-60247de517ef",
+  "name" : "GcpBlobStoreIT_testMultipartUpload_withObjectLock-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fmultipart-withObjectLock",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEjNtGdKwxAMWadOyxvdlzF1LIfEDrnKf0n4Xee_hSjSy2AEeLE8UgqaeUbtqzQrtiyL",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 05 May 2026 19:58:44 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "86971959-7f60-4bb1-9663-60247de517ef",
+  "persistent" : true,
+  "insertionIndex" : 1251
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-get-1.json
@@ -1,0 +1,44 @@
+{
+  "id" : "a2d97cc9-2b9e-4e5b-9ce8-d498bf805418",
+  "name" : "GcpBlobStoreIT_testMultipartUpload_withObjectLock-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEgJ-q8lwDEhOmFNmC85Ez1ipS7jcRyZaLa-EXl_i_5JzrEqrf5nuvlC2iMQFTIWio4w",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 05 May 2026 19:58:44 GMT",
+      "Date" : "Tue, 05 May 2026 19:58:44 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "a2d97cc9-2b9e-4e5b-9ce8-d498bf805418",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-2",
+  "insertionIndex" : 1252
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-get-2.json
@@ -1,0 +1,38 @@
+{
+  "id" : "81b425f2-96b8-4a76-8726-72f308b7a85e",
+  "name" : "GcpBlobStoreIT_testMultipartUpload_withObjectLock-GET-2",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fmultipart-withObjectLock",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/multipart-withObjectLock/1778011123186245\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fmultipart-withObjectLock\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fmultipart-withObjectLock?generation=1778011123186245&alt=media\",\n  \"name\": \"conformance-tests/multipart-withObjectLock\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778011123186245\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/x-www-form-urlencoded\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"10485760\",\n  \"crc32c\": \"jaLPjA==\",\n  \"etag\": \"CMX0ncv3opQDEAE=\",\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-05T19:58:43.301Z\",\n  \"updated\": \"2026-05-05T19:58:43.301Z\",\n  \"timeStorageClassUpdated\": \"2026-05-05T19:58:43.301Z\",\n  \"timeFinalized\": \"2026-05-05T19:58:43.301Z\",\n  \"metadata\": {\n    \"test-key\": \"test-value\"\n  }\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CMX0ncv3opQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEg7mTBHg4BAkVCPm4a7hSX74VU1sgAl4rl57HwYC7UKRKWSmzPaV8UitgRGnXR3nt-T",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 05 May 2026 19:58:43 GMT",
+      "Date" : "Tue, 05 May 2026 19:58:43 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "81b425f2-96b8-4a76-8726-72f308b7a85e",
+  "persistent" : true,
+  "insertionIndex" : 1253
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-get-3.json
@@ -1,0 +1,45 @@
+{
+  "id" : "6d91789a-edd6-4919-b7e8-88fdbfffa128",
+  "name" : "GcpBlobStoreIT_testMultipartUpload_withObjectLock-GET-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEiL4GK-JxiB0tjbed2MeiH3dGPLGWotR3Pzu8qU304W1YwDMsvdBcBJxkrgG1aTO6YG",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 05 May 2026 19:57:55 GMT",
+      "Date" : "Tue, 05 May 2026 19:57:55 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "6d91789a-edd6-4919-b7e8-88fdbfffa128",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-2",
+  "insertionIndex" : 1254
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-get-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-get-7.json
@@ -1,0 +1,45 @@
+{
+  "id" : "7ec030a5-5e1e-4259-8756-e2eca6cfa747",
+  "name" : "GcpBlobStoreIT_testMultipartUpload_withObjectLock-GET-7",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEhr4z922d_5i80L7zBP46tNduj45d2Y4vODIaZwQAiE9WaUFmZkz34EFAcc49XMVxu0",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 05 May 2026 19:58:36 GMT",
+      "Date" : "Tue, 05 May 2026 19:58:36 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "7ec030a5-5e1e-4259-8756-e2eca6cfa747",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-2",
+  "insertionIndex" : 1258
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-post-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-post-3.json
@@ -1,0 +1,45 @@
+{
+  "id" : "1e942be4-7013-4212-b72d-28f5dac276bd",
+  "name" : "GcpBlobStoreIT_testMultipartUpload_withObjectLock-POST-3",
+  "request" : {
+    "urlPath" : "/substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests%2Fmultipart-withObjectLock",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "ABPnzm7S7N3VT8b2HEf4jbaPbmEcgGmdOwOUE9zZ213gekN38TLGeqPByAqENMfNGGFlYkk"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>\"2b5c91ad399409ec9b409b66f5bb00fb\"</ETag></Part><Part><PartNumber>2</PartNumber><ETag>\"267c038cc2ec32ffd0ee2512ff5da5a5\"</ETag></Part></CompleteMultipartUpload>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version='1.0' encoding='UTF-8'?><CompleteMultipartUploadResult xmlns='http://s3.amazonaws.com/doc/2006-03-01/'><Location>http://storage.googleapis.com/substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/multipart-withObjectLock</Location><Bucket>substrate-sdk-gcp-poc1-test-bucket-versioned</Bucket><Key>conformance-tests/multipart-withObjectLock</Key><ETag>\"63a814bc1f352d8149b1dd9f3747e89e-2\"</ETag></CompleteMultipartUploadResult>",
+    "headers" : {
+      "x-goog-stored-content-length" : "10485760",
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "x-goog-metageneration" : "1",
+      "Pragma" : "no-cache",
+      "Date" : "Tue, 05 May 2026 19:58:43 GMT",
+      "x-goog-hash" : "crc32c=jaLPjA==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEju-7BQL0fURErv13mrWFytjbIlptTZ--s8gQdPP3gzq7wQbnFHyAu-bLKLEkQWWgMI",
+      "Vary" : "Origin",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "x-goog-generation" : "1778011123186245",
+      "Content-Type" : "text/html; charset=UTF-8"
+    }
+  },
+  "uuid" : "1e942be4-7013-4212-b72d-28f5dac276bd",
+  "persistent" : true,
+  "insertionIndex" : 1254
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-post-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-post-6.json
@@ -1,0 +1,38 @@
+{
+  "id" : "b904fcb4-3626-40ad-9038-dea2653d2564",
+  "name" : "GcpBlobStoreIT_testMultipartUpload_withObjectLock-POST-6",
+  "request" : {
+    "urlPath" : "/substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests%2Fmultipart-withObjectLock",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version='1.0' encoding='UTF-8'?><InitiateMultipartUploadResult xmlns='http://s3.amazonaws.com/doc/2006-03-01/'><Bucket>substrate-sdk-gcp-poc1-test-bucket-versioned</Bucket><Key>conformance-tests/multipart-withObjectLock</Key><UploadId>ABPnzm7S7N3VT8b2HEf4jbaPbmEcgGmdOwOUE9zZ213gekN38TLGeqPByAqENMfNGGFlYkk</UploadId></InitiateMultipartUploadResult>",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEjkft0XTdmz78sPcxmNapAVGBTl4LrjrUe5bmvAHXp8sTqbiNc9BVM70Cy9GvpeaA9r",
+      "Vary" : "Origin",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Pragma" : "no-cache",
+      "Date" : "Tue, 05 May 2026 19:58:37 GMT",
+      "Content-Type" : "text/html; charset=UTF-8"
+    }
+  },
+  "uuid" : "b904fcb4-3626-40ad-9038-dea2653d2564",
+  "persistent" : true,
+  "insertionIndex" : 1257
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-put-4.json
@@ -1,0 +1,47 @@
+{
+  "id" : "5e6b9060-dbb8-4f54-9285-5f77a2f4c3a2",
+  "name" : "GcpBlobStoreIT_testMultipartUpload_withObjectLock-PUT-4",
+  "request" : {
+    "urlPath" : "/substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests%2Fmultipart-withObjectLock",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "ABPnzm7S7N3VT8b2HEf4jbaPbmEcgGmdOwOUE9zZ213gekN38TLGeqPByAqENMfNGGFlYkk"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "matches" : ".*"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "\"267c038cc2ec32ffd0ee2512ff5da5a5\"",
+      "X-GUploader-UploadID" : "AAVLpEhl0R1navD0wTDWyyyHzT6FrlgsFv22bHeu0AklyEnJAD_EcPrfW_dOig09a6hpWVoI",
+      "Vary" : "Origin",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Pragma" : "no-cache",
+      "Date" : "Tue, 05 May 2026 19:58:42 GMT",
+      "Content-Type" : "text/html; charset=UTF-8",
+      "x-goog-hash" : [ "crc32c=RCmziw==", "md5=JnwDjMLsMv/Q7iUS/12lpQ==" ]
+    }
+  },
+  "uuid" : "5e6b9060-dbb8-4f54-9285-5f77a2f4c3a2",
+  "persistent" : true,
+  "insertionIndex" : 1255
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-put-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testmultipartupload_withobjectlock-put-5.json
@@ -1,0 +1,47 @@
+{
+  "id" : "2fba8155-ac2c-411e-96ac-8f8707bf144a",
+  "name" : "GcpBlobStoreIT_testMultipartUpload_withObjectLock-PUT-5",
+  "request" : {
+    "urlPath" : "/substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests%2Fmultipart-withObjectLock",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "ABPnzm7S7N3VT8b2HEf4jbaPbmEcgGmdOwOUE9zZ213gekN38TLGeqPByAqENMfNGGFlYkk"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "matches" : ".*"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "\"2b5c91ad399409ec9b409b66f5bb00fb\"",
+      "X-GUploader-UploadID" : "AAVLpEgwythlrKQlxrgvWE4AsD6--t9zKkEjxHnOD8-juEHYhJMg6hy1yuPa3cRwx8ZlYmNA",
+      "Vary" : "Origin",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Pragma" : "no-cache",
+      "Date" : "Tue, 05 May 2026 19:58:40 GMT",
+      "Content-Type" : "text/html; charset=UTF-8",
+      "x-goog-hash" : [ "crc32c=OGE8Qg==", "md5=K1yRrTmUCeybQJtm9bsA+w==" ]
+    }
+  },
+  "uuid" : "2fba8155-ac2c-411e-96ac-8f8707bf144a",
+  "persistent" : true,
+  "insertionIndex" : 1256
+}

--- a/blob/blob-inmemory/src/test/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStoreIT.java
+++ b/blob/blob-inmemory/src/test/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStoreIT.java
@@ -83,7 +83,7 @@ public class InMemoryBlobStoreIT extends AbstractBlobStoreIT {
 
     @Override
     public boolean isObjectLockSupported() {
-      return true;
+      return false;
     }
 
     @Override


### PR DESCRIPTION
- Added object lock configuration to MultipartUploadRequest
- Implemented object lock handling in AWS and GCP transformers
- Added conformance test for multipart upload with object lock
- Created WireMock recordings for AWS and GCP
- Updated unit tests for transformer classes
- Simplified multipart test data for better recording readability

## Summary

< Provide a brief description of the changes in this PR >

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
