### PR TITLE
docstore: Update the documentation for docstore query

### DIFF
--- a/documentation/guides/docstore-guide.md
+++ b/documentation/guides/docstore-guide.md
@@ -236,6 +236,12 @@ Query query = client.query();
 
 (Depends on driver implementation.)
 
+### Known Gap: Sort Key Ordering (DynamoDB vs. Firestore)
+
+DynamoDB silently returns results ordered by the sort key; Firestore does not. For parity across substrates, explicitly call `.orderBy("<sortKeyField>", true)` on every query where SK ordering is expected. The SDK translates this into a Firestore `StructuredQuery.OrderBy`, producing identical ordering on both.
+
+See [Query.orderBy](https://github.com/salesforce/multicloudj/blob/261630c72727ea1f43133325a85222a3f10f50d0/docstore/docstore-client/src/main/java/com/salesforce/multicloudj/docstore/client/Query.java#L274) for details.
+
 ## Advanced Usage
 
 ### Action Lists

--- a/documentation/guides/docstore-guide.md
+++ b/documentation/guides/docstore-guide.md
@@ -240,8 +240,6 @@ Query query = client.query();
 
 DynamoDB silently returns results ordered by the sort key; Firestore does not. For parity across substrates, explicitly call `.orderBy("<sortKeyField>", true)` on every query where SK ordering is expected. The SDK translates this into a Firestore `StructuredQuery.OrderBy`, producing identical ordering on both.
 
-See [Query.orderBy](https://github.com/salesforce/multicloudj/blob/261630c72727ea1f43133325a85222a3f10f50d0/docstore/docstore-client/src/main/java/com/salesforce/multicloudj/docstore/client/Query.java#L274) for details.
-
 ## Advanced Usage
 
 ### Action Lists


### PR DESCRIPTION
## Summary

< Provide a brief description of the changes in this PR >

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
