### PR TITLE
blobstore : Add method to get the provider type of BucketClient

### DIFF
--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
@@ -56,6 +56,10 @@ public class BucketClient implements AutoCloseable {
     return blobStore.getBucket();
   }
 
+  public String getProviderId() {
+    return blobStore.getProviderId();
+  }
+
   /**
    * Uploads the Blob content to substrate-specific Blob storage. Note: Specifying the contentLength
    * in the UploadRequest can dramatically improve upload efficiency because the substrate SDKs do


### PR DESCRIPTION
## Summary

Add simple method to know the provider type of a blobstore client, after it is created.
We need this to know if different clients are compatible with each others