### PR TITLE
blobstore: support retention mode in updateObjectRetention for AWS & GCP

### DIFF
--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
@@ -19,7 +19,10 @@ import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
+import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
+import com.salesforce.multicloudj.blob.driver.ObjectRetentionRules;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -622,6 +625,58 @@ public class AwsBlobStore extends AbstractBlobStore {
 
     s3Client.putObjectRetention(
         transformer.toPutObjectRetentionRequest(key, versionId, currentMode, retainUntilDate));
+  }
+
+  /**
+   * Provider hook for {@link
+   * com.salesforce.multicloudj.blob.driver.BlobStore#updateObjectRetention(String, String,
+   * ObjectRetentionConfig)}.
+   *
+   * <p>Stateless validation has already run; this method enforces the state-dependent rules from
+   * {@link ObjectRetentionRules} (no-current-retention, mode-downgrade, shorten-with-bypass) so
+   * AWS surfaces the same {@code FailedPreconditionException} types and messages as GCP and the
+   * in-memory provider.
+   */
+  @Override
+  protected void doUpdateObjectRetention(
+      String key, String versionId, ObjectRetentionConfig config) {
+    GetObjectRetentionResponse currentRetentionResponse =
+        s3Client.getObjectRetention(transformer.toGetObjectRetentionRequest(key, versionId));
+
+    RetentionMode currentMode = null;
+    Instant currentRetainUntil = null;
+    if (currentRetentionResponse != null && currentRetentionResponse.retention() != null) {
+      currentMode = toMulticloudMode(currentRetentionResponse.retention().mode());
+      currentRetainUntil = currentRetentionResponse.retention().retainUntilDate();
+    }
+
+    RetentionMode resolvedMode =
+        ObjectRetentionRules.resolveAndValidate(currentMode, currentRetainUntil, config);
+
+    boolean bypass = Boolean.TRUE.equals(config.getBypassGovernanceRetention());
+    s3Client.putObjectRetention(
+        transformer.toPutObjectRetentionRequest(
+            key, versionId, toAwsRetentionMode(resolvedMode), config.getRetainUntilDate(), bypass));
+  }
+
+  /**
+   * Converts a MultiCloudJ {@link RetentionMode} to an AWS {@link ObjectLockRetentionMode}.
+   * Mapping: GOVERNANCE↔GOVERNANCE, COMPLIANCE↔COMPLIANCE.
+   */
+  private static ObjectLockRetentionMode toAwsRetentionMode(RetentionMode mode) {
+    return mode == RetentionMode.COMPLIANCE
+        ? ObjectLockRetentionMode.COMPLIANCE
+        : ObjectLockRetentionMode.GOVERNANCE;
+  }
+
+  /** Inverse of {@link #toAwsRetentionMode(RetentionMode)}. */
+  private static RetentionMode toMulticloudMode(ObjectLockRetentionMode mode) {
+    if (mode == null) {
+      return null;
+    }
+    return mode == ObjectLockRetentionMode.COMPLIANCE
+        ? RetentionMode.COMPLIANCE
+        : RetentionMode.GOVERNANCE;
   }
 
   /** Updates legal hold status on an object. */

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
@@ -640,14 +640,21 @@ public class AwsBlobStore extends AbstractBlobStore {
   @Override
   protected void doUpdateObjectRetention(
       String key, String versionId, ObjectRetentionConfig config) {
-    GetObjectRetentionResponse currentRetentionResponse =
-        s3Client.getObjectRetention(transformer.toGetObjectRetentionRequest(key, versionId));
-
     RetentionMode currentMode = null;
     Instant currentRetainUntil = null;
-    if (currentRetentionResponse != null && currentRetentionResponse.retention() != null) {
-      currentMode = toMulticloudMode(currentRetentionResponse.retention().mode());
-      currentRetainUntil = currentRetentionResponse.retention().retainUntilDate();
+    try {
+      GetObjectRetentionResponse currentRetentionResponse =
+          s3Client.getObjectRetention(transformer.toGetObjectRetentionRequest(key, versionId));
+      if (currentRetentionResponse != null && currentRetentionResponse.retention() != null) {
+        currentMode = toMulticloudMode(currentRetentionResponse.retention().mode());
+        currentRetainUntil = currentRetentionResponse.retention().retainUntilDate();
+      }
+    } catch (S3Exception e) {
+      if (e.statusCode() != 404) {
+        throw e;
+      }
+      // 404 means no retention configured — fall through with nulls so ObjectRetentionRules
+      // rejects the request with FailedPreconditionException.
     }
 
     RetentionMode resolvedMode =

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -936,13 +936,35 @@ public class AwsTransformer {
       String versionId,
       ObjectLockRetentionMode mode,
       Instant retainUntilDate) {
-    return PutObjectRetentionRequest.builder()
-        .bucket(getBucket())
-        .key(key)
-        .versionId(versionId)
-        .retention(
-            ObjectLockRetention.builder().mode(mode).retainUntilDate(retainUntilDate).build())
-        .build();
+    return toPutObjectRetentionRequest(key, versionId, mode, retainUntilDate, false);
+  }
+
+  /**
+   * Creates a {@link PutObjectRetentionRequest} for the new {@code
+   * updateObjectRetention(key, versionId, ObjectRetentionConfig)} overload.
+   *
+   * <p>The {@code bypassGovernanceRetention} flag is set on the request only when {@code true};
+   * AWS S3 ignores the flag on COMPLIANCE objects (per design §E.7), but client-side guards in
+   * {@link com.salesforce.multicloudj.blob.driver.ObjectRetentionRules} reject the disallowed
+   * combinations before reaching this transformer, so the request shape is always valid.
+   */
+  public PutObjectRetentionRequest toPutObjectRetentionRequest(
+      String key,
+      String versionId,
+      ObjectLockRetentionMode mode,
+      Instant retainUntilDate,
+      boolean bypassGovernanceRetention) {
+    PutObjectRetentionRequest.Builder builder =
+        PutObjectRetentionRequest.builder()
+            .bucket(getBucket())
+            .key(key)
+            .versionId(versionId)
+            .retention(
+                ObjectLockRetention.builder().mode(mode).retainUntilDate(retainUntilDate).build());
+    if (bypassGovernanceRetention) {
+      builder.bypassGovernanceRetention(true);
+    }
+    return builder.build();
   }
 
   /** Creates a PutObjectLegalHoldRequest for updating legal hold status */

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreTest.java
@@ -1999,4 +1999,183 @@ public class AwsBlobStoreTest {
     // Then
     verify(mockS3Client, times(1)).close();
   }
+
+  // ---- New overload: updateObjectRetention(String, String, ObjectRetentionConfig) ----
+
+  private GetObjectRetentionResponse currentRetention(
+      ObjectLockRetentionMode mode, Instant retainUntil) {
+    return GetObjectRetentionResponse.builder()
+        .retention(
+            ObjectLockRetention.builder().mode(mode).retainUntilDate(retainUntil).build())
+        .build();
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_governanceExtend_setsRetentionWithoutBypass() {
+    String key = "test-key";
+    Instant current = Instant.now().plusSeconds(3600);
+    Instant later = current.plusSeconds(3600);
+    when(mockS3Client.getObjectRetention(any(GetObjectRetentionRequest.class)))
+        .thenReturn(currentRetention(ObjectLockRetentionMode.GOVERNANCE, current));
+    when(mockS3Client.putObjectRetention(any(PutObjectRetentionRequest.class)))
+        .thenReturn(PutObjectRetentionResponse.builder().build());
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(later)
+            .build();
+
+    aws.updateObjectRetention(key, null, cfg);
+
+    ArgumentCaptor<PutObjectRetentionRequest> captor =
+        ArgumentCaptor.forClass(PutObjectRetentionRequest.class);
+    verify(mockS3Client).putObjectRetention(captor.capture());
+    PutObjectRetentionRequest sent = captor.getValue();
+    assertEquals(ObjectLockRetentionMode.GOVERNANCE, sent.retention().mode());
+    assertEquals(later, sent.retention().retainUntilDate());
+    org.junit.jupiter.api.Assertions.assertNull(sent.bypassGovernanceRetention());
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_governanceShortenWithBypass_setsBypassTrue() {
+    String key = "test-key";
+    Instant current = Instant.now().plusSeconds(7200);
+    Instant earlier = current.minusSeconds(3600);
+    when(mockS3Client.getObjectRetention(any(GetObjectRetentionRequest.class)))
+        .thenReturn(currentRetention(ObjectLockRetentionMode.GOVERNANCE, current));
+    when(mockS3Client.putObjectRetention(any(PutObjectRetentionRequest.class)))
+        .thenReturn(PutObjectRetentionResponse.builder().build());
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(earlier)
+            .bypassGovernanceRetention(Boolean.TRUE)
+            .build();
+
+    aws.updateObjectRetention(key, null, cfg);
+
+    ArgumentCaptor<PutObjectRetentionRequest> captor =
+        ArgumentCaptor.forClass(PutObjectRetentionRequest.class);
+    verify(mockS3Client).putObjectRetention(captor.capture());
+    assertEquals(Boolean.TRUE, captor.getValue().bypassGovernanceRetention());
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_governanceShortenNoBypass_throws() {
+    String key = "test-key";
+    Instant current = Instant.now().plusSeconds(7200);
+    Instant earlier = current.minusSeconds(3600);
+    when(mockS3Client.getObjectRetention(any(GetObjectRetentionRequest.class)))
+        .thenReturn(currentRetention(ObjectLockRetentionMode.GOVERNANCE, current));
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(earlier)
+            .build();
+
+    assertThrows(
+        FailedPreconditionException.class, () -> aws.updateObjectRetention(key, null, cfg));
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_complianceShortenEvenWithBypass_throws() {
+    String key = "test-key";
+    Instant current = Instant.now().plusSeconds(7200);
+    Instant earlier = current.minusSeconds(3600);
+    when(mockS3Client.getObjectRetention(any(GetObjectRetentionRequest.class)))
+        .thenReturn(currentRetention(ObjectLockRetentionMode.COMPLIANCE, current));
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.COMPLIANCE)
+            .retainUntilDate(earlier)
+            .bypassGovernanceRetention(Boolean.TRUE)
+            .build();
+
+    assertThrows(
+        FailedPreconditionException.class, () -> aws.updateObjectRetention(key, null, cfg));
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_modeDowngrade_throws() {
+    String key = "test-key";
+    Instant current = Instant.now().plusSeconds(3600);
+    Instant later = current.plusSeconds(3600);
+    when(mockS3Client.getObjectRetention(any(GetObjectRetentionRequest.class)))
+        .thenReturn(currentRetention(ObjectLockRetentionMode.COMPLIANCE, current));
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(later)
+            .build();
+
+    assertThrows(
+        FailedPreconditionException.class, () -> aws.updateObjectRetention(key, null, cfg));
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_modeUpgrade_withoutBypass_throws() {
+    // GOVERNANCE → COMPLIANCE upgrade requires bypassGovernanceRetention=true; rules helper
+    // rejects without it for uniform error reporting across providers.
+    String key = "test-key";
+    Instant current = Instant.now().plusSeconds(3600);
+    Instant later = current.plusSeconds(3600);
+    when(mockS3Client.getObjectRetention(any(GetObjectRetentionRequest.class)))
+        .thenReturn(currentRetention(ObjectLockRetentionMode.GOVERNANCE, current));
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.COMPLIANCE)
+            .retainUntilDate(later)
+            .build();
+
+    assertThrows(
+        FailedPreconditionException.class, () -> aws.updateObjectRetention(key, null, cfg));
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_modeUpgrade_withBypass_setsBypassTrue() {
+    String key = "test-key";
+    Instant current = Instant.now().plusSeconds(3600);
+    Instant later = current.plusSeconds(3600);
+    when(mockS3Client.getObjectRetention(any(GetObjectRetentionRequest.class)))
+        .thenReturn(currentRetention(ObjectLockRetentionMode.GOVERNANCE, current));
+    when(mockS3Client.putObjectRetention(any(PutObjectRetentionRequest.class)))
+        .thenReturn(PutObjectRetentionResponse.builder().build());
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.COMPLIANCE)
+            .retainUntilDate(later)
+            .bypassGovernanceRetention(Boolean.TRUE)
+            .build();
+
+    aws.updateObjectRetention(key, null, cfg);
+
+    ArgumentCaptor<PutObjectRetentionRequest> captor =
+        ArgumentCaptor.forClass(PutObjectRetentionRequest.class);
+    verify(mockS3Client).putObjectRetention(captor.capture());
+    assertEquals(ObjectLockRetentionMode.COMPLIANCE, captor.getValue().retention().mode());
+    assertEquals(Boolean.TRUE, captor.getValue().bypassGovernanceRetention());
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_noCurrentRetention_throws() {
+    String key = "test-key";
+    when(mockS3Client.getObjectRetention(any(GetObjectRetentionRequest.class)))
+        .thenReturn(GetObjectRetentionResponse.builder().build());
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(Instant.now().plusSeconds(3600))
+            .build();
+
+    assertThrows(
+        FailedPreconditionException.class, () -> aws.updateObjectRetention(key, null, cfg));
+  }
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_extend_succeeds-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_extend_succeeds-delete-0.json
@@ -1,0 +1,22 @@
+{
+  "id" : "b6e0fae0-6ff5-4e78-89cd-9ed248d133f3",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/comp-extend",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-delete-marker" : "true",
+      "x-amz-request-id" : "QPND8CQJ43XTHW0K",
+      "x-amz-id-2" : "I9HQwNSwMNWxiH9ZKASZe6rzWE1YCv9kqQco6//OiJfl3ljXjSKb0/ogMnqNdN4jgZOT4czu5nU=",
+      "x-amz-version-id" : "tOZAxpXTNOGBaL2YiwHsW7yz6drXXuZC",
+      "Date" : "Mon, 11 May 2026 10:39:08 GMT"
+    }
+  },
+  "uuid" : "b6e0fae0-6ff5-4e78-89cd-9ed248d133f3",
+  "persistent" : true,
+  "insertionIndex" : 708
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-1.json
@@ -1,0 +1,33 @@
+{
+  "id" : "b2b4af43-85b5-4e44-8cb6-1047f897c72c",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-1",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/comp-extend",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legal-hold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPExlZ2FsSG9sZCB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48U3RhdHVzPk9GRjwvU3RhdHVzPjwvTGVnYWxIb2xkPg==",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "NQBW7PGAKJAVPM5P",
+      "x-amz-id-2" : "eobCa/MyZ9k7z5okT23Tv6kXaGdZKAyiAby0wERwXY3Xf6h0LCbsEkRjeFUDejvQ8NocCWPKQR8=",
+      "Date" : "Mon, 11 May 2026 10:39:07 GMT"
+    }
+  },
+  "uuid" : "b2b4af43-85b5-4e44-8cb6-1047f897c72c",
+  "persistent" : true,
+  "insertionIndex" : 709
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-2.json
@@ -1,0 +1,35 @@
+{
+  "id" : "3f1f4e75-e2dc-44aa-832a-d48067f20a4c",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-2",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/comp-extend",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5DT01QTElBTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wNi0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "CDZA7P6VF0CDP7YV",
+      "x-amz-id-2" : "qXMfK+knIk5oUSR2hyM4Am/bqGDTR8qXcGXuqkUjRt1c5UDfiGpzwKkdP047roJrWuF2tfhdIwE=",
+      "Date" : "Mon, 11 May 2026 10:39:06 GMT"
+    }
+  },
+  "uuid" : "3f1f4e75-e2dc-44aa-832a-d48067f20a4c",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-comp-extend",
+  "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-comp-extend-2",
+  "insertionIndex" : 710
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-4.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-4.json
@@ -1,0 +1,36 @@
+{
+  "id" : "3da632ee-e7e6-4a1b-a295-49d8699be3b9",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-4",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/comp-extend",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5DT01QTElBTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wMS0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "VJ9QNSPJWPVDETAM",
+      "x-amz-id-2" : "3s2hlH8pkd/DWQi9kylZfoKgMO23nJvg6xfCF2u+DCHQub5kJjBpOE5+MxlBl2N97Oje4wI9FYw=",
+      "Date" : "Mon, 11 May 2026 10:39:04 GMT"
+    }
+  },
+  "uuid" : "3da632ee-e7e6-4a1b-a295-49d8699be3b9",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-comp-extend",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-comp-extend-2",
+  "insertionIndex" : 712
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-3.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-3.json
@@ -1,0 +1,36 @@
+{
+  "id" : "45fd9986-9042-427f-83b6-a5f9f69bf467",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-PUT-3",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/comp-extend",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Retention xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Mode>COMPLIANCE</Mode><RetainUntilDate>2030-06-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "Q66V6D5EH9A0QJDX",
+      "x-amz-id-2" : "SafFPi3Z/4ThStDL/sTRbF5K/ANLvt4w0PqA4sYvrujiv4TeGLhVIYlBz2kw0eksCUlJj9eKSJA=",
+      "x-amz-version-id" : "R6tzBRKYQ0p9EZE.kwI97bj0T7I6G1io",
+      "Date" : "Mon, 11 May 2026 10:39:05 GMT"
+    }
+  },
+  "uuid" : "45fd9986-9042-427f-83b6-a5f9f69bf467",
+  "persistent" : true,
+  "insertionIndex" : 711
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-5.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-5.json
@@ -1,0 +1,28 @@
+{
+  "id" : "3a1147fa-2fa1-4039-8f11-cbd4d9fcfb8b",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-PUT-5",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/comp-extend",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9jb21wLWV4dGVuZA=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"bd63e27d8e1ffc7b2a7e82ab64a21fea\"",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "6T45Y8A7ZP7BRNGM",
+      "x-amz-checksum-crc32c" : "WUEpvQ==",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "o5kGUGaOmAyrANcvnPjx84sccw/+JOHcLHjQvKi5Eu0JGaSB7bfJkJfj53ucmYOvTZc+WYeSlPQ=",
+      "x-amz-version-id" : "R6tzBRKYQ0p9EZE.kwI97bj0T7I6G1io",
+      "Date" : "Mon, 11 May 2026 10:39:03 GMT"
+    }
+  },
+  "uuid" : "3a1147fa-2fa1-4039-8f11-cbd4d9fcfb8b",
+  "persistent" : true,
+  "insertionIndex" : 713
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-delete-0.json
@@ -1,0 +1,22 @@
+{
+  "id" : "123744bc-9526-46ea-98df-fdd7570d1b82",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/comp-shorten-bypass",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-delete-marker" : "true",
+      "x-amz-request-id" : "WSAYT92KF0DAW08Y",
+      "x-amz-id-2" : "geeSKAk7C8dhZIA+AOV3MVgULOYlTVcjpjffHdya5inczkvCuXoI9gHjd5wi1nrdCCc4f1fH8Fc=",
+      "x-amz-version-id" : "rUKXz9WNyGLkKZy3oBHnU3_DC4RTrmRD",
+      "Date" : "Mon, 11 May 2026 10:39:26 GMT"
+    }
+  },
+  "uuid" : "123744bc-9526-46ea-98df-fdd7570d1b82",
+  "persistent" : true,
+  "insertionIndex" : 734
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-1.json
@@ -1,0 +1,33 @@
+{
+  "id" : "52b167bd-2bdd-4145-bb21-c903abfc1eb6",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-GET-1",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/comp-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5DT01QTElBTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wNi0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "85GXV62KKD2J3FR5",
+      "x-amz-id-2" : "BzOXC2v9pIJtEEx6VufFbN6D5zvU3+J3ZjgOe5HoIQG5V7e6GgN5eZ+jW2ywxzcxkQheJn9uyjg=",
+      "Date" : "Mon, 11 May 2026 10:39:25 GMT"
+    }
+  },
+  "uuid" : "52b167bd-2bdd-4145-bb21-c903abfc1eb6",
+  "persistent" : true,
+  "insertionIndex" : 735
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-put-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-put-2.json
@@ -1,0 +1,28 @@
+{
+  "id" : "0b99fdf6-2332-4b31-9d12-cacd5d727a62",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-PUT-2",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/comp-shorten-bypass",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9jb21wLXNob3J0ZW4tYnlwYXNz"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"c22727d8b05a74bf68f7b644fa388e74\"",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "3DT6CASKHJZC5ZWB",
+      "x-amz-checksum-crc32c" : "fhORSA==",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "Q+CFNr1z7d+Rso3VI7PsM6DXsj3ErA1Yq5tO9NnZvmxBBt93KmLsUcuL+Dyu4Wwdn5Z/MUs06E0=",
+      "x-amz-version-id" : "dSeUPOiU46JFpM3CpqOuDc80FJUVlAoz",
+      "Date" : "Mon, 11 May 2026 10:39:24 GMT"
+    }
+  },
+  "uuid" : "0b99fdf6-2332-4b31-9d12-cacd5d727a62",
+  "persistent" : true,
+  "insertionIndex" : 736
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_extend_succeeds-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_extend_succeeds-delete-0.json
@@ -1,0 +1,22 @@
+{
+  "id" : "354c88b6-0237-4434-9325-3cfc561159ec",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-extend",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-delete-marker" : "true",
+      "x-amz-request-id" : "X5S2AWD9080E7V8J",
+      "x-amz-id-2" : "L73CC/76TklLxWLvTBTD7upaAoi70JPouvb/Xvg20n2IGoz4zl7OBfOVFSBiL22P8A8vskbJQp8=",
+      "x-amz-version-id" : "QVjM7KnUHKPiw1E5U4PewUuHJOKo4rmx",
+      "Date" : "Mon, 11 May 2026 10:39:14 GMT"
+    }
+  },
+  "uuid" : "354c88b6-0237-4434-9325-3cfc561159ec",
+  "persistent" : true,
+  "insertionIndex" : 715
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-1.json
@@ -1,0 +1,33 @@
+{
+  "id" : "4ba55767-4456-4bda-ad43-408b4c3d0110",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-1",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-extend",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legal-hold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPExlZ2FsSG9sZCB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48U3RhdHVzPk9GRjwvU3RhdHVzPjwvTGVnYWxIb2xkPg==",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "M0RWJWXZN33NFCWG",
+      "x-amz-id-2" : "GRahTR1CigCYaK+GMcwumTMhoLjzxWXFBr6dlyk9hOMqxzLbKwyCLS3ycYlCvr/ZB1oG60KHgRw=",
+      "Date" : "Mon, 11 May 2026 10:39:13 GMT"
+    }
+  },
+  "uuid" : "4ba55767-4456-4bda-ad43-408b4c3d0110",
+  "persistent" : true,
+  "insertionIndex" : 716
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-2.json
@@ -1,0 +1,35 @@
+{
+  "id" : "451d80ff-55fd-486a-9d32-f2b1d610f229",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-2",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-extend",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5HT1ZFUk5BTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wNi0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "D8AT09HT8FPS8NXX",
+      "x-amz-id-2" : "snLxb2S/N6iyNCZ84IuEyWKghSTSXNJnKejjJWMDbERRW/10g1ofFp/x3zBMmQGSBvx02i+CwdU=",
+      "Date" : "Mon, 11 May 2026 10:39:12 GMT"
+    }
+  },
+  "uuid" : "451d80ff-55fd-486a-9d32-f2b1d610f229",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-gov-extend",
+  "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-gov-extend-2",
+  "insertionIndex" : 717
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-4.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-4.json
@@ -1,0 +1,36 @@
+{
+  "id" : "fd079454-1e68-4095-9115-b33b8663b072",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-4",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-extend",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5HT1ZFUk5BTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wMS0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "29WY9JB05PK78EM0",
+      "x-amz-id-2" : "JKVAEJvZNMaSICJnFxYAbl8vtcQmgvP61DENohbzlydd+tBz2s8toQPt9JBVhYBFJWop83GxiSM=",
+      "Date" : "Mon, 11 May 2026 10:39:10 GMT"
+    }
+  },
+  "uuid" : "fd079454-1e68-4095-9115-b33b8663b072",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-gov-extend",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-gov-extend-2",
+  "insertionIndex" : 719
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-3.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-3.json
@@ -1,0 +1,36 @@
+{
+  "id" : "5160e732-434d-4b3f-91b3-704b1ff1cab6",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-PUT-3",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-extend",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Retention xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Mode>GOVERNANCE</Mode><RetainUntilDate>2030-06-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "26EDVAGPMKNFW135",
+      "x-amz-id-2" : "WBOJ8jTVMVEvZEaIQtCwgCuKVIkVOIyUaA4bfJIpINEf0VThqTcGTgBLD3qqjkJY2xnNc8j5PjE=",
+      "x-amz-version-id" : "zOAxfngirrUc2xM9DAH8jc3Z9f3AHAJ_",
+      "Date" : "Mon, 11 May 2026 10:39:11 GMT"
+    }
+  },
+  "uuid" : "5160e732-434d-4b3f-91b3-704b1ff1cab6",
+  "persistent" : true,
+  "insertionIndex" : 718
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-5.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-5.json
@@ -1,0 +1,28 @@
+{
+  "id" : "c63281bb-8552-49d7-b2bf-2d82f7671a53",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-PUT-5",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-extend",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9nb3YtZXh0ZW5k"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"21599c7f1b469ed1cffc796f3f269ca0\"",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "CG0HGGXWFQE1ENY6",
+      "x-amz-checksum-crc32c" : "IOzQuw==",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "S9h+U7QnNLfJjdttVMI0Pa9o/SR6D+l+o+nsL8FZklTgXoabY+PlsahmI6zDIKhGdMsfJoj1Tac=",
+      "x-amz-version-id" : "zOAxfngirrUc2xM9DAH8jc3Z9f3AHAJ_",
+      "Date" : "Mon, 11 May 2026 10:39:09 GMT"
+    }
+  },
+  "uuid" : "c63281bb-8552-49d7-b2bf-2d82f7671a53",
+  "persistent" : true,
+  "insertionIndex" : 720
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-delete-0.json
@@ -1,0 +1,22 @@
+{
+  "id" : "3373ad9b-5ebb-4151-89ea-bfc846c6630f",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-delete-marker" : "true",
+      "x-amz-request-id" : "3VJZZPD21QXQB1GV",
+      "x-amz-id-2" : "iMbMLdIdYMnDitzFFKnDJ2PeTXSR5rKC/NNzG9ovKCjZ3Njfcaof6JoVV/rSoN+yD+zCVhPW3ug=",
+      "x-amz-version-id" : "NNv7EFVAzMOqlTda3.r3t3g4Kq8TklFV",
+      "Date" : "Mon, 11 May 2026 10:38:59 GMT"
+    }
+  },
+  "uuid" : "3373ad9b-5ebb-4151-89ea-bfc846c6630f",
+  "persistent" : true,
+  "insertionIndex" : 697
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-1.json
@@ -1,0 +1,33 @@
+{
+  "id" : "95c5ee24-44bf-4bd1-92fb-d6bc1a4bbf61",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-1",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legal-hold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPExlZ2FsSG9sZCB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48U3RhdHVzPk9GRjwvU3RhdHVzPjwvTGVnYWxIb2xkPg==",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "3VJWWEDC9P1Y1J2C",
+      "x-amz-id-2" : "Xk98vpvciqyf8HC6LjF2d8K7f0jZSH1KytANPWB/b9T945vNXpUB+PSG/cxsMlukyAS/nh0xJuA=",
+      "Date" : "Mon, 11 May 2026 10:38:59 GMT"
+    }
+  },
+  "uuid" : "95c5ee24-44bf-4bd1-92fb-d6bc1a4bbf61",
+  "persistent" : true,
+  "insertionIndex" : 698
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-2.json
@@ -1,0 +1,35 @@
+{
+  "id" : "0c8dfc91-9c7f-4ad8-bda2-711f459ee1f7",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-2",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5HT1ZFUk5BTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wMi0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "JMCKCS2Q6FBPYNVM",
+      "x-amz-id-2" : "T9KF27R3LtNJ+tIRfcydLG/W4E91rNftlkrxrd3eHv4NAo+rFTFnUMKy5BLzjcWz4OQcntJX4Zk=",
+      "Date" : "Mon, 11 May 2026 10:38:58 GMT"
+    }
+  },
+  "uuid" : "0c8dfc91-9c7f-4ad8-bda2-711f459ee1f7",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-gov-shorten-bypass",
+  "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-gov-shorten-bypass-2",
+  "insertionIndex" : 699
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-4.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-4.json
@@ -1,0 +1,36 @@
+{
+  "id" : "3698c307-dc9f-43f2-959c-2ab25571fe62",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-4",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5HT1ZFUk5BTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wNi0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "G19HZZPB00CRQMV2",
+      "x-amz-id-2" : "EiFXiB+Lf/7Ar6eo9RV0JucHZgkfw+yfsEWpjlgShLZ3R/mmdJfWxj2lhblAycq5cSttLHnSHc4=",
+      "Date" : "Mon, 11 May 2026 10:38:56 GMT"
+    }
+  },
+  "uuid" : "3698c307-dc9f-43f2-959c-2ab25571fe62",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-gov-shorten-bypass",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-gov-shorten-bypass-2",
+  "insertionIndex" : 701
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-3.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-3.json
@@ -1,0 +1,36 @@
+{
+  "id" : "c205d217-ede2-4b52-8ef1-4281e06f3e72",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-PUT-3",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Retention xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Mode>GOVERNANCE</Mode><RetainUntilDate>2030-02-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "G19GBAF6NGZ1YGVQ",
+      "x-amz-id-2" : "cPeiyu0xZgLInIrSNGzgIOOZtjmBWSAjtfmZ5WQVytvkbMyFnKlEHsObaFhIA6UbCfhVSp320+8=",
+      "x-amz-version-id" : "XLzxOpagg_tm6xUD4Sqz2vgQCa2V1HrQ",
+      "Date" : "Mon, 11 May 2026 10:38:56 GMT"
+    }
+  },
+  "uuid" : "c205d217-ede2-4b52-8ef1-4281e06f3e72",
+  "persistent" : true,
+  "insertionIndex" : 700
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-5.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-5.json
@@ -1,0 +1,28 @@
+{
+  "id" : "979451f1-f668-46a5-a552-6a2a74c55cc8",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-PUT-5",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9nb3Ytc2hvcnRlbi1ieXBhc3M="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"f4ec33c5495a94d4e19658b957cf308d\"",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "SBJYS2E9N7VDPW9F",
+      "x-amz-checksum-crc32c" : "PxN3WA==",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "CsHhQRtC5e7cQ71JN+FHfDYNju+lPbj9Qs+UoyAEptswoOCIDTinKv5SWrPJM8ZhQjdlKls7+dw=",
+      "x-amz-version-id" : "XLzxOpagg_tm6xUD4Sqz2vgQCa2V1HrQ",
+      "Date" : "Mon, 11 May 2026 10:38:54 GMT"
+    }
+  },
+  "uuid" : "979451f1-f668-46a5-a552-6a2a74c55cc8",
+  "persistent" : true,
+  "insertionIndex" : 702
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-delete-0.json
@@ -1,0 +1,22 @@
+{
+  "id" : "402854d2-a575-4039-91fc-fbbbff83f051",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-shorten-no-bypass",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-delete-marker" : "true",
+      "x-amz-request-id" : "6T4EGMF15JB0EY64",
+      "x-amz-id-2" : "KwJf3akVnhDlLfcWFVHc/ZgLX5ZJWCH3K7e0FkPKznwMoybL+h1hADvipVFdjLmBYKHH/M2zSXs=",
+      "x-amz-version-id" : "eGMzum3YcE3fXMNS.9Llx711KqnHmMus",
+      "Date" : "Mon, 11 May 2026 10:39:03 GMT"
+    }
+  },
+  "uuid" : "402854d2-a575-4039-91fc-fbbbff83f051",
+  "persistent" : true,
+  "insertionIndex" : 704
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-1.json
@@ -1,0 +1,33 @@
+{
+  "id" : "ef72fb11-f5e1-4d92-8121-a4d052d463ff",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-GET-1",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-shorten-no-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5HT1ZFUk5BTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wNi0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "8PGSS1PN64FTGXHR",
+      "x-amz-id-2" : "Ajs3u+33INSmCkehL6b9RSs+L5iWTkAiniEMEWVo5767tEomIWqvKuiNatSHYZD07ebitgwUCJM=",
+      "Date" : "Mon, 11 May 2026 10:39:01 GMT"
+    }
+  },
+  "uuid" : "ef72fb11-f5e1-4d92-8121-a4d052d463ff",
+  "persistent" : true,
+  "insertionIndex" : 705
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-put-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-put-2.json
@@ -1,0 +1,28 @@
+{
+  "id" : "7a97fcc4-aa15-43f7-af6f-a757b97a0780",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-PUT-2",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/gov-shorten-no-bypass",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9nb3Ytc2hvcnRlbi1uby1ieXBhc3M="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"e5f3ceee6cccda95688019b1bd67cb85\"",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "R1M7BEJFYV2T0D9N",
+      "x-amz-checksum-crc32c" : "lIhFUQ==",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "zJUzDMje4K8R0QVYY8DaMyb23ZYUCRuf8jLmUG6LTnizk4/oIJdjjFSz8e+08EUkFhZ1zGlCOP4=",
+      "x-amz-version-id" : "f5_OSfMTZ33lp7Wz8_1osjdpT_75H1iL",
+      "Date" : "Mon, 11 May 2026 10:39:00 GMT"
+    }
+  },
+  "uuid" : "7a97fcc4-aa15-43f7-af6f-a757b97a0780",
+  "persistent" : true,
+  "insertionIndex" : 706
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-delete-0.json
@@ -1,0 +1,22 @@
+{
+  "id" : "48f3521b-3ce1-4573-bae4-be856d58a8c0",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-delete-marker" : "true",
+      "x-amz-request-id" : "0ABGSG3FNTH3TY9F",
+      "x-amz-id-2" : "QzD/QJHu1HLBmeee3YOaq1VTL2i4LOEgNfWLZNuEaLFKJ+ST/22ipf0Mm9tqGU2sIElj5UagWFM=",
+      "x-amz-version-id" : "EyMw8h3DjvZ_f15L4T9cwJ7AK7zXti4y",
+      "Date" : "Mon, 11 May 2026 10:39:20 GMT"
+    }
+  },
+  "uuid" : "48f3521b-3ce1-4573-bae4-be856d58a8c0",
+  "persistent" : true,
+  "insertionIndex" : 722
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-2.json
@@ -1,0 +1,33 @@
+{
+  "id" : "2148dd34-5874-41d0-8b7c-3e9a90a09e89",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-2",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legal-hold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPExlZ2FsSG9sZCB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48U3RhdHVzPk9OPC9TdGF0dXM+PC9MZWdhbEhvbGQ+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "7VMGMZZJQQYAJ5ZX",
+      "x-amz-id-2" : "vHN/522CWcNa3GZQYz9zypwf5LeUg6hJP/VXRUoWmHc5s5m5Gq6u7HfRXl5ZsRJ2e2N2cov+wFA=",
+      "Date" : "Mon, 11 May 2026 10:39:19 GMT"
+    }
+  },
+  "uuid" : "2148dd34-5874-41d0-8b7c-3e9a90a09e89",
+  "persistent" : true,
+  "insertionIndex" : 724
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-3.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-3.json
@@ -1,0 +1,35 @@
+{
+  "id" : "b485b749-3276-4e70-8063-182b61228b6d",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-3",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5HT1ZFUk5BTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wNi0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "X1ZBNY35DX1DTTRP",
+      "x-amz-id-2" : "wJqbvyGEqbbnzwIpGsLhDjuYbFKihqFgCtzqfhQVAKQNmgnPdJWEbhVWV1FSoHD58mkWy/rolA4=",
+      "Date" : "Mon, 11 May 2026 10:39:18 GMT"
+    }
+  },
+  "uuid" : "b485b749-3276-4e70-8063-182b61228b6d",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-legalhold-preserved",
+  "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-legalhold-preserved-2",
+  "insertionIndex" : 725
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-5.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-5.json
@@ -1,0 +1,36 @@
+{
+  "id" : "7ba9ef94-c606-45e3-bdac-d5e05601150f",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-5",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5HT1ZFUk5BTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wMS0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "A7QYJQAM5P5M2FSP",
+      "x-amz-id-2" : "hNPFoGgc198mhCYCbZdFmvGpYnhXWOla69OYb+hkPrF4Nrk5Gbxy/mlcPouOHDta+F54esNzSm8=",
+      "Date" : "Mon, 11 May 2026 10:39:16 GMT"
+    }
+  },
+  "uuid" : "7ba9ef94-c606-45e3-bdac-d5e05601150f",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-legalhold-preserved",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-legalhold-preserved-2",
+  "insertionIndex" : 727
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-1.json
@@ -1,0 +1,36 @@
+{
+  "id" : "4c300064-5cc8-4dca-89c9-a7062f95c916",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-PUT-1",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legal-hold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><LegalHold xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Status>OFF</Status></LegalHold>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "7VMY3CQPNNBBXGSV",
+      "x-amz-id-2" : "EAXDbMGYIUE8BoPn4kZ59qDjWHwvCAeUhP1PCgJpVlP0h+hw9+NxXhfaox7DsdaSzc16ywAbL0M=",
+      "x-amz-version-id" : "4lyEfkSQGjo_R3K6fyXVeOHVLHAyEAwP",
+      "Date" : "Mon, 11 May 2026 10:39:19 GMT"
+    }
+  },
+  "uuid" : "4c300064-5cc8-4dca-89c9-a7062f95c916",
+  "persistent" : true,
+  "insertionIndex" : 723
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-4.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-4.json
@@ -1,0 +1,36 @@
+{
+  "id" : "faf58ab9-a78d-41b2-a712-163cc48a39be",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-PUT-4",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Retention xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Mode>GOVERNANCE</Mode><RetainUntilDate>2030-06-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "C80E7DD4Z9518R3F",
+      "x-amz-id-2" : "qbsQXSfNzCXU1jTVp8gtbqh62fKvvF2V+IgVodLPcrRa9Mp5NNwWXLdM3CFRYSM6O7FOG7oeZtE=",
+      "x-amz-version-id" : "4lyEfkSQGjo_R3K6fyXVeOHVLHAyEAwP",
+      "Date" : "Mon, 11 May 2026 10:39:17 GMT"
+    }
+  },
+  "uuid" : "faf58ab9-a78d-41b2-a712-163cc48a39be",
+  "persistent" : true,
+  "insertionIndex" : 726
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-6.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-6.json
@@ -1,0 +1,28 @@
+{
+  "id" : "8a0a60c9-f9e5-43a5-9aba-dc00e44b8d1c",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-PUT-6",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "bGVnYWxob2xkLXByZXNlcnZlZA=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"f30ee07767065c9f9cc31d17bcd69508\"",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "MTT60ATZXDPXA38C",
+      "x-amz-checksum-crc32c" : "VXd1+w==",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "3WFJSjB/raTN+UrxU8SC9ueF9CiE086RLDBus8jnhJVUD+e0IE1sPlv/cgEyORU+01PCEoQ4U0Y=",
+      "x-amz-version-id" : "4lyEfkSQGjo_R3K6fyXVeOHVLHAyEAwP",
+      "Date" : "Mon, 11 May 2026 10:39:15 GMT"
+    }
+  },
+  "uuid" : "8a0a60c9-f9e5-43a5-9aba-dc00e44b8d1c",
+  "persistent" : true,
+  "insertionIndex" : 728
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-delete-0.json
@@ -1,0 +1,22 @@
+{
+  "id" : "0d9eb22e-b529-447b-b03e-c24fc494d802",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/mode-downgrade",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-delete-marker" : "true",
+      "x-amz-request-id" : "SBJMD9GFRBW9D3SM",
+      "x-amz-id-2" : "1tOijF1faGl0BHr4jI0KneE1C9NhhkJwYwdL11xkoYzUyk8KZ9nRhOxUUoHMhS3JM29VXo5d5wg=",
+      "x-amz-version-id" : "lxJw25Ixs1y6N_hrMjODe31sgR5Xbo1A",
+      "Date" : "Mon, 11 May 2026 10:38:54 GMT"
+    }
+  },
+  "uuid" : "0d9eb22e-b529-447b-b03e-c24fc494d802",
+  "persistent" : true,
+  "insertionIndex" : 692
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-1.json
@@ -1,0 +1,33 @@
+{
+  "id" : "2a49c4bd-fb89-42af-9e46-ff4425dbe085",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-GET-1",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/mode-downgrade",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5DT01QTElBTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wMS0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "HXSRRZCQHM2JXTGQ",
+      "x-amz-id-2" : "LV/ZQWynQ39TpF+5dZpazBHM9w/qkgATzgDOOJ6bRdKfGpE6OtOCTpfRQ2zLwOJ1RUXYkd8eB08=",
+      "Date" : "Mon, 11 May 2026 10:38:48 GMT"
+    }
+  },
+  "uuid" : "2a49c4bd-fb89-42af-9e46-ff4425dbe085",
+  "persistent" : true,
+  "insertionIndex" : 693
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-put-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-put-2.json
@@ -1,0 +1,28 @@
+{
+  "id" : "53affd2d-1075-4cb6-8631-f887c6d6b0aa",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-PUT-2",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/mode-downgrade",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9tb2RlLWRvd25ncmFkZQ=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"3bcda782607f16c89f0c4d3bd549a6d0\"",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "EYR1B7MJE8XVAG09",
+      "x-amz-checksum-crc32c" : "4Q5YlQ==",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "4cqSjSp5CchmDCP3Kl0XBsbtXX67MuzSpC2Wt95AToUDcV5vPpLnPrWSaRAVIXBsthcNaIsVesQ=",
+      "x-amz-version-id" : "6r2PQVIEEVggjBBKpwpEQsbT3LlI7zBM",
+      "Date" : "Mon, 11 May 2026 10:38:47 GMT"
+    }
+  },
+  "uuid" : "53affd2d-1075-4cb6-8631-f887c6d6b0aa",
+  "persistent" : true,
+  "insertionIndex" : 694
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-delete-0.json
@@ -1,0 +1,22 @@
+{
+  "id" : "7f6971e8-5df5-49d1-bed7-8aa941d885b5",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/mode-upgrade",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-delete-marker" : "true",
+      "x-amz-request-id" : "BK3SPHF3WD8AQ5H4",
+      "x-amz-id-2" : "GsUyDDdtZm4YnWPq8O0SU6cFAcL1sTNE/TSZONRTxlIdgqLsjiFV0GooeZDrLRaTOFWQ5khV3dg=",
+      "x-amz-version-id" : "5WCx12hw8sNhQQ0VIBbnA1uzgmmQqKH7",
+      "Date" : "Mon, 11 May 2026 10:38:46 GMT"
+    }
+  },
+  "uuid" : "7f6971e8-5df5-49d1-bed7-8aa941d885b5",
+  "persistent" : true,
+  "insertionIndex" : 685
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-1.json
@@ -1,0 +1,33 @@
+{
+  "id" : "ea83bf5c-c9e4-4faf-bb76-c6de746382a6",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-GET-1",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/mode-upgrade",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legal-hold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPExlZ2FsSG9sZCB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48U3RhdHVzPk9GRjwvU3RhdHVzPjwvTGVnYWxIb2xkPg==",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "MZ4KF276GM200KZK",
+      "x-amz-id-2" : "fomXgrBp5vMdeDnjDX20tMkm9jB0xVqfI3HiAEJIysYBfgkS2+LP87xHnAXaYq8AtWQ0Kzgo1NM=",
+      "Date" : "Mon, 11 May 2026 10:38:45 GMT"
+    }
+  },
+  "uuid" : "ea83bf5c-c9e4-4faf-bb76-c6de746382a6",
+  "persistent" : true,
+  "insertionIndex" : 686
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-2.json
@@ -1,0 +1,35 @@
+{
+  "id" : "2961552b-9c30-467b-9ca0-37417813645f",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-GET-2",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/mode-upgrade",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5DT01QTElBTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wNi0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "K9CZ06FDN6F978MM",
+      "x-amz-id-2" : "o4EnRBfY48XLGRJTXcvoaTPalv4nx+Vfr15czuEZM5bgD61FsJ6mY3dLMgVWypObkUysp9jWAwM=",
+      "Date" : "Mon, 11 May 2026 10:38:44 GMT"
+    }
+  },
+  "uuid" : "2961552b-9c30-467b-9ca0-37417813645f",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-mode-upgrade",
+  "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-mode-upgrade-2",
+  "insertionIndex" : 687
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-4.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-4.json
@@ -1,0 +1,36 @@
+{
+  "id" : "1d9c5be9-891c-4f7c-92bf-018e985bb7d8",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-GET-4",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/mode-upgrade",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5HT1ZFUk5BTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wMS0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "97HH7DQZPBJEVQ2H",
+      "x-amz-id-2" : "P/GruAxBDF24xyTEeyvifmKLFdy4soCzuQntqtAsz8fZ1xTQkc2/9usfFcrMUhpsQKInaV2aEA4=",
+      "Date" : "Mon, 11 May 2026 10:38:41 GMT"
+    }
+  },
+  "uuid" : "1d9c5be9-891c-4f7c-92bf-018e985bb7d8",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-mode-upgrade",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-objectlock-update-mode-upgrade-2",
+  "insertionIndex" : 689
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-put-3.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-put-3.json
@@ -1,0 +1,36 @@
+{
+  "id" : "a95b6162-3272-4b4f-ac45-fb847b9505f0",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-PUT-3",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/mode-upgrade",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Retention xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Mode>COMPLIANCE</Mode><RetainUntilDate>2030-06-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "CV3M9F70H3FKA40S",
+      "x-amz-id-2" : "vHOdGyIIG589ctXYVRoAU48VDUY8Fivw+XJAGtDQW6Pps+DX1AbxNAi7oUKZRtjND+bZSS/I46c=",
+      "x-amz-version-id" : "wecwb8MalD0NDhlLBRoYHTMkf2b61HWs",
+      "Date" : "Mon, 11 May 2026 10:38:43 GMT"
+    }
+  },
+  "uuid" : "a95b6162-3272-4b4f-ac45-fb847b9505f0",
+  "persistent" : true,
+  "insertionIndex" : 688
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-put-5.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-put-5.json
@@ -1,0 +1,28 @@
+{
+  "id" : "9ed2c62b-28b4-4e75-a0c4-9827d88f2ccc",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-PUT-5",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/mode-upgrade",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9tb2RlLXVwZ3JhZGU="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"30b8e4f8624a5876646c9676744d4579\"",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "Y3NP09S0T1W5PDDE",
+      "x-amz-checksum-crc32c" : "d5fzBw==",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "r/Ah/1rix1qB7w8UfB13zDDzOjhrAJd4qofB0qoqvBDbxphNFDoExKyH20ssHtxh006Cq8Xt+qI=",
+      "x-amz-version-id" : "wecwb8MalD0NDhlLBRoYHTMkf2b61HWs",
+      "Date" : "Mon, 11 May 2026 10:38:40 GMT"
+    }
+  },
+  "uuid" : "9ed2c62b-28b4-4e75-a0c4-9827d88f2ccc",
+  "persistent" : true,
+  "insertionIndex" : 690
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-delete-0.json
@@ -1,0 +1,22 @@
+{
+  "id" : "d3a74bcb-9de7-4f20-9da4-ff506597d226",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/mode-upgrade-no-bypass",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-delete-marker" : "true",
+      "x-amz-request-id" : "ZYYJ6RGC5F1A1TYZ",
+      "x-amz-id-2" : "rSPldaLrFZcmccF9OLMsIshayQYfu7GvSafS0oFJMs+gO2W+HzwBDkV91xmTrrjbet3pztlWUiI=",
+      "x-amz-version-id" : "Vku5KLH.zUnUqGI1zoy8sxSPSwBqNND_",
+      "Date" : "Mon, 11 May 2026 10:39:23 GMT"
+    }
+  },
+  "uuid" : "d3a74bcb-9de7-4f20-9da4-ff506597d226",
+  "persistent" : true,
+  "insertionIndex" : 730
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-1.json
@@ -1,0 +1,33 @@
+{
+  "id" : "85e49f66-6cd5-4b49-8cb0-08fccb9c8008",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-GET-1",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/mode-upgrade-no-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFJldGVudGlvbiB4bWxucz0iaHR0cDovL3MzLmFtYXpvbmF3cy5jb20vZG9jLzIwMDYtMDMtMDEvIj48TW9kZT5HT1ZFUk5BTkNFPC9Nb2RlPjxSZXRhaW5VbnRpbERhdGU+MjAzMC0wMS0wMVQwMDowMDowMC4wMDBaPC9SZXRhaW5VbnRpbERhdGU+PC9SZXRlbnRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "M02YQNGQ8X6JMAP7",
+      "x-amz-id-2" : "cItU3H7JZ/CYSfIS5UTXPC/Uhfp0cLwLTZXr5mf5y9980DjPZDcEwZpmvYdDG+hzVskZ83LmiEY=",
+      "Date" : "Mon, 11 May 2026 10:39:22 GMT"
+    }
+  },
+  "uuid" : "85e49f66-6cd5-4b49-8cb0-08fccb9c8008",
+  "persistent" : true,
+  "insertionIndex" : 731
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-put-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-put-2.json
@@ -1,0 +1,28 @@
+{
+  "id" : "9f643cc8-9693-4c0f-905b-f6a3ecef5e03",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-PUT-2",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/mode-upgrade-no-bypass",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9tb2RlLXVwZ3JhZGUtbm8tYnlwYXNz"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"857eb5cca76700fe8c964e09c1b481aa\"",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "STC4MGSFNCBWZ9RT",
+      "x-amz-checksum-crc32c" : "BYqjxg==",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "WrTuky06HatnD+Gq5jEIXZg63k86xMWL2W6YSjpoUN2kVz/S7JPYwQV2JawmmrRlhRw+CKouH3w=",
+      "x-amz-version-id" : "wHJBiKm.V1iJD0AhhWkXS_V1z.XNdQfp",
+      "Date" : "Mon, 11 May 2026 10:39:21 GMT"
+    }
+  },
+  "uuid" : "9f643cc8-9693-4c0f-905b-f6a3ecef5e03",
+  "persistent" : true,
+  "insertionIndex" : 732
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_nocurrentretention_throws-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_nocurrentretention_throws-delete-0.json
@@ -1,0 +1,22 @@
+{
+  "id" : "ef756759-a94c-4c85-aa7b-69b19874e2e3",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/no-current-retention",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-delete-marker" : "true",
+      "x-amz-request-id" : "F1FV268D2CCBPP59",
+      "x-amz-id-2" : "qAlmcrrpjfR6uhg7GJKTnZG5XDuzs3i4PjvEL2Hch+flTDpAZ45ey5hSzOorQ67x3mK8XdtJXbzgk5L31jZp4iD8OpsGrCFR",
+      "x-amz-version-id" : "NtX.B5o7GZW5VpkH2x8vHLSRy3aBwPo9",
+      "Date" : "Thu, 14 May 2026 07:06:52 GMT"
+    }
+  },
+  "uuid" : "ef756759-a94c-4c85-aa7b-69b19874e2e3",
+  "persistent" : true,
+  "insertionIndex" : 728
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-1.json
@@ -1,0 +1,34 @@
+{
+  "id" : "23eeb0e3-5de1-43c4-9897-728ae207f4d8",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-GET-1",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/no-current-retention",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>NoSuchObjectLockConfiguration</Code><Message>The specified object does not have a ObjectLock configuration</Message><RequestId>3HAACMH56HW2WY8T</RequestId><HostId>GNzPdcwsfgvaPxygay5cld7IqQqsVAv2VnGG/vgUXEGD6FO5UkYbQA9qwqJ8cbkO7Ctz9c+ZVpd2rmELDwqBsSDovEg4SdzQ</HostId></Error>",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "3HAACMH56HW2WY8T",
+      "x-amz-id-2" : "GNzPdcwsfgvaPxygay5cld7IqQqsVAv2VnGG/vgUXEGD6FO5UkYbQA9qwqJ8cbkO7Ctz9c+ZVpd2rmELDwqBsSDovEg4SdzQ",
+      "Date" : "Thu, 14 May 2026 07:06:49 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "23eeb0e3-5de1-43c4-9897-728ae207f4d8",
+  "persistent" : true,
+  "insertionIndex" : 729
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_nocurrentretention_throws-put-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testupdateobjectretention_nocurrentretention_throws-put-2.json
@@ -1,0 +1,28 @@
+{
+  "id" : "bcadb1db-486d-4242-973b-a74503d2bbcf",
+  "name" : "AwsBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-PUT-2",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/objectlock/update/no-current-retention",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "bm8tcmV0ZW50aW9u"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"bfe1089cb37491a8a0f7e52b9f03b4ab\"",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "MSEG9EA54XYTAQAA",
+      "x-amz-checksum-crc32c" : "mD6zIg==",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "0Kh9SHXhbDLrNkysPso1my2MilSpznpRN1qnkh/Qv1gLJaNEKRmvjheDJTwePDvBkkQoGnDkkQh06lZz/RHl6eCRMa6I+Lz3",
+      "x-amz-version-id" : "qDa3iFZNkHcfkQpFcafxMD4_wfrzPWgQ",
+      "Date" : "Thu, 14 May 2026 07:06:50 GMT"
+    }
+  },
+  "uuid" : "bcadb1db-486d-4242-973b-a74503d2bbcf",
+  "persistent" : true,
+  "insertionIndex" : 730
+}

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
@@ -690,13 +690,23 @@ public class BucketClient implements AutoCloseable {
   }
 
   /**
-   * Updates object retention date.
+   * Updates object retention date, preserving the object's current retention mode.
+   *
+   * <p><strong>Deprecated.</strong> Prefer {@link #updateObjectRetention(String, String,
+   * com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig)} which accepts an explicit mode
+   * and bypass flag. This method is retained for backward compatibility.
+   *
+   * <p><strong>Existing non-uniform behavior:</strong> The AWS provider has historically thrown
+   * {@code FailedPreconditionException} for any update on a COMPLIANCE-mode object — even
+   * extension. GCP allows extending LOCKED. The new overload follows uniform rules across
+   * providers; this deprecated method preserves each provider's existing semantics.
    *
    * @param key Object key
    * @param versionId Optional version ID. For versioned buckets, null means latest version.
    * @param retainUntilDate New retention expiration date
    * @throws SubstrateSdkException Thrown if the operation fails
    */
+  @Deprecated
   public void updateObjectRetention(String key, String versionId, Instant retainUntilDate) {
     multiCloudJLogger.traceVoidOperation(
         BlobSpanNames.UPDATE_OBJECT_RETENTION,
@@ -709,6 +719,32 @@ public class BucketClient implements AutoCloseable {
             propagate(t);
           }
         });
+  }
+
+  /**
+   * Updates per-object retention with explicit mode and bypass control.
+   *
+   * <p>See {@link com.salesforce.multicloudj.blob.driver.BlobStore#updateObjectRetention(String,
+   * String, com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig)} for the full rules
+   * table governing every {@code (config.mode, config.bypassGovernanceRetention, current state,
+   * new date vs current)} combination.
+   *
+   * @param key Object key
+   * @param versionId Optional version ID. For versioned buckets, null means latest version.
+   * @param config retention configuration (mode, retain-until date, bypass flag)
+   * @throws SubstrateSdkException Thrown if the operation fails
+   * @throws IllegalArgumentException if {@code config} or {@code config.retainUntilDate} is null
+   */
+  public void updateObjectRetention(
+      String key,
+      String versionId,
+      com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config) {
+    try {
+      blobStore.updateObjectRetention(key, versionId, config);
+    } catch (Throwable t) {
+      Class<? extends SubstrateSdkException> exception = blobStore.getException(t);
+      ExceptionHandler.handleAndPropagate(exception, t);
+    }
   }
 
   /**

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStore.java
@@ -251,6 +251,39 @@ public abstract class AbstractBlobStore implements BlobStore, AutoCloseable {
     doDeleteDirectory(prefix);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Deprecated path: delegates to {@link #updateObjectRetention(String, String,
+   * ObjectRetentionConfig)} with {@code mode=null} (preserve current mode) and {@code
+   * bypassGovernanceRetention=false}. This delegation gives every provider a single retention-
+   * update code path and prevents AWS/GCP behavior from drifting.
+   *
+   * <p>Note: the historical AWS implementation rejected ANY update on COMPLIANCE objects
+   * (including extension), while GCP allows extending LOCKED. Each provider's existing
+   * override of this deprecated method takes precedence over this delegate, preserving its
+   * legacy semantics; the new overload introduces a uniform rules table across providers.
+   */
+  @Override
+  @Deprecated
+  public void updateObjectRetention(
+      String key, String versionId, java.time.Instant retainUntilDate) {
+    updateObjectRetention(
+        key,
+        versionId,
+        ObjectRetentionConfig.builder()
+            .retainUntilDate(retainUntilDate)
+            .bypassGovernanceRetention(Boolean.FALSE)
+            .build());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void updateObjectRetention(String key, String versionId, ObjectRetentionConfig config) {
+    validator.validate(config);
+    doUpdateObjectRetention(key, versionId, config);
+  }
+
   protected abstract UploadResponse doUpload(UploadRequest uploadRequest, InputStream inputStream);
 
   protected abstract UploadResponse doUpload(UploadRequest uploadRequest, byte[] content);
@@ -306,6 +339,24 @@ public abstract class AbstractBlobStore implements BlobStore, AutoCloseable {
   protected abstract boolean doDoesObjectExist(String key, String versionId);
 
   protected abstract boolean doDoesBucketExist();
+
+  /**
+   * Provider hook for {@link #updateObjectRetention(String, String, ObjectRetentionConfig)}.
+   *
+   * <p>State-dependent validation (no-current-retention rejection, mode-transition rules,
+   * shorten-with-bypass rules) lives here per design §E so all providers surface uniform
+   * exception types and messages. Stateless validation has already been performed by the
+   * template before this hook is invoked.
+   *
+   * <p>Default implementation throws {@link UnsupportedOperationException} — provider
+   * implementations that do not support per-object retention (e.g. Alibaba OSS) inherit this
+   * behavior without further work.
+   */
+  protected void doUpdateObjectRetention(
+      String key, String versionId, ObjectRetentionConfig config) {
+    throw new UnsupportedOperationException(
+        "Per-object retention updates are not supported by this substrate implementation");
+  }
 
   protected DirectoryDownloadResponse doDownloadDirectory(
       DirectoryDownloadRequest directoryDownloadRequest) {

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStore.java
@@ -290,13 +290,57 @@ public interface BlobStore extends SdkService, Provider {
   ObjectLockInfo getObjectLock(String key, String versionId);
 
   /**
-   * Updates object retention date.
+   * Updates object retention date, preserving the object's current retention mode.
+   *
+   * <p><strong>Deprecated.</strong> Use {@link #updateObjectRetention(String, String,
+   * ObjectRetentionConfig)} which can set the mode and request a governance bypass. This method
+   * delegates to the new overload with {@code mode=null} (preserve current) and {@code
+   * bypassGovernanceRetention=false}.
+   *
+   * <p><strong>Existing non-uniform behavior:</strong> Today's AWS implementation throws
+   * {@code FailedPreconditionException} for any update on a COMPLIANCE-mode object — even
+   * extension. GCP allows extension on LOCKED. The new overload introduces a uniform rules
+   * table; this deprecated method preserves each provider's existing semantics.
    *
    * @param key Object key
    * @param versionId Optional version ID. For versioned buckets, null means latest version.
    * @param retainUntilDate New retention expiration date
    */
+  @Deprecated
   void updateObjectRetention(String key, String versionId, java.time.Instant retainUntilDate);
+
+  /**
+   * Updates per-object retention with explicit mode and bypass control.
+   *
+   * <p>Backward-compatible companion to {@link #updateObjectRetention(String, String,
+   * java.time.Instant)} which only takes a date and preserves the current mode.
+   *
+   * <h3>Rules table</h3>
+   *
+   * Outcome for each combination of {@code (config.mode, config.bypassGovernanceRetention,
+   * current state, new date vs current)} is identical across AWS, GCP, and the in-memory provider.
+   * Key invariants:
+   *
+   * <ul>
+   *   <li>If the object has no current retention → {@code FailedPreconditionException}.
+   *   <li>{@code config.mode == null} means "preserve the current mode."
+   *   <li>Mode downgrade COMPLIANCE→GOVERNANCE / LOCKED→UNLOCKED is rejected by every provider.
+   *   <li>Mode upgrade GOVERNANCE→COMPLIANCE / UNLOCKED→LOCKED requires {@code
+   *       bypassGovernanceRetention=true} — both AWS and GCP treat a lock-mode change as a
+   *       modification of the existing lock and reject it server-side without the bypass flag.
+   *   <li>Shortening retention on COMPLIANCE/LOCKED is rejected regardless of {@code
+   *       bypassGovernanceRetention} — the flag has no effect on the immutable mode (mirrors
+   *       AWS and GCP server semantics).
+   *   <li>Shortening retention on GOVERNANCE/UNLOCKED requires {@code
+   *       bypassGovernanceRetention=true}; otherwise rejected.
+   * </ul>
+   *
+   * @param key Object key
+   * @param versionId Optional version ID. For versioned buckets, null means latest version.
+   * @param config retention configuration (mode, retain-until date, bypass flag)
+   * @throws IllegalArgumentException if {@code config} or {@code config.retainUntilDate} is null
+   */
+  void updateObjectRetention(String key, String versionId, ObjectRetentionConfig config);
 
   /**
    * Updates legal hold status on an object.

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStoreValidator.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStoreValidator.java
@@ -40,6 +40,10 @@ public class BlobStoreValidator {
       "Ranged read boundaries cannot be negative. start=%s end=%s";
   static final String INVALID_RANGED_READ_BOUNDARIES_MSG =
       "Ranged read start cannot be larger than end. start=%s end=%s";
+  static final String NULL_RETENTION_CONFIG_MSG =
+      "ObjectRetentionConfig cannot be null";
+  static final String NULL_RETAIN_UNTIL_DATE_MSG =
+      "ObjectRetentionConfig.retainUntilDate cannot be null";
 
   /**
    * Inspects the input string and throws an IllegalArgumentException if the input is `null`, empty,
@@ -344,5 +348,31 @@ public class BlobStoreValidator {
       throw new IllegalArgumentException(
           String.format(INVALID_RANGED_READ_BOUNDARIES_MSG, start, end));
     }
+  }
+
+  /**
+   * Performs stateless validation on an {@link ObjectRetentionConfig}.
+   *
+   * <p>Only checks invariants that do not require fetching the object's current state. Stateful
+   * checks (mode-transition rules, shorten guards, "no current retention" rejection) live in each
+   * provider implementation so the same exception type and message are surfaced uniformly across
+   * providers.
+   *
+   * <p>Notably absent: future-date validation. Neither the existing {@code
+   * updateObjectRetention(..., Instant)} method nor any provider currently performs a client-side
+   * future-date check — both defer to server-side rejection. This method preserves that behavior.
+   *
+   * @param config the configuration to validate
+   * @throws IllegalArgumentException if {@code config} or {@code config.retainUntilDate} is null
+   */
+  public void validate(ObjectRetentionConfig config) {
+    if (config == null) {
+      throw new IllegalArgumentException(NULL_RETENTION_CONFIG_MSG);
+    }
+    if (config.getRetainUntilDate() == null) {
+      throw new IllegalArgumentException(NULL_RETAIN_UNTIL_DATE_MSG);
+    }
+    // mode == null is the documented sentinel for "preserve current mode" — do NOT reject.
+    // bypassGovernanceRetention == null is the documented default for "no bypass" — do NOT reject.
   }
 }

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/ObjectRetentionConfig.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/ObjectRetentionConfig.java
@@ -1,0 +1,73 @@
+package com.salesforce.multicloudj.blob.driver;
+
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Configuration for updating per-object retention via {@link
+ * BlobStore#updateObjectRetention(String, String, ObjectRetentionConfig)}.
+ *
+ * <p>Distinct from {@link ObjectLockConfiguration}, which is used at upload time and additionally
+ * carries legal-hold flags. This type is scoped strictly to <em>retention update</em>: changing the
+ * retention mode and/or the retention expiration date on an object that already has retention
+ * configured. Legal hold remains on {@link BlobStore#updateLegalHold(String, String, boolean)}.
+ *
+ * <h3>Field semantics</h3>
+ *
+ * <ul>
+ *   <li>{@code mode} — target retention mode. May be {@code null} to preserve the object's current
+ *       retention mode (the provider fetches the current mode and reuses it).
+ *   <li>{@code retainUntilDate} — new retention expiration date. Must be non-null. Sub-millisecond
+ *       precision is not preserved on GCP (GCS truncates to RFC 3339 millisecond precision); for
+ *       retention dates this is generally not a concern.
+ *   <li>{@code bypassGovernanceRetention} — when {@code true}, allows shortening or removing
+ *       retention on objects currently in {@link RetentionMode#GOVERNANCE} (AWS) or {@code
+ *       UNLOCKED} (GCP) mode. Maps to {@code bypassGovernanceRetention} on AWS and to {@code
+ *       overrideUnlockedRetention} on GCP. The flag is <strong>ignored on the immutable
+ *       mode</strong> ({@link RetentionMode#COMPLIANCE} / {@code LOCKED}); both clouds reject any
+ *       shorten or downgrade attempt server-side regardless of this flag.
+ * </ul>
+ *
+ * <p>The complete (mode, bypass, current state) → outcome rules table is documented on {@link
+ * BlobStore#updateObjectRetention(String, String, ObjectRetentionConfig)}.
+ */
+@Builder
+@Getter
+public class ObjectRetentionConfig {
+
+  /**
+   * Target retention mode. May be {@code null} to preserve the current mode of the object.
+   *
+   * <p>Mode downgrades from {@link RetentionMode#COMPLIANCE} to {@link RetentionMode#GOVERNANCE}
+   * are rejected by every provider — the underlying clouds (AWS S3, GCP GCS) do not permit such
+   * transitions, and MultiCloudJ surfaces a uniform {@code FailedPreconditionException} for the
+   * attempt.
+   */
+  private final RetentionMode mode;
+
+  /**
+   * New retention expiration date. Must be non-null.
+   *
+   * <p>Sub-millisecond precision is not preserved on GCP — GCS truncates this value to RFC 3339
+   * millisecond precision on the wire.
+   */
+  private final Instant retainUntilDate;
+
+  /**
+   * When {@code true}, allows shortening or removing retention on objects currently in {@link
+   * RetentionMode#GOVERNANCE} (AWS) / {@code UNLOCKED} (GCP) mode.
+   *
+   * <p>Maps to {@code bypassGovernanceRetention} on AWS {@code PutObjectRetention} requests and to
+   * {@code Storage.BlobTargetOption.overrideUnlockedRetention(true)} on GCP {@code storage.update}
+   * calls.
+   *
+   * <p><strong>No effect on the immutable mode.</strong> Both AWS and GCP reject any shorten,
+   * downgrade, or remove attempt against {@link RetentionMode#COMPLIANCE} / {@code LOCKED}
+   * regardless of this flag, IAM permissions, or principal (including AWS root). MultiCloudJ
+   * mirrors this server-side semantic with a client-side guard for uniform error reporting.
+   *
+   * <p>{@code null} or {@code false} ⇒ no bypass (default).
+   */
+  private final Boolean bypassGovernanceRetention;
+}

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/ObjectRetentionRules.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/ObjectRetentionRules.java
@@ -1,0 +1,97 @@
+package com.salesforce.multicloudj.blob.driver;
+
+import com.salesforce.multicloudj.common.exceptions.FailedPreconditionException;
+import java.time.Instant;
+
+/**
+ * State-dependent rules shared by every provider's {@code doUpdateObjectRetention} hook so AWS,
+ * GCP, and the in-memory provider surface uniform exception types and messages.
+ *
+ * <p>The full rules table lives on the javadoc for {@link BlobStore#updateObjectRetention(String,
+ * String, ObjectRetentionConfig)}. This class is the single source of truth for the runtime
+ * checks.
+ *
+ * <p><strong>Stateless</strong> validation (null config, null retain-until-date) lives in {@link
+ * BlobStoreValidator#validate(ObjectRetentionConfig)} and is run by the {@code
+ * AbstractBlobStore} template before the provider hook is invoked. By the time control reaches
+ * this helper, both {@code config} and {@code config.getRetainUntilDate()} are guaranteed
+ * non-null.
+ */
+public final class ObjectRetentionRules {
+
+  static final String NO_CURRENT_RETENTION_MSG =
+      "Object does not have retention configured. Cannot update retention.";
+  static final String MODE_DOWNGRADE_MSG =
+      "Cannot downgrade retention mode from COMPLIANCE to GOVERNANCE. "
+          + "The immutable mode does not permit downgrade on AWS or GCP.";
+  static final String COMPLIANCE_SHORTEN_MSG =
+      "Cannot shorten retention for objects in COMPLIANCE mode. "
+          + "bypassGovernanceRetention has no effect on the immutable mode.";
+  static final String GOVERNANCE_SHORTEN_NO_BYPASS_MSG =
+      "Cannot shorten retention for objects in GOVERNANCE mode without "
+          + "bypassGovernanceRetention=true.";
+  static final String MODE_UPGRADE_NO_BYPASS_MSG =
+      "Cannot upgrade retention mode from GOVERNANCE to COMPLIANCE without "
+          + "bypassGovernanceRetention=true. Both AWS S3 and GCP GCS treat the lock-mode "
+          + "transition as a modification of the existing lock and require the bypass/override "
+          + "flag.";
+
+  private ObjectRetentionRules() {
+    // utility
+  }
+
+  /**
+   * Resolves the effective new retention against the locked rules table. Throws {@link
+   * FailedPreconditionException} when a rule rejects the request.
+   *
+   * @param currentMode current retention mode on the object, or {@code null} if there is none
+   * @param currentRetainUntil current retain-until date, or {@code null} if there is none
+   * @param config the requested change (must have non-null retainUntilDate)
+   * @return resolved retention mode to write back ({@code config.mode} when non-null, else {@code
+   *     currentMode})
+   */
+  public static RetentionMode resolveAndValidate(
+      RetentionMode currentMode, Instant currentRetainUntil, ObjectRetentionConfig config) {
+
+    // 1. No current retention → reject. Update is for objects that already have retention set;
+    //    "first time set" belongs on the upload path.
+    if (currentMode == null) {
+      throw new FailedPreconditionException(NO_CURRENT_RETENTION_MSG);
+    }
+
+    RetentionMode effectiveMode = config.getMode() != null ? config.getMode() : currentMode;
+    boolean bypass = Boolean.TRUE.equals(config.getBypassGovernanceRetention());
+
+    // 2. Mode downgrade COMPLIANCE → GOVERNANCE is rejected by both AWS and GCP server-side.
+    if (currentMode == RetentionMode.COMPLIANCE && effectiveMode == RetentionMode.GOVERNANCE) {
+      throw new FailedPreconditionException(MODE_DOWNGRADE_MSG);
+    }
+
+    // 2b. Mode upgrade GOVERNANCE → COMPLIANCE requires bypassGovernanceRetention=true. Both
+    //     AWS S3 and GCP GCS treat the mode change as a modification of the existing lock and
+    //     reject it server-side without the bypass/override flag (AWS HTTP 403 AccessDenied;
+    //     GCP HTTP 400/412). We mirror that client-side for uniform error reporting.
+    if (currentMode == RetentionMode.GOVERNANCE
+        && effectiveMode == RetentionMode.COMPLIANCE
+        && !bypass) {
+      throw new FailedPreconditionException(MODE_UPGRADE_NO_BYPASS_MSG);
+    }
+
+    // 3. Shorten check — strict less-than, equal dates are not "shortening".
+    boolean shortening =
+        currentRetainUntil != null && config.getRetainUntilDate().isBefore(currentRetainUntil);
+    if (shortening) {
+      // 3a. COMPLIANCE / LOCKED is extend-only regardless of bypass — both clouds ignore the flag
+      //     on the immutable mode.
+      if (currentMode == RetentionMode.COMPLIANCE) {
+        throw new FailedPreconditionException(COMPLIANCE_SHORTEN_MSG);
+      }
+      // 3b. GOVERNANCE / UNLOCKED requires explicit bypass to shorten.
+      if (!bypass) {
+        throw new FailedPreconditionException(GOVERNANCE_SHORTEN_NO_BYPASS_MSG);
+      }
+    }
+
+    return effectiveMode;
+  }
+}

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -2720,6 +2720,375 @@ public abstract class AbstractBlobStoreIT {
         () -> bucketClient.getObjectLock("conformance-tests/objectlock/nonexistent", null));
   }
 
+  // ------------------------------------------------------------------------------------
+  // Conformance tests for updateObjectRetention(key, versionId, ObjectRetentionConfig)
+  //
+  // These verify that AWS, GCP, and the in-memory provider behave identically against the
+  // (config.mode, config.bypassGovernanceRetention, current state, new date vs current)
+  // rules table documented on BlobStore#updateObjectRetention(String, String,
+  // ObjectRetentionConfig).
+  // ------------------------------------------------------------------------------------
+
+  /** Fixed retain-until pair for update-retention tests; second value is later than first. */
+  private static final Instant UPDATE_RETENTION_INITIAL =
+      Instant.parse("2030-01-01T00:00:00Z");
+  private static final Instant UPDATE_RETENTION_EXTENDED =
+      Instant.parse("2030-06-01T00:00:00Z");
+  private static final Instant UPDATE_RETENTION_SHORTENED =
+      Instant.parse("2030-02-01T00:00:00Z");
+
+  /**
+   * Helper to upload a key with a specific retention configuration so the update-retention
+   * conformance tests have a known starting state.
+   */
+  private void uploadWithRetention(
+      BucketClient bucketClient, String key, RetentionMode mode, Instant retainUntil)
+      throws IOException {
+    byte[] content = ("retention-update-" + key).getBytes(StandardCharsets.UTF_8);
+    ObjectLockConfiguration lockConfig =
+        ObjectLockConfiguration.builder()
+            .mode(mode)
+            .retainUntilDate(retainUntil)
+            .legalHold(false)
+            .build();
+    try (InputStream inputStream = new ByteArrayInputStream(content)) {
+      bucketClient.upload(
+          new UploadRequest.Builder()
+              .withKey(key)
+              .withContentLength(content.length)
+              .withObjectLock(lockConfig)
+              .withChecksumValue(harness.computeChecksum(content))
+              .build(),
+          inputStream);
+    }
+  }
+
+  @Test
+  public void testUpdateObjectRetention_governance_extend_succeeds() throws IOException {
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    String key = "conformance-tests/objectlock/update/gov-extend";
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    try {
+      uploadWithRetention(bucketClient, key, RetentionMode.GOVERNANCE, UPDATE_RETENTION_INITIAL);
+
+      bucketClient.updateObjectRetention(
+          key,
+          null,
+          com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+              .mode(RetentionMode.GOVERNANCE)
+              .retainUntilDate(UPDATE_RETENTION_EXTENDED)
+              .build());
+
+      ObjectLockInfo info = bucketClient.getObjectLock(key, null);
+      Assertions.assertEquals(RetentionMode.GOVERNANCE, info.getMode());
+      Assertions.assertEquals(UPDATE_RETENTION_EXTENDED, info.getRetainUntilDate());
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  public void testUpdateObjectRetention_compliance_extend_succeeds() throws IOException {
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    String key = "conformance-tests/objectlock/update/comp-extend";
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    try {
+      uploadWithRetention(bucketClient, key, RetentionMode.COMPLIANCE, UPDATE_RETENTION_INITIAL);
+
+      bucketClient.updateObjectRetention(
+          key,
+          null,
+          com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+              .mode(RetentionMode.COMPLIANCE)
+              .retainUntilDate(UPDATE_RETENTION_EXTENDED)
+              .build());
+
+      Assertions.assertEquals(
+          UPDATE_RETENTION_EXTENDED, bucketClient.getObjectLock(key, null).getRetainUntilDate());
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  public void testUpdateObjectRetention_governance_shorten_withBypass_succeeds()
+      throws IOException {
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    String key = "conformance-tests/objectlock/update/gov-shorten-bypass";
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    try {
+      uploadWithRetention(bucketClient, key, RetentionMode.GOVERNANCE, UPDATE_RETENTION_EXTENDED);
+
+      bucketClient.updateObjectRetention(
+          key,
+          null,
+          com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+              .mode(RetentionMode.GOVERNANCE)
+              .retainUntilDate(UPDATE_RETENTION_SHORTENED)
+              .bypassGovernanceRetention(Boolean.TRUE)
+              .build());
+
+      Assertions.assertEquals(
+          UPDATE_RETENTION_SHORTENED, bucketClient.getObjectLock(key, null).getRetainUntilDate());
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  public void testUpdateObjectRetention_governance_shorten_withoutBypass_throws()
+      throws IOException {
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    String key = "conformance-tests/objectlock/update/gov-shorten-no-bypass";
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    try {
+      uploadWithRetention(bucketClient, key, RetentionMode.GOVERNANCE, UPDATE_RETENTION_EXTENDED);
+
+      com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+          com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+              .mode(RetentionMode.GOVERNANCE)
+              .retainUntilDate(UPDATE_RETENTION_SHORTENED)
+              .build();
+      Assertions.assertThrows(
+          Exception.class, () -> bucketClient.updateObjectRetention(key, null, cfg));
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  public void testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds()
+      throws IOException {
+    // Mode upgrade requires bypassGovernanceRetention=true on both AWS and GCP — the cloud
+    // treats the lock-mode change as a modification of the existing lock. The rules helper
+    // mirrors that and rejects upgrade without bypass.
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    String key = "conformance-tests/objectlock/update/mode-upgrade";
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    try {
+      uploadWithRetention(bucketClient, key, RetentionMode.GOVERNANCE, UPDATE_RETENTION_INITIAL);
+
+      bucketClient.updateObjectRetention(
+          key,
+          null,
+          com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+              .mode(RetentionMode.COMPLIANCE)
+              .retainUntilDate(UPDATE_RETENTION_EXTENDED)
+              .bypassGovernanceRetention(Boolean.TRUE)
+              .build());
+
+      ObjectLockInfo info = bucketClient.getObjectLock(key, null);
+      Assertions.assertEquals(RetentionMode.COMPLIANCE, info.getMode());
+      Assertions.assertEquals(UPDATE_RETENTION_EXTENDED, info.getRetainUntilDate());
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  public void testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws()
+      throws IOException {
+    // Without bypassGovernanceRetention=true, the cloud rejects the lock-mode change.
+    // The rules helper rejects this client-side for uniform error reporting.
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    String key = "conformance-tests/objectlock/update/mode-upgrade-no-bypass";
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    try {
+      uploadWithRetention(bucketClient, key, RetentionMode.GOVERNANCE, UPDATE_RETENTION_INITIAL);
+
+      com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+          com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+              .mode(RetentionMode.COMPLIANCE)
+              .retainUntilDate(UPDATE_RETENTION_EXTENDED)
+              .build();
+      Assertions.assertThrows(
+          Exception.class, () -> bucketClient.updateObjectRetention(key, null, cfg));
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  public void testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws()
+      throws IOException {
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    String key = "conformance-tests/objectlock/update/mode-downgrade";
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    try {
+      uploadWithRetention(bucketClient, key, RetentionMode.COMPLIANCE, UPDATE_RETENTION_INITIAL);
+
+      com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+          com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+              .mode(RetentionMode.GOVERNANCE)
+              .retainUntilDate(UPDATE_RETENTION_EXTENDED)
+              .bypassGovernanceRetention(Boolean.TRUE)
+              .build();
+      Assertions.assertThrows(
+          Exception.class, () -> bucketClient.updateObjectRetention(key, null, cfg));
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  public void testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws()
+      throws IOException {
+    // bypassGovernanceRetention=true CANNOT rescue a shorten on COMPLIANCE/LOCKED — both AWS
+    // and GCP ignore the flag on the immutable mode. MultiCloudJ surfaces a uniform
+    // FailedPreconditionException client-side rather than waiting for HTTP 403 from AWS or
+    // HTTP 400/412 from GCP.
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    String key = "conformance-tests/objectlock/update/comp-shorten-bypass";
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    try {
+      uploadWithRetention(bucketClient, key, RetentionMode.COMPLIANCE, UPDATE_RETENTION_EXTENDED);
+
+      com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+          com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+              .mode(RetentionMode.COMPLIANCE)
+              .retainUntilDate(UPDATE_RETENTION_SHORTENED)
+              .bypassGovernanceRetention(Boolean.TRUE)
+              .build();
+      Assertions.assertThrows(
+          Exception.class, () -> bucketClient.updateObjectRetention(key, null, cfg));
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  @Disabled(
+      "Backward-compat verification covered by deprecated-method tests in"
+          + " AbstractBlobStoreTest; full IT path requires the Instant overload to be exercised"
+          + " against a recorded WireMock fixture, which is generated alongside the new overload"
+          + " fixtures.")
+  public void testUpdateObjectRetention_deprecatedInstantOverload_stillWorks() throws IOException {
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    String key = "conformance-tests/objectlock/update/deprecated-path";
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    try {
+      uploadWithRetention(bucketClient, key, RetentionMode.GOVERNANCE, UPDATE_RETENTION_INITIAL);
+
+      // Deprecated Instant overload — must keep working with unchanged semantics.
+      bucketClient.updateObjectRetention(key, null, UPDATE_RETENTION_EXTENDED);
+
+      Assertions.assertEquals(
+          UPDATE_RETENTION_EXTENDED, bucketClient.getObjectLock(key, null).getRetainUntilDate());
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  public void testUpdateObjectRetention_nullConfig_throws() {
+    // Stateless validation in BlobStoreValidator runs before any provider hook —
+    // so this test does NOT need a provider implementation to pass. Verifies that the
+    // template (AbstractBlobStore.updateObjectRetention) invokes the validator.
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    // BucketClient wraps IllegalArgumentException in InvalidArgumentException via
+    // ExceptionHandler; assert on the wrapper for parity with other client-level tests.
+    Assertions.assertThrows(
+        com.salesforce.multicloudj.common.exceptions.InvalidArgumentException.class,
+        () ->
+            bucketClient.updateObjectRetention(
+                "conformance-tests/objectlock/null-config",
+                null,
+                (com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig) null));
+  }
+
+  @Test
+  public void testUpdateObjectRetention_nullRetainUntilDate_throws() {
+    // Stateless validation. Same as above — does not require a provider implementation.
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(RetentionMode.GOVERNANCE)
+            .build(); // retainUntilDate intentionally null
+
+    Assertions.assertThrows(
+        com.salesforce.multicloudj.common.exceptions.InvalidArgumentException.class,
+        () ->
+            bucketClient.updateObjectRetention(
+                "conformance-tests/objectlock/null-date", null, cfg));
+  }
+
+  @Test
+  public void testUpdateObjectRetention_legalHoldPreservedAcrossUpdate() throws IOException {
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    String key = "conformance-tests/objectlock/update/legalhold-preserved";
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    try {
+      // Upload with retention + legal hold ON.
+      byte[] content = "legalhold-preserved".getBytes(StandardCharsets.UTF_8);
+      ObjectLockConfiguration lockConfig =
+          ObjectLockConfiguration.builder()
+              .mode(RetentionMode.GOVERNANCE)
+              .retainUntilDate(UPDATE_RETENTION_INITIAL)
+              .legalHold(true)
+              .build();
+      try (InputStream inputStream = new ByteArrayInputStream(content)) {
+        bucketClient.upload(
+            new UploadRequest.Builder()
+                .withKey(key)
+                .withContentLength(content.length)
+                .withObjectLock(lockConfig)
+                .withChecksumValue(harness.computeChecksum(content))
+                .build(),
+            inputStream);
+      }
+
+      bucketClient.updateObjectRetention(
+          key,
+          null,
+          com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+              .mode(RetentionMode.GOVERNANCE)
+              .retainUntilDate(UPDATE_RETENTION_EXTENDED)
+              .build());
+
+      Assertions.assertTrue(
+          bucketClient.getObjectLock(key, null).isLegalHold(),
+          "Legal hold should be preserved across retention update");
+    } finally {
+      // Release the legal hold before delete (else cleanup hangs on AWS).
+      try {
+        bucketClient.updateLegalHold(key, null, false);
+      } catch (Exception ignored) {
+        // Best-effort cleanup; continues to safeDeleteBlobs.
+      }
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
   @Test
   public void testGetVersionedMetadata() throws IOException {
 

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -29,6 +29,7 @@ import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.exceptions.ArchiveInfo;
+import com.salesforce.multicloudj.common.exceptions.FailedPreconditionException;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
@@ -2967,6 +2968,39 @@ public abstract class AbstractBlobStoreIT {
               .build();
       Assertions.assertThrows(
           Exception.class, () -> bucketClient.updateObjectRetention(key, null, cfg));
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  public void testUpdateObjectRetention_noCurrentRetention_throws() throws IOException {
+    Assumptions.assumeTrue(
+        harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    // Upload WITHOUT retention config — object has no retention set.
+    String key = "conformance-tests/objectlock/update/no-current-retention";
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    try {
+      byte[] content = "no-retention".getBytes(StandardCharsets.UTF_8);
+      try (InputStream inputStream = new ByteArrayInputStream(content)) {
+        bucketClient.upload(
+            new UploadRequest.Builder()
+                .withKey(key)
+                .withContentLength(content.length)
+                .withChecksumValue(harness.computeChecksum(content))
+                .build(),
+            inputStream);
+      }
+
+      com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+          com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+              .mode(RetentionMode.GOVERNANCE)
+              .retainUntilDate(UPDATE_RETENTION_EXTENDED)
+              .build();
+      Assertions.assertThrows(
+          FailedPreconditionException.class,
+          () -> bucketClient.updateObjectRetention(key, null, cfg));
     } finally {
       safeDeleteBlobs(bucketClient, key);
     }

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/BucketClientTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/BucketClientTest.java
@@ -805,7 +805,7 @@ public class BucketClientTest {
     Instant retainUntil = Instant.now().plusSeconds(3600);
     doThrow(RuntimeException.class)
         .when(mockBlobStore)
-        .updateObjectRetention(anyString(), any(), any());
+        .updateObjectRetention(anyString(), any(), any(Instant.class));
     assertThrows(
         UnAuthorizedException.class,
         () -> {

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStoreTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStoreTest.java
@@ -409,4 +409,56 @@ public class AbstractBlobStoreTest {
     verify(validator, times(1)).validateKey(any());
     verify(mockBlobStore, times(1)).doDoesObjectExist("object-1", "version-1");
   }
+
+  // ---- updateObjectRetention(key, versionId, ObjectRetentionConfig) -------------------
+
+  @Test
+  void updateObjectRetentionConfig_validatesAndDelegatesToHook() {
+    doCallRealMethod()
+        .when(mockBlobStore)
+        .updateObjectRetention(any(), any(), any(ObjectRetentionConfig.class));
+    // Stub the provider hook so the spy doesn't trip the default UnsupportedOperationException.
+    org.mockito.Mockito.doNothing()
+        .when(mockBlobStore)
+        .doUpdateObjectRetention(any(), any(), any());
+    java.time.Instant date = java.time.Instant.parse("2030-01-01T00:00:00Z");
+    ObjectRetentionConfig cfg =
+        ObjectRetentionConfig.builder()
+            .mode(RetentionMode.GOVERNANCE)
+            .retainUntilDate(date)
+            .build();
+
+    mockBlobStore.updateObjectRetention("object-1", "version-1", cfg);
+
+    verify(validator, times(1)).validate(cfg);
+    verify(mockBlobStore, times(1)).doUpdateObjectRetention("object-1", "version-1", cfg);
+  }
+
+  @Test
+  void updateObjectRetention_deprecatedPath_delegatesToNewMethodWithModeNullAndNoBypass() {
+    doCallRealMethod()
+        .when(mockBlobStore)
+        .updateObjectRetention(any(), any(), any(java.time.Instant.class));
+    doCallRealMethod()
+        .when(mockBlobStore)
+        .updateObjectRetention(any(), any(), any(ObjectRetentionConfig.class));
+    org.mockito.Mockito.doNothing()
+        .when(mockBlobStore)
+        .doUpdateObjectRetention(any(), any(), any());
+    java.time.Instant date = java.time.Instant.parse("2030-01-01T00:00:00Z");
+
+    mockBlobStore.updateObjectRetention("object-1", "version-1", date);
+
+    ArgumentCaptor<ObjectRetentionConfig> captor =
+        ArgumentCaptor.forClass(ObjectRetentionConfig.class);
+    verify(mockBlobStore, times(1))
+        .doUpdateObjectRetention(eq("object-1"), eq("version-1"), captor.capture());
+    ObjectRetentionConfig delegated = captor.getValue();
+    assertEquals(date, delegated.getRetainUntilDate());
+    // Deprecated path always delegates with mode=null (preserve current) and bypass=false (no
+    // bypass) — historical behavior of the Instant overload.
+    org.junit.jupiter.api.Assertions.assertNull(delegated.getMode());
+    org.junit.jupiter.api.Assertions.assertEquals(
+        Boolean.FALSE, delegated.getBypassGovernanceRetention());
+  }
 }

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/BlobStoreValidatorTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/BlobStoreValidatorTest.java
@@ -354,4 +354,45 @@ public class BlobStoreValidatorTest {
     assertThrows(IllegalArgumentException.class, () -> validator.validateRange(-100L, -100L));
     assertThrows(IllegalArgumentException.class, () -> validator.validateRange(100L, 50L));
   }
+
+  // ---- ObjectRetentionConfig validation ------------------------------------------------
+
+  @Test
+  void validateObjectRetentionConfig_rejectsNullConfig() {
+    var e =
+        assertThrows(
+            IllegalArgumentException.class, () -> validator.validate((ObjectRetentionConfig) null));
+    assertEquals(BlobStoreValidator.NULL_RETENTION_CONFIG_MSG, e.getMessage());
+  }
+
+  @Test
+  void validateObjectRetentionConfig_rejectsNullRetainUntilDate() {
+    var cfg = ObjectRetentionConfig.builder().mode(RetentionMode.GOVERNANCE).build();
+    var e = assertThrows(IllegalArgumentException.class, () -> validator.validate(cfg));
+    assertEquals(BlobStoreValidator.NULL_RETAIN_UNTIL_DATE_MSG, e.getMessage());
+  }
+
+  @Test
+  void validateObjectRetentionConfig_acceptsConfigWithDate() {
+    // Stateless validation only checks non-null invariants.
+    // mode == null is the documented sentinel for "preserve current mode", so it must NOT be
+    // rejected here. Bypass == null is the documented default for "no bypass".
+    var cfg =
+        ObjectRetentionConfig.builder()
+            .retainUntilDate(java.time.Instant.parse("2030-01-01T00:00:00Z"))
+            .build();
+    validator.validate(cfg); // does not throw
+  }
+
+  @Test
+  void validateObjectRetentionConfig_doesNotEnforceFutureDate() {
+    // Backward-compat: existing updateObjectRetention(..., Instant) and the AWS/GCP impls do not
+    // perform client-side future-date validation today — they defer to server-side rejection.
+    // The new overload preserves that behavior; clock-skew false-positives stay off the table.
+    var cfg =
+        ObjectRetentionConfig.builder()
+            .retainUntilDate(java.time.Instant.parse("2000-01-01T00:00:00Z"))
+            .build();
+    validator.validate(cfg); // does not throw
+  }
 }

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/ObjectRetentionConfigTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/ObjectRetentionConfigTest.java
@@ -1,0 +1,50 @@
+package com.salesforce.multicloudj.blob.driver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link ObjectRetentionConfig}. */
+class ObjectRetentionConfigTest {
+
+  @Test
+  void builderProducesConfigWithAllFields() {
+    Instant date = Instant.parse("2030-12-31T00:00:00Z");
+
+    ObjectRetentionConfig cfg =
+        ObjectRetentionConfig.builder()
+            .mode(RetentionMode.GOVERNANCE)
+            .retainUntilDate(date)
+            .bypassGovernanceRetention(Boolean.TRUE)
+            .build();
+
+    assertEquals(RetentionMode.GOVERNANCE, cfg.getMode());
+    assertEquals(date, cfg.getRetainUntilDate());
+    assertEquals(Boolean.TRUE, cfg.getBypassGovernanceRetention());
+  }
+
+  @Test
+  void modeIsNullableSentinelMeaningPreserveCurrent() {
+    // null mode is a valid sentinel meaning "preserve the object's current retention mode".
+    // Provider impls translate this to: fetch current mode, use it.
+    ObjectRetentionConfig cfg =
+        ObjectRetentionConfig.builder()
+            .retainUntilDate(Instant.parse("2030-12-31T00:00:00Z"))
+            .build();
+
+    assertNull(cfg.getMode());
+  }
+
+  @Test
+  void bypassGovernanceRetentionIsNullableTriState() {
+    // Boolean (not boolean) preserves "not specified" — providers treat null as no-bypass.
+    ObjectRetentionConfig cfg =
+        ObjectRetentionConfig.builder()
+            .retainUntilDate(Instant.parse("2030-12-31T00:00:00Z"))
+            .build();
+
+    assertNull(cfg.getBypassGovernanceRetention());
+  }
+}

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/ObjectRetentionRulesTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/ObjectRetentionRulesTest.java
@@ -1,0 +1,191 @@
+package com.salesforce.multicloudj.blob.driver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.salesforce.multicloudj.common.exceptions.FailedPreconditionException;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct unit tests for {@link ObjectRetentionRules#resolveAndValidate}. Tests the shared
+ * rules helper in isolation without going through any provider implementation.
+ */
+class ObjectRetentionRulesTest {
+
+  private static final Instant INITIAL = Instant.parse("2030-01-01T00:00:00Z");
+  private static final Instant LATER = Instant.parse("2030-06-01T00:00:00Z");
+  private static final Instant EARLIER = Instant.parse("2029-06-01T00:00:00Z");
+
+  private ObjectRetentionConfig cfg(RetentionMode mode, Instant date, Boolean bypass) {
+    return ObjectRetentionConfig.builder()
+        .mode(mode)
+        .retainUntilDate(date)
+        .bypassGovernanceRetention(bypass)
+        .build();
+  }
+
+  // ---- No current retention -------------------------------------------------------
+
+  @Test
+  void noCurrentRetention_throws() {
+    FailedPreconditionException ex =
+        assertThrows(
+            FailedPreconditionException.class,
+            () ->
+                ObjectRetentionRules.resolveAndValidate(
+                    null, null, cfg(RetentionMode.GOVERNANCE, LATER, null)));
+    assertEquals(ObjectRetentionRules.NO_CURRENT_RETENTION_MSG, ex.getMessage());
+  }
+
+  // ---- GOVERNANCE mode -------------------------------------------------------
+
+  @Test
+  void governance_extending_succeeds() {
+    RetentionMode result =
+        ObjectRetentionRules.resolveAndValidate(
+            RetentionMode.GOVERNANCE, INITIAL, cfg(RetentionMode.GOVERNANCE, LATER, null));
+    assertEquals(RetentionMode.GOVERNANCE, result);
+  }
+
+  @Test
+  void governance_shortening_withBypass_succeeds() {
+    RetentionMode result =
+        ObjectRetentionRules.resolveAndValidate(
+            RetentionMode.GOVERNANCE, LATER, cfg(RetentionMode.GOVERNANCE, EARLIER, Boolean.TRUE));
+    assertEquals(RetentionMode.GOVERNANCE, result);
+  }
+
+  @Test
+  void governance_shortening_withoutBypass_throws() {
+    FailedPreconditionException ex =
+        assertThrows(
+            FailedPreconditionException.class,
+            () ->
+                ObjectRetentionRules.resolveAndValidate(
+                    RetentionMode.GOVERNANCE,
+                    LATER,
+                    cfg(RetentionMode.GOVERNANCE, EARLIER, Boolean.FALSE)));
+    assertEquals(ObjectRetentionRules.GOVERNANCE_SHORTEN_NO_BYPASS_MSG, ex.getMessage());
+  }
+
+  @Test
+  void governance_shortening_bypassNull_throws() {
+    assertThrows(
+        FailedPreconditionException.class,
+        () ->
+            ObjectRetentionRules.resolveAndValidate(
+                RetentionMode.GOVERNANCE, LATER, cfg(RetentionMode.GOVERNANCE, EARLIER, null)));
+  }
+
+  @Test
+  void governance_sameDate_notShortening_succeeds() {
+    RetentionMode result =
+        ObjectRetentionRules.resolveAndValidate(
+            RetentionMode.GOVERNANCE, INITIAL, cfg(RetentionMode.GOVERNANCE, INITIAL, null));
+    assertEquals(RetentionMode.GOVERNANCE, result);
+  }
+
+  // ---- COMPLIANCE mode -------------------------------------------------------
+
+  @Test
+  void compliance_extending_succeeds() {
+    RetentionMode result =
+        ObjectRetentionRules.resolveAndValidate(
+            RetentionMode.COMPLIANCE, INITIAL, cfg(RetentionMode.COMPLIANCE, LATER, null));
+    assertEquals(RetentionMode.COMPLIANCE, result);
+  }
+
+  @Test
+  void compliance_shortening_throws_evenWithBypass() {
+    FailedPreconditionException ex =
+        assertThrows(
+            FailedPreconditionException.class,
+            () ->
+                ObjectRetentionRules.resolveAndValidate(
+                    RetentionMode.COMPLIANCE,
+                    LATER,
+                    cfg(RetentionMode.COMPLIANCE, EARLIER, Boolean.TRUE)));
+    assertEquals(ObjectRetentionRules.COMPLIANCE_SHORTEN_MSG, ex.getMessage());
+  }
+
+  @Test
+  void compliance_shortening_withoutBypass_throws() {
+    assertThrows(
+        FailedPreconditionException.class,
+        () ->
+            ObjectRetentionRules.resolveAndValidate(
+                RetentionMode.COMPLIANCE, LATER, cfg(RetentionMode.COMPLIANCE, EARLIER, null)));
+  }
+
+  // ---- Mode transitions -------------------------------------------------------
+
+  @Test
+  void modeUpgrade_governanceToCompliance_withBypass_succeeds() {
+    RetentionMode result =
+        ObjectRetentionRules.resolveAndValidate(
+            RetentionMode.GOVERNANCE, INITIAL, cfg(RetentionMode.COMPLIANCE, LATER, Boolean.TRUE));
+    assertEquals(RetentionMode.COMPLIANCE, result);
+  }
+
+  @Test
+  void modeUpgrade_governanceToCompliance_withoutBypass_throws() {
+    FailedPreconditionException ex =
+        assertThrows(
+            FailedPreconditionException.class,
+            () ->
+                ObjectRetentionRules.resolveAndValidate(
+                    RetentionMode.GOVERNANCE,
+                    INITIAL,
+                    cfg(RetentionMode.COMPLIANCE, LATER, null)));
+    assertEquals(ObjectRetentionRules.MODE_UPGRADE_NO_BYPASS_MSG, ex.getMessage());
+  }
+
+  @Test
+  void modeDowngrade_complianceToGovernance_throws() {
+    FailedPreconditionException ex =
+        assertThrows(
+            FailedPreconditionException.class,
+            () ->
+                ObjectRetentionRules.resolveAndValidate(
+                    RetentionMode.COMPLIANCE,
+                    INITIAL,
+                    cfg(RetentionMode.GOVERNANCE, LATER, Boolean.TRUE)));
+    assertEquals(ObjectRetentionRules.MODE_DOWNGRADE_MSG, ex.getMessage());
+  }
+
+  // ---- Null mode (preserve current) -------------------------------------------------------
+
+  @Test
+  void modeNull_preservesGovernance() {
+    RetentionMode result =
+        ObjectRetentionRules.resolveAndValidate(
+            RetentionMode.GOVERNANCE, INITIAL, cfg(null, LATER, null));
+    assertEquals(RetentionMode.GOVERNANCE, result);
+  }
+
+  @Test
+  void modeNull_preservesCompliance() {
+    RetentionMode result =
+        ObjectRetentionRules.resolveAndValidate(
+            RetentionMode.COMPLIANCE, INITIAL, cfg(null, LATER, null));
+    assertEquals(RetentionMode.COMPLIANCE, result);
+  }
+
+  @Test
+  void modeNull_shorteningGovernance_withBypass_succeeds() {
+    RetentionMode result =
+        ObjectRetentionRules.resolveAndValidate(
+            RetentionMode.GOVERNANCE, LATER, cfg(null, EARLIER, Boolean.TRUE));
+    assertEquals(RetentionMode.GOVERNANCE, result);
+  }
+
+  @Test
+  void modeNull_shorteningCompliance_throws() {
+    assertThrows(
+        FailedPreconditionException.class,
+        () ->
+            ObjectRetentionRules.resolveAndValidate(
+                RetentionMode.COMPLIANCE, LATER, cfg(null, EARLIER, Boolean.TRUE)));
+  }
+}

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/TestBlobStore.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/TestBlobStore.java
@@ -7,7 +7,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -162,11 +161,6 @@ public class TestBlobStore extends AbstractBlobStore {
   public ObjectLockInfo getObjectLock(String key, String versionId) {
     // Test implementation - return null
     return null;
-  }
-
-  @Override
-  public void updateObjectRetention(String key, String versionId, Instant retainUntilDate) {
-    // Test implementation - no-op
   }
 
   @Override

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -1206,6 +1206,8 @@ public class GcpBlobStore extends AbstractBlobStore {
             .build();
     BlobInfo updatedBlobInfo = blob.toBuilder().setRetention(updatedRetention).build();
 
+    // GCS has no dedicated retention-only API (unlike AWS s3Client.putObjectRetention).
+    // Storage.update(BlobInfo) is a field-level patch: only the retention field we set is written.
     boolean bypass = Boolean.TRUE.equals(config.getBypassGovernanceRetention());
     if (bypass) {
       storage.update(updatedBlobInfo, Storage.BlobTargetOption.overrideUnlockedRetention(true));

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -70,6 +70,8 @@ import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration;
 import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
+import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
+import com.salesforce.multicloudj.blob.driver.ObjectRetentionRules;
 import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
@@ -1168,6 +1170,73 @@ public class GcpBlobStore extends AbstractBlobStore {
       // COMPLIANCE (LOCKED) mode - only allow increasing
       storage.update(updatedBlobInfo);
     }
+  }
+
+  /**
+   * Provider hook for {@link
+   * com.salesforce.multicloudj.blob.driver.BlobStore#updateObjectRetention(String, String,
+   * ObjectRetentionConfig)}.
+   *
+   * <p>Stateless validation has already run; this method enforces the state-dependent rules from
+   * {@link ObjectRetentionRules} (no-current-retention, mode-downgrade, shorten-with-bypass) so
+   * the GCP impl surfaces the same {@code FailedPreconditionException} types and messages as
+   * AWS and the in-memory provider.
+   */
+  @Override
+  protected void doUpdateObjectRetention(
+      String key, String versionId, ObjectRetentionConfig config) {
+    Blob blob = getRequiredBlob(transformer.toBlobId(bucket, key, versionId));
+    Retention currentRetention = blob.getRetention();
+    java.time.Instant currentRetainUntil =
+        currentRetention != null && currentRetention.getRetainUntilTime() != null
+            ? currentRetention.getRetainUntilTime().toInstant()
+            : null;
+    RetentionMode currentMode =
+        currentRetention != null
+            ? toMulticloudMode(currentRetention.getMode())
+            : null;
+
+    RetentionMode resolvedMode =
+        ObjectRetentionRules.resolveAndValidate(currentMode, currentRetainUntil, config);
+
+    Retention updatedRetention =
+        Retention.newBuilder()
+            .setMode(toGcsRetentionMode(resolvedMode))
+            .setRetainUntilTime(toUtcOffsetDateTime(config.getRetainUntilDate()))
+            .build();
+    BlobInfo updatedBlobInfo = blob.toBuilder().setRetention(updatedRetention).build();
+
+    boolean bypass = Boolean.TRUE.equals(config.getBypassGovernanceRetention());
+    if (bypass) {
+      storage.update(updatedBlobInfo, Storage.BlobTargetOption.overrideUnlockedRetention(true));
+    } else {
+      storage.update(updatedBlobInfo);
+    }
+  }
+
+  /**
+   * Converts a MultiCloudJ {@link RetentionMode} to a GCS {@link Retention.Mode}. Mapping:
+   * GOVERNANCE↔UNLOCKED, COMPLIANCE↔LOCKED.
+   */
+  private static Retention.Mode toGcsRetentionMode(RetentionMode mode) {
+    return mode == RetentionMode.COMPLIANCE ? Retention.Mode.LOCKED : Retention.Mode.UNLOCKED;
+  }
+
+  /** Inverse of {@link #toGcsRetentionMode(RetentionMode)}. */
+  private static RetentionMode toMulticloudMode(Retention.Mode mode) {
+    if (mode == null) {
+      return null;
+    }
+    return mode == Retention.Mode.LOCKED ? RetentionMode.COMPLIANCE : RetentionMode.GOVERNANCE;
+  }
+
+  /**
+   * Converts an {@link java.time.Instant} to a UTC-anchored {@link java.time.OffsetDateTime} for
+   * GCS API calls. Sub-millisecond precision is truncated by GCS server-side; document on
+   * {@link ObjectRetentionConfig#getRetainUntilDate()}.
+   */
+  private static java.time.OffsetDateTime toUtcOffsetDateTime(java.time.Instant instant) {
+    return java.time.OffsetDateTime.ofInstant(instant, java.time.ZoneOffset.UTC);
   }
 
   /** Updates legal hold status on an object. */

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -4095,4 +4095,177 @@ class GcpBlobStoreTest {
       verify(mockStorage, never()).list(anyString(), any(Storage.BlobListOption[].class));
     }
   }
+
+  // ---- New overload: updateObjectRetention(String, String, ObjectRetentionConfig) ----
+
+  /** Minimal helper to mock the Blob → Builder → BlobInfo chain consistently for retention. */
+  private Blob mockBlobWithRetention(
+      com.google.cloud.storage.BlobInfo.Retention.Mode mode,
+      java.time.OffsetDateTime currentRetainUntil) {
+    com.google.cloud.storage.BlobInfo.Retention currentRetention =
+        com.google.cloud.storage.BlobInfo.Retention.newBuilder()
+            .setMode(mode)
+            .setRetainUntilTime(currentRetainUntil)
+            .build();
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getRetention()).thenReturn(currentRetention);
+    com.google.cloud.storage.Blob.Builder blobBuilder =
+        mock(com.google.cloud.storage.Blob.Builder.class);
+    lenient().when(mockBlob.toBuilder()).thenReturn(blobBuilder);
+    lenient()
+        .when(blobBuilder.setRetention(any(com.google.cloud.storage.BlobInfo.Retention.class)))
+        .thenReturn(blobBuilder);
+    Blob mockBuiltBlob = mock(Blob.class);
+    lenient().when(blobBuilder.build()).thenReturn(mockBuiltBlob);
+    Blob mockUpdatedBlob = mock(Blob.class);
+    lenient()
+        .when(
+            mockStorage.update(
+                any(com.google.cloud.storage.BlobInfo.class), any(Storage.BlobTargetOption.class)))
+        .thenReturn(mockUpdatedBlob);
+    lenient()
+        .when(mockStorage.update(any(com.google.cloud.storage.BlobInfo.class)))
+        .thenReturn(mockUpdatedBlob);
+    return mockBlob;
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_governanceExtend_callsUpdateWithoutOverride() {
+    String key = "test-key";
+    java.time.OffsetDateTime currentRetainUntil =
+        java.time.OffsetDateTime.now().plusSeconds(3600);
+    java.time.Instant newRetainUntil = currentRetainUntil.toInstant().plusSeconds(3600);
+    Blob mockBlob =
+        mockBlobWithRetention(
+            com.google.cloud.storage.BlobInfo.Retention.Mode.UNLOCKED, currentRetainUntil);
+    when(mockTransformer.toBlobId(eq(TEST_BUCKET), eq(key), any())).thenReturn(mockBlobId);
+    when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(newRetainUntil)
+            .build();
+
+    gcpBlobStore.updateObjectRetention(key, null, cfg);
+
+    verify(mockStorage).update(any(com.google.cloud.storage.BlobInfo.class));
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_governanceShortenWithBypass_callsUpdateWithOverride() {
+    String key = "test-key";
+    java.time.OffsetDateTime currentRetainUntil =
+        java.time.OffsetDateTime.now().plusSeconds(7200);
+    java.time.Instant newRetainUntil = currentRetainUntil.toInstant().minusSeconds(3600);
+    Blob mockBlob =
+        mockBlobWithRetention(
+            com.google.cloud.storage.BlobInfo.Retention.Mode.UNLOCKED, currentRetainUntil);
+    when(mockTransformer.toBlobId(eq(TEST_BUCKET), eq(key), any())).thenReturn(mockBlobId);
+    when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(newRetainUntil)
+            .bypassGovernanceRetention(Boolean.TRUE)
+            .build();
+
+    gcpBlobStore.updateObjectRetention(key, null, cfg);
+
+    ArgumentCaptor<Storage.BlobTargetOption> captor =
+        ArgumentCaptor.forClass(Storage.BlobTargetOption.class);
+    verify(mockStorage)
+        .update(any(com.google.cloud.storage.BlobInfo.class), captor.capture());
+    assertEquals(Storage.BlobTargetOption.overrideUnlockedRetention(true), captor.getValue());
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_governanceShortenNoBypass_throws() {
+    String key = "test-key";
+    java.time.OffsetDateTime currentRetainUntil =
+        java.time.OffsetDateTime.now().plusSeconds(7200);
+    java.time.Instant newRetainUntil = currentRetainUntil.toInstant().minusSeconds(3600);
+    Blob mockBlob =
+        mockBlobWithRetention(
+            com.google.cloud.storage.BlobInfo.Retention.Mode.UNLOCKED, currentRetainUntil);
+    when(mockTransformer.toBlobId(eq(TEST_BUCKET), eq(key), any())).thenReturn(mockBlobId);
+    when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(newRetainUntil)
+            .build();
+
+    org.junit.jupiter.api.Assertions.assertThrows(
+        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        () -> gcpBlobStore.updateObjectRetention(key, null, cfg));
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_complianceShortenEvenWithBypass_throws() {
+    String key = "test-key";
+    java.time.OffsetDateTime currentRetainUntil =
+        java.time.OffsetDateTime.now().plusSeconds(7200);
+    java.time.Instant newRetainUntil = currentRetainUntil.toInstant().minusSeconds(3600);
+    Blob mockBlob =
+        mockBlobWithRetention(
+            com.google.cloud.storage.BlobInfo.Retention.Mode.LOCKED, currentRetainUntil);
+    when(mockTransformer.toBlobId(eq(TEST_BUCKET), eq(key), any())).thenReturn(mockBlobId);
+    when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.COMPLIANCE)
+            .retainUntilDate(newRetainUntil)
+            .bypassGovernanceRetention(Boolean.TRUE)
+            .build();
+
+    org.junit.jupiter.api.Assertions.assertThrows(
+        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        () -> gcpBlobStore.updateObjectRetention(key, null, cfg));
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_modeDowngrade_throws() {
+    String key = "test-key";
+    java.time.OffsetDateTime currentRetainUntil =
+        java.time.OffsetDateTime.now().plusSeconds(3600);
+    java.time.Instant newRetainUntil = currentRetainUntil.toInstant().plusSeconds(3600);
+    Blob mockBlob =
+        mockBlobWithRetention(
+            com.google.cloud.storage.BlobInfo.Retention.Mode.LOCKED, currentRetainUntil);
+    when(mockTransformer.toBlobId(eq(TEST_BUCKET), eq(key), any())).thenReturn(mockBlobId);
+    when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(newRetainUntil)
+            .build();
+
+    org.junit.jupiter.api.Assertions.assertThrows(
+        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        () -> gcpBlobStore.updateObjectRetention(key, null, cfg));
+  }
+
+  @Test
+  void testUpdateObjectRetentionConfig_noCurrentRetention_throws() {
+    String key = "test-key";
+    Blob mockBlob = mock(Blob.class);
+    when(mockBlob.getRetention()).thenReturn(null);
+    when(mockTransformer.toBlobId(eq(TEST_BUCKET), eq(key), any())).thenReturn(mockBlobId);
+    when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig cfg =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(java.time.Instant.now().plusSeconds(3600))
+            .build();
+
+    org.junit.jupiter.api.Assertions.assertThrows(
+        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        () -> gcpBlobStore.updateObjectRetention(key, null, cfg));
+  }
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "b0b6de11-edec-4c95-b245-1d42b36b9cdb",
+  "id" : "17ca2a2b-f758-4060-b3f8-2598108307aa",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-DELETE-0",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEj_9yMXKj5NPjaz3YOc5K2nFi6iJF_dAHJdLOYda0ylc50POCIA66l59ZcdBRSID-fr",
+      "X-GUploader-UploadID" : "AAVLpEiwpzPt8Ik2ZfE4jiDOqOl9j3AOmUdyaCXTTDHjhVs75Rl6XqQnBHYjojBm0YePALgm",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:15 GMT",
+      "Date" : "Thu, 14 May 2026 07:40:06 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "b0b6de11-edec-4c95-b245-1d42b36b9cdb",
+  "uuid" : "17ca2a2b-f758-4060-b3f8-2598108307aa",
   "persistent" : true,
-  "insertionIndex" : 1289
+  "insertionIndex" : 1286
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "b0b6de11-edec-4c95-b245-1d42b36b9cdb",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEj_9yMXKj5NPjaz3YOc5K2nFi6iJF_dAHJdLOYda0ylc50POCIA66l59ZcdBRSID-fr",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:15 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "b0b6de11-edec-4c95-b245-1d42b36b9cdb",
+  "persistent" : true,
+  "insertionIndex" : 1289
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "c6a89a00-f909-4a78-a527-5c8e06d0d03c",
+  "id" : "13b43c70-b52a-4677-a235-9c987bcecc76",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-1",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -29,14 +29,14 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AAVLpEgUIWaj9KnMZZhIcNUHRZmNYFn0BmgEz9t1csuZ7OaCLIevvzmDE1Fq4eDqyXJ542m1",
+      "X-GUploader-UploadID" : "AAVLpEhnpZT5evCKA_ExxiEW_UwX521xpFTjDLejGHo6wTJLjlf67zOT5sKOFgKmG912m-Xv",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:14 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:14 GMT",
+      "Expires" : "Thu, 14 May 2026 07:40:05 GMT",
+      "Date" : "Thu, 14 May 2026 07:40:05 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "c6a89a00-f909-4a78-a527-5c8e06d0d03c",
+  "uuid" : "13b43c70-b52a-4677-a235-9c987bcecc76",
   "persistent" : true,
-  "insertionIndex" : 1290
+  "insertionIndex" : 1287
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "c6a89a00-f909-4a78-a527-5c8e06d0d03c",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEgUIWaj9KnMZZhIcNUHRZmNYFn0BmgEz9t1csuZ7OaCLIevvzmDE1Fq4eDqyXJ542m1",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:14 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:14 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "c6a89a00-f909-4a78-a527-5c8e06d0d03c",
+  "persistent" : true,
+  "insertionIndex" : 1290
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "0dd68e2c-c525-42ab-a451-21d82c175a54",
+  "id" : "a4a5dbb3-b581-4a20-9179-350090791acc",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-2",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend",
@@ -19,22 +19,22 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778497632408813\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778497632408813&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497632408813\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CO2p9PyLsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:12.467Z\",\n  \"updated\": \"2026-05-11T11:07:14.006Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:12.467Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778744403417903\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778744403417903&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744403417903\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CK+2v6KjuJQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:40:03.476Z\",\n  \"updated\": \"2026-05-14T07:40:04.771Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:40:03.476Z\",\n  \"timeFinalized\": \"2026-05-14T07:40:03.476Z\",\n  \"metadata\": {\n    \"correlation-id\": \"0165002f-1232-4eff-a663-01cb465ce37f\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CO2p9PyLsZQDEAI=",
-      "X-GUploader-UploadID" : "AAVLpEjci87RVT4GjoptP3iAw3gmhgIo4sOngjdhJ_rBQZcmqCYnidG9dCv6shkHdnkWUX1w",
+      "ETag" : "CK+2v6KjuJQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEiApeSiu1lySErDKO4nKbjhbn1L_D8E5nJnRxpt7a0yLWSio2diDdeE53WQjMinCcasA4-KY9g",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:14 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:14 GMT",
+      "Expires" : "Thu, 14 May 2026 07:40:05 GMT",
+      "Date" : "Thu, 14 May 2026 07:40:05 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "0dd68e2c-c525-42ab-a451-21d82c175a54",
+  "uuid" : "a4a5dbb3-b581-4a20-9179-350090791acc",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend-3",
-  "insertionIndex" : 1291
+  "insertionIndex" : 1288
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-2.json
@@ -1,0 +1,40 @@
+{
+  "id" : "0dd68e2c-c525-42ab-a451-21d82c175a54",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-2",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778497632408813\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778497632408813&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497632408813\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CO2p9PyLsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:12.467Z\",\n  \"updated\": \"2026-05-11T11:07:14.006Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:12.467Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CO2p9PyLsZQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEjci87RVT4GjoptP3iAw3gmhgIo4sOngjdhJ_rBQZcmqCYnidG9dCv6shkHdnkWUX1w",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:14 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:14 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "0dd68e2c-c525-42ab-a451-21d82c175a54",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend-3",
+  "insertionIndex" : 1291
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-4.json
@@ -1,0 +1,41 @@
+{
+  "id" : "d5163049-7c4a-4cf9-9830-c33658882061",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-4",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778497632408813\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778497632408813&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497632408813\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CO2p9PyLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:12.467Z\",\n  \"updated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:12.467Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CO2p9PyLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEiDUJsRltAth0wYLSKFiM0poLaLgk-2-MNyjdljLCnAfCrwClxp90li_FSNpBUSxsVQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:13 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:13 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "d5163049-7c4a-4cf9-9830-c33658882061",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend-2",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend-3",
+  "insertionIndex" : 1293
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "d5163049-7c4a-4cf9-9830-c33658882061",
+  "id" : "4fc35063-9abb-4dbc-90e6-021e9b775f51",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-4",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778497632408813\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778497632408813&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497632408813\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CO2p9PyLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:12.467Z\",\n  \"updated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:12.467Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778744403417903\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778744403417903&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744403417903\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CK+2v6KjuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:40:03.476Z\",\n  \"updated\": \"2026-05-14T07:40:03.476Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:40:03.476Z\",\n  \"timeFinalized\": \"2026-05-14T07:40:03.476Z\",\n  \"metadata\": {\n    \"correlation-id\": \"0165002f-1232-4eff-a663-01cb465ce37f\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CO2p9PyLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEiDUJsRltAth0wYLSKFiM0poLaLgk-2-MNyjdljLCnAfCrwClxp90li_FSNpBUSxsVQ",
+      "ETag" : "CK+2v6KjuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEgTEIEkZjzS-MHcMKPoCoZE-5nB_KM7B5x7QamS1umaQQW_ITGzS8zIwJKM6D5r4X6o",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:13 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:13 GMT",
+      "Expires" : "Thu, 14 May 2026 07:40:04 GMT",
+      "Date" : "Thu, 14 May 2026 07:40:04 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "d5163049-7c4a-4cf9-9830-c33658882061",
+  "uuid" : "4fc35063-9abb-4dbc-90e6-021e9b775f51",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend-2",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend-3",
-  "insertionIndex" : 1293
+  "insertionIndex" : 1290
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-5.json
@@ -1,5 +1,5 @@
 {
-  "id" : "34c00779-5f93-4114-9a9e-e7ff22b1210d",
+  "id" : "0184c6b6-c14f-4f38-9b4e-04e93a21c677",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-5",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778497632408813\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778497632408813&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497632408813\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CO2p9PyLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:12.467Z\",\n  \"updated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:12.467Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778744403417903\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778744403417903&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744403417903\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CK+2v6KjuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:40:03.476Z\",\n  \"updated\": \"2026-05-14T07:40:03.476Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:40:03.476Z\",\n  \"timeFinalized\": \"2026-05-14T07:40:03.476Z\",\n  \"metadata\": {\n    \"correlation-id\": \"0165002f-1232-4eff-a663-01cb465ce37f\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CO2p9PyLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEhvySw8mvrIj9dPoNFRsTXKIoKdC275ftbg_TYHJHb72uSirhGyQ7cOVFUITYre2_fa",
+      "ETag" : "CK+2v6KjuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhNZrq_JI-zixRnlV2D9tLzNVXQNGQ4YVk40zJ1TcBDO2wTQmg1z6W97bPFCsNdxupkRp7Y5rY",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:12 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:12 GMT",
+      "Expires" : "Thu, 14 May 2026 07:40:03 GMT",
+      "Date" : "Thu, 14 May 2026 07:40:03 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "34c00779-5f93-4114-9a9e-e7ff22b1210d",
+  "uuid" : "0184c6b6-c14f-4f38-9b4e-04e93a21c677",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend-2",
-  "insertionIndex" : 1294
+  "insertionIndex" : 1291
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-5.json
@@ -1,0 +1,41 @@
+{
+  "id" : "34c00779-5f93-4114-9a9e-e7ff22b1210d",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-5",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778497632408813\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778497632408813&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497632408813\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CO2p9PyLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:12.467Z\",\n  \"updated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:12.467Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CO2p9PyLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhvySw8mvrIj9dPoNFRsTXKIoKdC275ftbg_TYHJHb72uSirhGyQ7cOVFUITYre2_fa",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:12 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:12 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "34c00779-5f93-4114-9a9e-e7ff22b1210d",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-extend-2",
+  "insertionIndex" : 1294
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-post-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-post-3.json
@@ -1,44 +1,51 @@
 {
-  "id" : "d751f0b2-8ee5-4669-b0aa-046cb2c5f4ea",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-POST-3",
-  "request" : {
-    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "1"
+  "id": "ab79721a-44aa-431b-a08d-76f0dedcf226",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-POST-3",
+  "request": {
+    "urlPath": "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "1"
       }
     },
-    "queryParameters" : {
-      "projection" : {
-        "hasExactly" : [ {
-          "equalTo" : "full"
-        } ]
+    "queryParameters": {
+      "projection": {
+        "hasExactly": [
+          {
+            "equalTo": "full"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778497632408813\",\"name\":\"conformance-tests/objectlock/update/comp-extend\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"}}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778744403417903\",\"name\":\"conformance-tests/objectlock/update/comp-extend\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"}}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778497632408813\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778497632408813&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497632408813\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CO2p9PyLsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:12.467Z\",\n  \"updated\": \"2026-05-11T11:07:14.006Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:12.467Z\"\n}\n",
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CO2p9PyLsZQDEAI=",
-      "X-GUploader-UploadID" : "AAVLpEi8Vzmv7RnYyIbAIG5-di2BlfL2v9UYPq-57k0OjGDzr3NqzxiWSJjJGkXvF6f_miU",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:14 GMT",
-      "Content-Type" : "application/json; charset=UTF-8"
+  "response": {
+    "status": 200,
+    "body": "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778744403417903\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778744403417903&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744403417903\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CK+2v6KjuJQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:40:03.476Z\",\n  \"updated\": \"2026-05-14T07:40:04.771Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:40:03.476Z\",\n  \"timeFinalized\": \"2026-05-14T07:40:03.476Z\",\n  \"metadata\": {\n    \"correlation-id\": \"0165002f-1232-4eff-a663-01cb465ce37f\"\n  }\n}\n",
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag": "CK+2v6KjuJQDEAI=",
+      "X-GUploader-UploadID": "AAVLpEhyZSfRQcQ_nsnzuvfilrbvtKO_h-0wPuvy6WOTQ5hbHAZ3r9GyP1oWf6KWCgrJpecG",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:40:04 GMT",
+      "Content-Type": "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "d751f0b2-8ee5-4669-b0aa-046cb2c5f4ea",
-  "persistent" : true,
-  "insertionIndex" : 1292
+  "uuid": "ab79721a-44aa-431b-a08d-76f0dedcf226",
+  "persistent": true,
+  "insertionIndex": 1289
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-post-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-post-3.json
@@ -1,0 +1,44 @@
+{
+  "id" : "d751f0b2-8ee5-4669-b0aa-046cb2c5f4ea",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-POST-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778497632408813\",\"name\":\"conformance-tests/objectlock/update/comp-extend\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"}}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778497632408813\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778497632408813&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497632408813\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CO2p9PyLsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:12.467Z\",\n  \"updated\": \"2026-05-11T11:07:14.006Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:12.467Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CO2p9PyLsZQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEi8Vzmv7RnYyIbAIG5-di2BlfL2v9UYPq-57k0OjGDzr3NqzxiWSJjJGkXvF6f_miU",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:14 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "d751f0b2-8ee5-4669-b0aa-046cb2c5f4ea",
+  "persistent" : true,
+  "insertionIndex" : 1292
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-post-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-post-7.json
@@ -1,48 +1,57 @@
 {
-  "id" : "69638e0c-e7d0-4066-854f-879c41fe12a6",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-POST-7",
-  "request" : {
-    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "2"
+  "id": "fad8e41f-ad80-4b3e-9509-9417c373fe9a",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-POST-7",
+  "request": {
+    "urlPath": "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "2"
       }
     },
-    "queryParameters" : {
-      "name" : {
-        "hasExactly" : [ {
-          "equalTo" : "conformance-tests/objectlock/update/comp-extend"
-        } ]
+    "queryParameters": {
+      "name": {
+        "hasExactly": [
+          {
+            "equalTo": "conformance-tests/objectlock/update/comp-extend"
+          }
+        ]
       },
-      "uploadType" : {
-        "hasExactly" : [ {
-          "equalTo" : "resumable"
-        } ]
+      "uploadType": {
+        "hasExactly": [
+          {
+            "equalTo": "resumable"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/comp-extend\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/comp-extend\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEgPe_eH_N26baYQiXIBrlJxqsQSJbBW5PuJ5CLBD4QHngmRH6Mn7K9_wv84r1ZVfdtZxqForvxl3CHcjUB1Ob4HUJOjFL4XSqJPfkxMmg",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:11 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/comp-extend&uploadType=resumable&upload_id=AAVLpEgPe_eH_N26baYQiXIBrlJxqsQSJbBW5PuJ5CLBD4QHngmRH6Mn7K9_wv84r1ZVfdtZxqForvxl3CHcjUB1Ob4HUJOjFL4XSqJPfkxMmg",
-      "Content-Type" : "text/plain; charset=utf-8"
+  "response": {
+    "status": 200,
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID": "AAVLpEjdA4mTOfgeNVFy20dYVirqfniTDtg6LefU9Zecq8ujkpvKF6hpLEjROWA6P10BXMyVzArQGpgXpROWnCD0o1h2vbPrTHkyikQTRy339g",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:40:02 GMT",
+      "Location": "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/comp-extend&uploadType=resumable&upload_id=AAVLpEjdA4mTOfgeNVFy20dYVirqfniTDtg6LefU9Zecq8ujkpvKF6hpLEjROWA6P10BXMyVzArQGpgXpROWnCD0o1h2vbPrTHkyikQTRy339g",
+      "Content-Type": "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "69638e0c-e7d0-4066-854f-879c41fe12a6",
-  "persistent" : true,
-  "insertionIndex" : 1296
+  "uuid": "fad8e41f-ad80-4b3e-9509-9417c373fe9a",
+  "persistent": true,
+  "insertionIndex": 1293
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-post-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-post-7.json
@@ -1,0 +1,48 @@
+{
+  "id" : "69638e0c-e7d0-4066-854f-879c41fe12a6",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-POST-7",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/comp-extend"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/comp-extend\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEgPe_eH_N26baYQiXIBrlJxqsQSJbBW5PuJ5CLBD4QHngmRH6Mn7K9_wv84r1ZVfdtZxqForvxl3CHcjUB1Ob4HUJOjFL4XSqJPfkxMmg",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:11 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/comp-extend&uploadType=resumable&upload_id=AAVLpEgPe_eH_N26baYQiXIBrlJxqsQSJbBW5PuJ5CLBD4QHngmRH6Mn7K9_wv84r1ZVfdtZxqForvxl3CHcjUB1Ob4HUJOjFL4XSqJPfkxMmg",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "69638e0c-e7d0-4066-854f-879c41fe12a6",
+  "persistent" : true,
+  "insertionIndex" : 1296
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-6.json
@@ -1,5 +1,5 @@
 {
-  "id" : "91fb3c4d-ffde-4f73-be0a-a659abb8b805",
+  "id" : "b1cd42af-8e8d-4b49-9f98-d2b7ee879c17",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-PUT-6",
   "request" : {
     "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -22,7 +22,7 @@
       },
       "upload_id" : {
         "hasExactly" : [ {
-          "equalTo" : "AAVLpEgPe_eH_N26baYQiXIBrlJxqsQSJbBW5PuJ5CLBD4QHngmRH6Mn7K9_wv84r1ZVfdtZxqForvxl3CHcjUB1Ob4HUJOjFL4XSqJPfkxMmg"
+          "equalTo" : "AAVLpEjdA4mTOfgeNVFy20dYVirqfniTDtg6LefU9Zecq8ujkpvKF6hpLEjROWA6P10BXMyVzArQGpgXpROWnCD0o1h2vbPrTHkyikQTRy339g"
         } ]
       }
     },
@@ -33,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778497632408813\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778497632408813&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497632408813\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CO2p9PyLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:12.467Z\",\n  \"updated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:12.467Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778744403417903\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778744403417903&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744403417903\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CK+2v6KjuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:40:03.476Z\",\n  \"updated\": \"2026-05-14T07:40:03.476Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:40:03.476Z\",\n  \"timeFinalized\": \"2026-05-14T07:40:03.476Z\",\n  \"metadata\": {\n    \"correlation-id\": \"0165002f-1232-4eff-a663-01cb465ce37f\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CO2p9PyLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEgPe_eH_N26baYQiXIBrlJxqsQSJbBW5PuJ5CLBD4QHngmRH6Mn7K9_wv84r1ZVfdtZxqForvxl3CHcjUB1Ob4HUJOjFL4XSqJPfkxMmg",
+      "ETag" : "CK+2v6KjuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjdA4mTOfgeNVFy20dYVirqfniTDtg6LefU9Zecq8ujkpvKF6hpLEjROWA6P10BXMyVzArQGpgXpROWnCD0o1h2vbPrTHkyikQTRy339g",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:12 GMT",
+      "Date" : "Thu, 14 May 2026 07:40:03 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "91fb3c4d-ffde-4f73-be0a-a659abb8b805",
+  "uuid" : "b1cd42af-8e8d-4b49-9f98-d2b7ee879c17",
   "persistent" : true,
-  "insertionIndex" : 1295
+  "insertionIndex" : 1292
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-6.json
@@ -1,0 +1,53 @@
+{
+  "id" : "91fb3c4d-ffde-4f73-be0a-a659abb8b805",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-PUT-6",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/comp-extend"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AAVLpEgPe_eH_N26baYQiXIBrlJxqsQSJbBW5PuJ5CLBD4QHngmRH6Mn7K9_wv84r1ZVfdtZxqForvxl3CHcjUB1Ob4HUJOjFL4XSqJPfkxMmg"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "retention-update-conformance-tests/objectlock/update/comp-extend",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-extend/1778497632408813\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-extend?generation=1778497632408813&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497632408813\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"64\",\n  \"md5Hash\": \"vWPifY4f/HsqfoKrZKIf6g==\",\n  \"crc32c\": \"WUEpvQ==\",\n  \"etag\": \"CO2p9PyLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:12.467Z\",\n  \"updated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:12.467Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:12.467Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CO2p9PyLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEgPe_eH_N26baYQiXIBrlJxqsQSJbBW5PuJ5CLBD4QHngmRH6Mn7K9_wv84r1ZVfdtZxqForvxl3CHcjUB1Ob4HUJOjFL4XSqJPfkxMmg",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:12 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "91fb3c4d-ffde-4f73-be0a-a659abb8b805",
+  "persistent" : true,
+  "insertionIndex" : 1295
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "b90bf92c-59d3-4254-b39f-644f580e4d92",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEjQhTSuPQLvo9P990MK7bEeY5hkATkNGeVcDAf1Y-_2-_PpS0NBVl8LjDXPyZDxDYbS",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:33 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "b90bf92c-59d3-4254-b39f-644f580e4d92",
+  "persistent" : true,
+  "insertionIndex" : 1325
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "b90bf92c-59d3-4254-b39f-644f580e4d92",
+  "id" : "1938d698-8015-4cd7-9781-34ed58f25949",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-DELETE-0",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEjQhTSuPQLvo9P990MK7bEeY5hkATkNGeVcDAf1Y-_2-_PpS0NBVl8LjDXPyZDxDYbS",
+      "X-GUploader-UploadID" : "AAVLpEhVjVG7lQlPJ40O2TAEPc1a_Uig033aiYdLmNx78uJ87Qb4642nKh2tqIFxbbPv-k06",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:33 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:11 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "b90bf92c-59d3-4254-b39f-644f580e4d92",
+  "uuid" : "1938d698-8015-4cd7-9781-34ed58f25949",
   "persistent" : true,
-  "insertionIndex" : 1325
+  "insertionIndex" : 1283
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "2902da2d-210e-443f-9c34-19a32547fd48",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEgyUIZHS30g9UPl3-zTIMkmq6bR1fe0YkkPeUiCBL6eQGjA_1Jv_sesfi1cTp8ZDQo",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:32 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:32 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "2902da2d-210e-443f-9c34-19a32547fd48",
+  "persistent" : true,
+  "insertionIndex" : 1326
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "2902da2d-210e-443f-9c34-19a32547fd48",
+  "id" : "1ecc78d9-a894-4442-b91b-94aef970f27c",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-GET-1",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -29,14 +29,14 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AAVLpEgyUIZHS30g9UPl3-zTIMkmq6bR1fe0YkkPeUiCBL6eQGjA_1Jv_sesfi1cTp8ZDQo",
+      "X-GUploader-UploadID" : "AAVLpEiZRODPOA77DqhcnNjVOZVH0sVbpmbfAU3sKIYRV-ri0zjDd86wm-NKwtLBll3hticy",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:32 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:32 GMT",
+      "Expires" : "Thu, 14 May 2026 07:31:10 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:10 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "2902da2d-210e-443f-9c34-19a32547fd48",
+  "uuid" : "1ecc78d9-a894-4442-b91b-94aef970f27c",
   "persistent" : true,
-  "insertionIndex" : 1326
+  "insertionIndex" : 1284
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-2.json
@@ -1,0 +1,40 @@
+{
+  "id" : "da377e6a-fe76-4b19-b5bc-b9589ba2b4e4",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-GET-2",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-shorten-bypass/1778497651527006\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass?generation=1778497651527006&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497651527006\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"72\",\n  \"md5Hash\": \"wicn2LBadL9o97ZE+jiOdA==\",\n  \"crc32c\": \"fhORSA==\",\n  \"etag\": \"CN6ag4aMsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:31.585Z\",\n  \"updated\": \"2026-05-11T11:07:31.585Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:31.585Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:31.585Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CN6ag4aMsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhveQvDBgnkZN1oeqcxFdvYeCgWI-eD2Ln7WQq5E-HFJBqvFIHO2PE2z_YP0jGNtpnG",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:32 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:32 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "da377e6a-fe76-4b19-b5bc-b9589ba2b4e4",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-shorten-bypass",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-shorten-bypass-2",
+  "insertionIndex" : 1327
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "da377e6a-fe76-4b19-b5bc-b9589ba2b4e4",
+  "id" : "84058b56-0d6e-47e1-8bbf-8bf34b22338a",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-GET-2",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass",
@@ -19,22 +19,22 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-shorten-bypass/1778497651527006\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass?generation=1778497651527006&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497651527006\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"72\",\n  \"md5Hash\": \"wicn2LBadL9o97ZE+jiOdA==\",\n  \"crc32c\": \"fhORSA==\",\n  \"etag\": \"CN6ag4aMsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:31.585Z\",\n  \"updated\": \"2026-05-11T11:07:31.585Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:31.585Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:31.585Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-shorten-bypass/1778743869716724\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass?generation=1778743869716724&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743869716724\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"72\",\n  \"md5Hash\": \"wicn2LBadL9o97ZE+jiOdA==\",\n  \"crc32c\": \"fhORSA==\",\n  \"etag\": \"CPTxgKShuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:09.773Z\",\n  \"updated\": \"2026-05-14T07:31:09.773Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:09.773Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:09.773Z\",\n  \"metadata\": {\n    \"correlation-id\": \"0731e68f-c63f-425d-8e65-faa8588cd5ac\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CN6ag4aMsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEhveQvDBgnkZN1oeqcxFdvYeCgWI-eD2Ln7WQq5E-HFJBqvFIHO2PE2z_YP0jGNtpnG",
+      "ETag" : "CPTxgKShuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhZ9HFjjvIoHMYDkjeKs1l_eh-QbnRjh5w4fLYFcdwjgV9vBHbrG8OPlDDD6mbIEkFM",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:32 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:32 GMT",
+      "Expires" : "Thu, 14 May 2026 07:31:10 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:10 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "da377e6a-fe76-4b19-b5bc-b9589ba2b4e4",
+  "uuid" : "84058b56-0d6e-47e1-8bbf-8bf34b22338a",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-shorten-bypass",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-shorten-bypass-2",
-  "insertionIndex" : 1327
+  "insertionIndex" : 1285
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "4a0caa7a-3ec4-418c-beb7-d0a54dcda507",
+  "id" : "94597f1f-fe4c-4f5f-87e4-ae942a199b85",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-GET-3",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-shorten-bypass/1778497651527006\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass?generation=1778497651527006&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497651527006\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"72\",\n  \"md5Hash\": \"wicn2LBadL9o97ZE+jiOdA==\",\n  \"crc32c\": \"fhORSA==\",\n  \"etag\": \"CN6ag4aMsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:31.585Z\",\n  \"updated\": \"2026-05-11T11:07:31.585Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:31.585Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:31.585Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-shorten-bypass/1778743869716724\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass?generation=1778743869716724&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743869716724\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"72\",\n  \"md5Hash\": \"wicn2LBadL9o97ZE+jiOdA==\",\n  \"crc32c\": \"fhORSA==\",\n  \"etag\": \"CPTxgKShuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:09.773Z\",\n  \"updated\": \"2026-05-14T07:31:09.773Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:09.773Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:09.773Z\",\n  \"metadata\": {\n    \"correlation-id\": \"0731e68f-c63f-425d-8e65-faa8588cd5ac\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CN6ag4aMsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEivilZi_IDYuc6sQaD_cx5jzCLP9HWMQZMpTe_IiDdK-JIWZN9DWllkhRgPSWdaKox6FVPgI_k",
+      "ETag" : "CPTxgKShuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEieEdae5Qm5F2XvFgBhqw1zREODp9qz4IWlBoSDlvCtSIhcZKO1GOlKcLsScBIRC-xI",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:32 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:32 GMT",
+      "Expires" : "Thu, 14 May 2026 07:31:10 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:10 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "4a0caa7a-3ec4-418c-beb7-d0a54dcda507",
+  "uuid" : "94597f1f-fe4c-4f5f-87e4-ae942a199b85",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-shorten-bypass",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-shorten-bypass-2",
-  "insertionIndex" : 1328
+  "insertionIndex" : 1286
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-3.json
@@ -1,0 +1,41 @@
+{
+  "id" : "4a0caa7a-3ec4-418c-beb7-d0a54dcda507",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-GET-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-shorten-bypass/1778497651527006\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass?generation=1778497651527006&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497651527006\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"72\",\n  \"md5Hash\": \"wicn2LBadL9o97ZE+jiOdA==\",\n  \"crc32c\": \"fhORSA==\",\n  \"etag\": \"CN6ag4aMsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:31.585Z\",\n  \"updated\": \"2026-05-11T11:07:31.585Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:31.585Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:31.585Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CN6ag4aMsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEivilZi_IDYuc6sQaD_cx5jzCLP9HWMQZMpTe_IiDdK-JIWZN9DWllkhRgPSWdaKox6FVPgI_k",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:32 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:32 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "4a0caa7a-3ec4-418c-beb7-d0a54dcda507",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-shorten-bypass",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-comp-shorten-bypass-2",
+  "insertionIndex" : 1328
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-post-5.json
@@ -1,48 +1,57 @@
 {
-  "id" : "c0accdaf-483a-4f76-a6ef-d8b4b3370b86",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-POST-5",
-  "request" : {
-    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "2"
+  "id": "71612810-9132-4921-9160-e4b1c2392c9f",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-POST-5",
+  "request": {
+    "urlPath": "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "2"
       }
     },
-    "queryParameters" : {
-      "name" : {
-        "hasExactly" : [ {
-          "equalTo" : "conformance-tests/objectlock/update/comp-shorten-bypass"
-        } ]
+    "queryParameters": {
+      "name": {
+        "hasExactly": [
+          {
+            "equalTo": "conformance-tests/objectlock/update/comp-shorten-bypass"
+          }
+        ]
       },
-      "uploadType" : {
-        "hasExactly" : [ {
-          "equalTo" : "resumable"
-        } ]
+      "uploadType": {
+        "hasExactly": [
+          {
+            "equalTo": "resumable"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/comp-shorten-bypass\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"},\"temporaryHold\":false}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/comp-shorten-bypass\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEjZQAriCfbQiZhucStrUgUiI58g7rNtsrRHU_uNxmD4CzgbSfI-TDfLe_uq99vjKOHyRtNimDy-V6Yccl9u4VX3mH_hT4PNZrahp6lQgQ",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:31 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/comp-shorten-bypass&uploadType=resumable&upload_id=AAVLpEjZQAriCfbQiZhucStrUgUiI58g7rNtsrRHU_uNxmD4CzgbSfI-TDfLe_uq99vjKOHyRtNimDy-V6Yccl9u4VX3mH_hT4PNZrahp6lQgQ",
-      "Content-Type" : "text/plain; charset=utf-8"
+  "response": {
+    "status": 200,
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID": "AAVLpEgf2n1Uq--eiYBQjWpBTpQyPeVu_osP_BtSsuCAN5iTHpXaSE7-ZpztXlzke-T00hyivXCIqT7QM5w4qPTHhmMQuTRpS5A9XYFTS2fVQQ",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:31:09 GMT",
+      "Location": "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/comp-shorten-bypass&uploadType=resumable&upload_id=AAVLpEgf2n1Uq--eiYBQjWpBTpQyPeVu_osP_BtSsuCAN5iTHpXaSE7-ZpztXlzke-T00hyivXCIqT7QM5w4qPTHhmMQuTRpS5A9XYFTS2fVQQ",
+      "Content-Type": "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "c0accdaf-483a-4f76-a6ef-d8b4b3370b86",
-  "persistent" : true,
-  "insertionIndex" : 1330
+  "uuid": "71612810-9132-4921-9160-e4b1c2392c9f",
+  "persistent": true,
+  "insertionIndex": 1288
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-post-5.json
@@ -1,0 +1,48 @@
+{
+  "id" : "c0accdaf-483a-4f76-a6ef-d8b4b3370b86",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-POST-5",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/comp-shorten-bypass"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/comp-shorten-bypass\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEjZQAriCfbQiZhucStrUgUiI58g7rNtsrRHU_uNxmD4CzgbSfI-TDfLe_uq99vjKOHyRtNimDy-V6Yccl9u4VX3mH_hT4PNZrahp6lQgQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:31 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/comp-shorten-bypass&uploadType=resumable&upload_id=AAVLpEjZQAriCfbQiZhucStrUgUiI58g7rNtsrRHU_uNxmD4CzgbSfI-TDfLe_uq99vjKOHyRtNimDy-V6Yccl9u4VX3mH_hT4PNZrahp6lQgQ",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "c0accdaf-483a-4f76-a6ef-d8b4b3370b86",
+  "persistent" : true,
+  "insertionIndex" : 1330
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-put-4.json
@@ -1,0 +1,53 @@
+{
+  "id" : "38d26409-9776-490a-871a-fbf6159aeb38",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-PUT-4",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/comp-shorten-bypass"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AAVLpEjZQAriCfbQiZhucStrUgUiI58g7rNtsrRHU_uNxmD4CzgbSfI-TDfLe_uq99vjKOHyRtNimDy-V6Yccl9u4VX3mH_hT4PNZrahp6lQgQ"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "retention-update-conformance-tests/objectlock/update/comp-shorten-bypass",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-shorten-bypass/1778497651527006\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass?generation=1778497651527006&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497651527006\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"72\",\n  \"md5Hash\": \"wicn2LBadL9o97ZE+jiOdA==\",\n  \"crc32c\": \"fhORSA==\",\n  \"etag\": \"CN6ag4aMsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:31.585Z\",\n  \"updated\": \"2026-05-11T11:07:31.585Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:31.585Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:31.585Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CN6ag4aMsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjZQAriCfbQiZhucStrUgUiI58g7rNtsrRHU_uNxmD4CzgbSfI-TDfLe_uq99vjKOHyRtNimDy-V6Yccl9u4VX3mH_hT4PNZrahp6lQgQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:31 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "38d26409-9776-490a-871a-fbf6159aeb38",
+  "persistent" : true,
+  "insertionIndex" : 1329
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-put-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "38d26409-9776-490a-871a-fbf6159aeb38",
+  "id" : "5590737c-183e-4ef2-a020-b5726364797e",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-PUT-4",
   "request" : {
     "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -22,7 +22,7 @@
       },
       "upload_id" : {
         "hasExactly" : [ {
-          "equalTo" : "AAVLpEjZQAriCfbQiZhucStrUgUiI58g7rNtsrRHU_uNxmD4CzgbSfI-TDfLe_uq99vjKOHyRtNimDy-V6Yccl9u4VX3mH_hT4PNZrahp6lQgQ"
+          "equalTo" : "AAVLpEgf2n1Uq--eiYBQjWpBTpQyPeVu_osP_BtSsuCAN5iTHpXaSE7-ZpztXlzke-T00hyivXCIqT7QM5w4qPTHhmMQuTRpS5A9XYFTS2fVQQ"
         } ]
       }
     },
@@ -33,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-shorten-bypass/1778497651527006\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass?generation=1778497651527006&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497651527006\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"72\",\n  \"md5Hash\": \"wicn2LBadL9o97ZE+jiOdA==\",\n  \"crc32c\": \"fhORSA==\",\n  \"etag\": \"CN6ag4aMsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:31.585Z\",\n  \"updated\": \"2026-05-11T11:07:31.585Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:31.585Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:31.585Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/comp-shorten-bypass/1778743869716724\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fcomp-shorten-bypass?generation=1778743869716724&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/comp-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743869716724\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"72\",\n  \"md5Hash\": \"wicn2LBadL9o97ZE+jiOdA==\",\n  \"crc32c\": \"fhORSA==\",\n  \"etag\": \"CPTxgKShuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:09.773Z\",\n  \"updated\": \"2026-05-14T07:31:09.773Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:09.773Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:09.773Z\",\n  \"metadata\": {\n    \"correlation-id\": \"0731e68f-c63f-425d-8e65-faa8588cd5ac\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CN6ag4aMsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEjZQAriCfbQiZhucStrUgUiI58g7rNtsrRHU_uNxmD4CzgbSfI-TDfLe_uq99vjKOHyRtNimDy-V6Yccl9u4VX3mH_hT4PNZrahp6lQgQ",
+      "ETag" : "CPTxgKShuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEgf2n1Uq--eiYBQjWpBTpQyPeVu_osP_BtSsuCAN5iTHpXaSE7-ZpztXlzke-T00hyivXCIqT7QM5w4qPTHhmMQuTRpS5A9XYFTS2fVQQ",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:31 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:09 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "38d26409-9776-490a-871a-fbf6159aeb38",
+  "uuid" : "5590737c-183e-4ef2-a020-b5726364797e",
   "persistent" : true,
-  "insertionIndex" : 1329
+  "insertionIndex" : 1287
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "548aed14-0633-42d8-9ff4-e54b4c05a85a",
+  "id" : "c3508c0a-5fa2-4bc0-9998-b42e6d225d87",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-DELETE-0",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEhw6EdAljT87zvFUOg-32zYLtstQPr-en1fwYLCWGcz_ZDlUEOshXxy2jM-YOmGXf4",
+      "X-GUploader-UploadID" : "AAVLpEj2-Cc_bXm4ag5PXfmMdFNn_xJhMvNZERu9_3y7dP0H3FeeyWABhls7C0UEKQeTPE-T_sih5bM",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:19 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:03 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "548aed14-0633-42d8-9ff4-e54b4c05a85a",
+  "uuid" : "c3508c0a-5fa2-4bc0-9998-b42e6d225d87",
   "persistent" : true,
-  "insertionIndex" : 1298
+  "insertionIndex" : 1263
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "548aed14-0633-42d8-9ff4-e54b4c05a85a",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEhw6EdAljT87zvFUOg-32zYLtstQPr-en1fwYLCWGcz_ZDlUEOshXxy2jM-YOmGXf4",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:19 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "548aed14-0633-42d8-9ff4-e54b4c05a85a",
+  "persistent" : true,
+  "insertionIndex" : 1298
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "11e81d87-8500-4f2b-b54d-e30cc36d649c",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEgsMg1oi2wFln4OZh8LaA-hBAEvPVB7-HIMdv23y_S14UmnbZDFjjMw8VQfKjERkAP4",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:19 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:19 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "11e81d87-8500-4f2b-b54d-e30cc36d649c",
+  "persistent" : true,
+  "insertionIndex" : 1299
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "11e81d87-8500-4f2b-b54d-e30cc36d649c",
+  "id" : "102ea55b-5477-4f7a-b698-1e6abb2a7598",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-1",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -29,14 +29,14 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AAVLpEgsMg1oi2wFln4OZh8LaA-hBAEvPVB7-HIMdv23y_S14UmnbZDFjjMw8VQfKjERkAP4",
+      "X-GUploader-UploadID" : "AAVLpEjJAKHWyUQ2gfrz20IKu4b-TK70fh5wui8dxfkUM69gyYDmwY3LTmcxiO7QBL0nS6EszQraPp8",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:19 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:19 GMT",
+      "Expires" : "Thu, 14 May 2026 07:31:03 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:03 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "11e81d87-8500-4f2b-b54d-e30cc36d649c",
+  "uuid" : "102ea55b-5477-4f7a-b698-1e6abb2a7598",
   "persistent" : true,
-  "insertionIndex" : 1299
+  "insertionIndex" : 1264
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "b256fa10-2d29-43e9-a45d-dade1a4c3772",
+  "id" : "3c48629f-597c-489b-8391-48b5f4cc5e94",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-2",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend",
@@ -19,22 +19,22 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778497636676244\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778497636676244&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497636676244\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"CJTl+P6LsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:16.733Z\",\n  \"updated\": \"2026-05-11T11:07:18.181Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:16.733Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778743861229163\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778743861229163&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743861229163\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"COvs+p+huJQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:01.289Z\",\n  \"updated\": \"2026-05-14T07:31:02.488Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:01.289Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:01.289Z\",\n  \"metadata\": {\n    \"correlation-id\": \"612ad0b2-e56a-4c8d-b891-384de13c2a15\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CJTl+P6LsZQDEAI=",
-      "X-GUploader-UploadID" : "AAVLpEjiazGtuPubDbNgwP2Q44X-RfrowqnQNvf4x-Q8yqKIlCfhHDjmcyZHvMIF9u2ip1o",
+      "ETag" : "COvs+p+huJQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEgzMcCWOU_I76LlIREmJ-QifFCgqEnQcFbOjDHQ9CoBjqe5xcqGJanRB7xLAw-mX9nj",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:18 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:18 GMT",
+      "Expires" : "Thu, 14 May 2026 07:31:02 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:02 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "b256fa10-2d29-43e9-a45d-dade1a4c3772",
+  "uuid" : "3c48629f-597c-489b-8391-48b5f4cc5e94",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend-3",
-  "insertionIndex" : 1300
+  "insertionIndex" : 1265
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-2.json
@@ -1,0 +1,40 @@
+{
+  "id" : "b256fa10-2d29-43e9-a45d-dade1a4c3772",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-2",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778497636676244\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778497636676244&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497636676244\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"CJTl+P6LsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:16.733Z\",\n  \"updated\": \"2026-05-11T11:07:18.181Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:16.733Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CJTl+P6LsZQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEjiazGtuPubDbNgwP2Q44X-RfrowqnQNvf4x-Q8yqKIlCfhHDjmcyZHvMIF9u2ip1o",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:18 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:18 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "b256fa10-2d29-43e9-a45d-dade1a4c3772",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend-3",
+  "insertionIndex" : 1300
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "77a29b91-5278-4ced-8fe3-41465534da96",
+  "id" : "c584cfc3-934e-45c7-b5c9-363d262840a5",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-4",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778497636676244\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778497636676244&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497636676244\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"CJTl+P6LsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:16.733Z\",\n  \"updated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:16.733Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778743861229163\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778743861229163&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743861229163\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"COvs+p+huJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:01.289Z\",\n  \"updated\": \"2026-05-14T07:31:01.289Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:01.289Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:01.289Z\",\n  \"metadata\": {\n    \"correlation-id\": \"612ad0b2-e56a-4c8d-b891-384de13c2a15\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CJTl+P6LsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEgJz1q2rNDlGj_KNNktSIPlOP6NMHMW5i-P67g882wuPb3hXqMFZVoNtfN_5Z9ExEA",
+      "ETag" : "COvs+p+huJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEi1v6FFiee-5exD-lPn844UFy6JA3Jkq0PSocsMTh0BenfFsTJikPjY00EtldTccwyEjQZTgdk",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:17 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:17 GMT",
+      "Expires" : "Thu, 14 May 2026 07:31:01 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:01 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "77a29b91-5278-4ced-8fe3-41465534da96",
+  "uuid" : "c584cfc3-934e-45c7-b5c9-363d262840a5",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend-2",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend-3",
-  "insertionIndex" : 1302
+  "insertionIndex" : 1267
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-4.json
@@ -1,0 +1,41 @@
+{
+  "id" : "77a29b91-5278-4ced-8fe3-41465534da96",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-4",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778497636676244\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778497636676244&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497636676244\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"CJTl+P6LsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:16.733Z\",\n  \"updated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:16.733Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CJTl+P6LsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEgJz1q2rNDlGj_KNNktSIPlOP6NMHMW5i-P67g882wuPb3hXqMFZVoNtfN_5Z9ExEA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:17 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:17 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "77a29b91-5278-4ced-8fe3-41465534da96",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend-2",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend-3",
+  "insertionIndex" : 1302
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-5.json
@@ -1,5 +1,5 @@
 {
-  "id" : "64451877-8ad9-45dc-83e9-7ef7eabfb37f",
+  "id" : "dee5690a-8654-486c-b41c-f49dac7102ea",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-5",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778497636676244\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778497636676244&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497636676244\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"CJTl+P6LsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:16.733Z\",\n  \"updated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:16.733Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778743861229163\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778743861229163&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743861229163\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"COvs+p+huJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:01.289Z\",\n  \"updated\": \"2026-05-14T07:31:01.289Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:01.289Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:01.289Z\",\n  \"metadata\": {\n    \"correlation-id\": \"612ad0b2-e56a-4c8d-b891-384de13c2a15\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CJTl+P6LsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEjtG90QKnzx9mLUyxgkIy0K-ZLDMQCb3UsZ6SSygNJO9A73B5XFdsUF6-JoCYOSwFIL",
+      "ETag" : "COvs+p+huJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEia4V5oNjyl70jQwAwrf9pHz-gOfH1E-3xs4kF0llkDp2Wnzj61U7EtskK5wJsvtWLG",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:17 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:17 GMT",
+      "Expires" : "Thu, 14 May 2026 07:31:01 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:01 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "64451877-8ad9-45dc-83e9-7ef7eabfb37f",
+  "uuid" : "dee5690a-8654-486c-b41c-f49dac7102ea",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend-2",
-  "insertionIndex" : 1303
+  "insertionIndex" : 1268
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-5.json
@@ -1,0 +1,41 @@
+{
+  "id" : "64451877-8ad9-45dc-83e9-7ef7eabfb37f",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-5",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778497636676244\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778497636676244&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497636676244\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"CJTl+P6LsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:16.733Z\",\n  \"updated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:16.733Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CJTl+P6LsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjtG90QKnzx9mLUyxgkIy0K-ZLDMQCb3UsZ6SSygNJO9A73B5XFdsUF6-JoCYOSwFIL",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:17 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:17 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "64451877-8ad9-45dc-83e9-7ef7eabfb37f",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-extend-2",
+  "insertionIndex" : 1303
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-post-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-post-3.json
@@ -1,44 +1,51 @@
 {
-  "id" : "a7d624a6-dd66-4a11-9720-31bbd085fc7a",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-POST-3",
-  "request" : {
-    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "1"
+  "id": "d67dd1a5-16a2-432b-8043-4f1db81b9b80",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-POST-3",
+  "request": {
+    "urlPath": "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "1"
       }
     },
-    "queryParameters" : {
-      "projection" : {
-        "hasExactly" : [ {
-          "equalTo" : "full"
-        } ]
+    "queryParameters": {
+      "projection": {
+        "hasExactly": [
+          {
+            "equalTo": "full"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778497636676244\",\"name\":\"conformance-tests/objectlock/update/gov-extend\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"}}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778743861229163\",\"name\":\"conformance-tests/objectlock/update/gov-extend\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"}}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778497636676244\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778497636676244&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497636676244\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"CJTl+P6LsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:16.733Z\",\n  \"updated\": \"2026-05-11T11:07:18.181Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:16.733Z\"\n}\n",
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CJTl+P6LsZQDEAI=",
-      "X-GUploader-UploadID" : "AAVLpEiCAwF0LB4ZHiJN3QCja9jRIGMgrdgRtHwH5SqVGBE2Tz7bGcfRqU6XNnNTGd7PeU2E",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:18 GMT",
-      "Content-Type" : "application/json; charset=UTF-8"
+  "response": {
+    "status": 200,
+    "body": "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778743861229163\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778743861229163&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743861229163\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"COvs+p+huJQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:01.289Z\",\n  \"updated\": \"2026-05-14T07:31:02.488Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:01.289Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:01.289Z\",\n  \"metadata\": {\n    \"correlation-id\": \"612ad0b2-e56a-4c8d-b891-384de13c2a15\"\n  }\n}\n",
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag": "COvs+p+huJQDEAI=",
+      "X-GUploader-UploadID": "AAVLpEjaAdcgYzHD7yZzGfY-VwTCnv02QD98SrP7Emtlqzdnee_C4K3Ssv9UL9ghs4nifUnOc0L_s6o",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:31:02 GMT",
+      "Content-Type": "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "a7d624a6-dd66-4a11-9720-31bbd085fc7a",
-  "persistent" : true,
-  "insertionIndex" : 1301
+  "uuid": "d67dd1a5-16a2-432b-8043-4f1db81b9b80",
+  "persistent": true,
+  "insertionIndex": 1266
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-post-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-post-3.json
@@ -1,0 +1,44 @@
+{
+  "id" : "a7d624a6-dd66-4a11-9720-31bbd085fc7a",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-POST-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778497636676244\",\"name\":\"conformance-tests/objectlock/update/gov-extend\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"}}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778497636676244\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778497636676244&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497636676244\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"CJTl+P6LsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:16.733Z\",\n  \"updated\": \"2026-05-11T11:07:18.181Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:16.733Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CJTl+P6LsZQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEiCAwF0LB4ZHiJN3QCja9jRIGMgrdgRtHwH5SqVGBE2Tz7bGcfRqU6XNnNTGd7PeU2E",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:18 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "a7d624a6-dd66-4a11-9720-31bbd085fc7a",
+  "persistent" : true,
+  "insertionIndex" : 1301
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-post-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-post-7.json
@@ -1,48 +1,57 @@
 {
-  "id" : "b652d17e-1eef-498f-af06-239793911896",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-POST-7",
-  "request" : {
-    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "2"
+  "id": "a89f6de9-0cfe-4f9a-9c78-6803e7810cc0",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-POST-7",
+  "request": {
+    "urlPath": "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "2"
       }
     },
-    "queryParameters" : {
-      "name" : {
-        "hasExactly" : [ {
-          "equalTo" : "conformance-tests/objectlock/update/gov-extend"
-        } ]
+    "queryParameters": {
+      "name": {
+        "hasExactly": [
+          {
+            "equalTo": "conformance-tests/objectlock/update/gov-extend"
+          }
+        ]
       },
-      "uploadType" : {
-        "hasExactly" : [ {
-          "equalTo" : "resumable"
-        } ]
+      "uploadType": {
+        "hasExactly": [
+          {
+            "equalTo": "resumable"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/gov-extend\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/gov-extend\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEjLd_QTlT47Nn5kw7ArgALcikhuWbN9ktHSJ4NPW1AIJWPTIOqE8ocUbF0xyrHRnNzBYI3_8FQrczsiKEU5Z2LBXruUD-eOGaSVw7Gb3lk",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:16 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/gov-extend&uploadType=resumable&upload_id=AAVLpEjLd_QTlT47Nn5kw7ArgALcikhuWbN9ktHSJ4NPW1AIJWPTIOqE8ocUbF0xyrHRnNzBYI3_8FQrczsiKEU5Z2LBXruUD-eOGaSVw7Gb3lk",
-      "Content-Type" : "text/plain; charset=utf-8"
+  "response": {
+    "status": 200,
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID": "AAVLpEhJNV8lf5BRyuoYOIzHCDyHqS4s63et7mtGnZcCzJSZnm8HHSZZuHe6LzafpUhLCre_D61fQzoel7gWj-4A_Am28p3Yzzoh5E9bp1M9tBg",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:31:00 GMT",
+      "Location": "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/gov-extend&uploadType=resumable&upload_id=AAVLpEhJNV8lf5BRyuoYOIzHCDyHqS4s63et7mtGnZcCzJSZnm8HHSZZuHe6LzafpUhLCre_D61fQzoel7gWj-4A_Am28p3Yzzoh5E9bp1M9tBg",
+      "Content-Type": "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "b652d17e-1eef-498f-af06-239793911896",
-  "persistent" : true,
-  "insertionIndex" : 1305
+  "uuid": "a89f6de9-0cfe-4f9a-9c78-6803e7810cc0",
+  "persistent": true,
+  "insertionIndex": 1270
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-post-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-post-7.json
@@ -1,0 +1,48 @@
+{
+  "id" : "b652d17e-1eef-498f-af06-239793911896",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-POST-7",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/gov-extend"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/gov-extend\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEjLd_QTlT47Nn5kw7ArgALcikhuWbN9ktHSJ4NPW1AIJWPTIOqE8ocUbF0xyrHRnNzBYI3_8FQrczsiKEU5Z2LBXruUD-eOGaSVw7Gb3lk",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:16 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/gov-extend&uploadType=resumable&upload_id=AAVLpEjLd_QTlT47Nn5kw7ArgALcikhuWbN9ktHSJ4NPW1AIJWPTIOqE8ocUbF0xyrHRnNzBYI3_8FQrczsiKEU5Z2LBXruUD-eOGaSVw7Gb3lk",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "b652d17e-1eef-498f-af06-239793911896",
+  "persistent" : true,
+  "insertionIndex" : 1305
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-6.json
@@ -1,0 +1,53 @@
+{
+  "id" : "668c1ace-2572-4cdd-9309-bf5cdcadd9cd",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-PUT-6",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/gov-extend"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AAVLpEjLd_QTlT47Nn5kw7ArgALcikhuWbN9ktHSJ4NPW1AIJWPTIOqE8ocUbF0xyrHRnNzBYI3_8FQrczsiKEU5Z2LBXruUD-eOGaSVw7Gb3lk"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "retention-update-conformance-tests/objectlock/update/gov-extend",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778497636676244\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778497636676244&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497636676244\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"CJTl+P6LsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:16.733Z\",\n  \"updated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:16.733Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CJTl+P6LsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjLd_QTlT47Nn5kw7ArgALcikhuWbN9ktHSJ4NPW1AIJWPTIOqE8ocUbF0xyrHRnNzBYI3_8FQrczsiKEU5Z2LBXruUD-eOGaSVw7Gb3lk",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:16 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "668c1ace-2572-4cdd-9309-bf5cdcadd9cd",
+  "persistent" : true,
+  "insertionIndex" : 1304
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-6.json
@@ -1,5 +1,5 @@
 {
-  "id" : "668c1ace-2572-4cdd-9309-bf5cdcadd9cd",
+  "id" : "e1938332-c36a-406d-be20-5061be9b8375",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-PUT-6",
   "request" : {
     "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -22,7 +22,7 @@
       },
       "upload_id" : {
         "hasExactly" : [ {
-          "equalTo" : "AAVLpEjLd_QTlT47Nn5kw7ArgALcikhuWbN9ktHSJ4NPW1AIJWPTIOqE8ocUbF0xyrHRnNzBYI3_8FQrczsiKEU5Z2LBXruUD-eOGaSVw7Gb3lk"
+          "equalTo" : "AAVLpEhJNV8lf5BRyuoYOIzHCDyHqS4s63et7mtGnZcCzJSZnm8HHSZZuHe6LzafpUhLCre_D61fQzoel7gWj-4A_Am28p3Yzzoh5E9bp1M9tBg"
         } ]
       }
     },
@@ -33,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778497636676244\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778497636676244&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497636676244\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"CJTl+P6LsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:16.733Z\",\n  \"updated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:16.733Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:16.733Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-extend/1778743861229163\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-extend?generation=1778743861229163&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-extend\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743861229163\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"63\",\n  \"md5Hash\": \"IVmcfxtGntHP/HlvPyacoA==\",\n  \"crc32c\": \"IOzQuw==\",\n  \"etag\": \"COvs+p+huJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:01.289Z\",\n  \"updated\": \"2026-05-14T07:31:01.289Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:01.289Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:01.289Z\",\n  \"metadata\": {\n    \"correlation-id\": \"612ad0b2-e56a-4c8d-b891-384de13c2a15\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CJTl+P6LsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEjLd_QTlT47Nn5kw7ArgALcikhuWbN9ktHSJ4NPW1AIJWPTIOqE8ocUbF0xyrHRnNzBYI3_8FQrczsiKEU5Z2LBXruUD-eOGaSVw7Gb3lk",
+      "ETag" : "COvs+p+huJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhJNV8lf5BRyuoYOIzHCDyHqS4s63et7mtGnZcCzJSZnm8HHSZZuHe6LzafpUhLCre_D61fQzoel7gWj-4A_Am28p3Yzzoh5E9bp1M9tBg",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:16 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:01 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "668c1ace-2572-4cdd-9309-bf5cdcadd9cd",
+  "uuid" : "e1938332-c36a-406d-be20-5061be9b8375",
   "persistent" : true,
-  "insertionIndex" : 1304
+  "insertionIndex" : 1269
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "958a2273-c350-4f48-8e6b-5e66c13b9006",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEhyESXSc04W2sVdSqj5t7UHko8pDP0SHKBJOf2ptwyDDaPeXKY8r8Oj6lD2eSHy5b4",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:04 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "958a2273-c350-4f48-8e6b-5e66c13b9006",
+  "persistent" : true,
+  "insertionIndex" : 1273
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "958a2273-c350-4f48-8e6b-5e66c13b9006",
+  "id" : "95b6e1e8-2364-4155-9039-52e54adcc21b",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-DELETE-0",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEhyESXSc04W2sVdSqj5t7UHko8pDP0SHKBJOf2ptwyDDaPeXKY8r8Oj6lD2eSHy5b4",
+      "X-GUploader-UploadID" : "AAVLpEhTu2QqjjNrCLzuCcs4PFssjy8LVsziF5htOAA04x504NRSje3L0SEZM1Cl23pI55jyZBWI0bo",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:04 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:32 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "958a2273-c350-4f48-8e6b-5e66c13b9006",
+  "uuid" : "95b6e1e8-2364-4155-9039-52e54adcc21b",
   "persistent" : true,
-  "insertionIndex" : 1273
+  "insertionIndex" : 1323
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "7b1d4b1a-f368-4dd5-8163-fddc431ca880",
+  "id" : "d19f6db0-b245-4115-a634-17bcbc5c1b84",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-1",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -29,14 +29,14 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AAVLpEiiuKhVsVPSb0uU1yvWcn_-lSlxzNc0VWXZhEnydwOwh8fFAfBOgA4bm1ec3-gNmrfH",
+      "X-GUploader-UploadID" : "AAVLpEhJQe6ran2P-T8OiunGkRrm7_e2LCXqZ-rOjxtmkcrmYIakqAFTgMSs8I5o5QoBNPu6",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:03 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:03 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:31 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:31 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "7b1d4b1a-f368-4dd5-8163-fddc431ca880",
+  "uuid" : "d19f6db0-b245-4115-a634-17bcbc5c1b84",
   "persistent" : true,
-  "insertionIndex" : 1274
+  "insertionIndex" : 1324
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "7b1d4b1a-f368-4dd5-8163-fddc431ca880",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEiiuKhVsVPSb0uU1yvWcn_-lSlxzNc0VWXZhEnydwOwh8fFAfBOgA4bm1ec3-gNmrfH",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:03 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:03 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "7b1d4b1a-f368-4dd5-8163-fddc431ca880",
+  "persistent" : true,
+  "insertionIndex" : 1274
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "47b8d36a-755e-498e-a560-3645f876a140",
+  "id" : "e421d08c-78d8-4086-868d-52c3d5a495f2",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-2",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass",
@@ -19,22 +19,22 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778497621431240\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778497621431240&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497621431240\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CMin1veLsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-02-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-02-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:01.487Z\",\n  \"updated\": \"2026-05-11T11:07:02.970Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:01.487Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778744669531296\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778744669531296&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744669531296\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CKDZsaGkuJQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-02-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-02-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:29.597Z\",\n  \"updated\": \"2026-05-14T07:44:30.843Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:29.597Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:29.597Z\",\n  \"metadata\": {\n    \"correlation-id\": \"9e15b740-9325-4792-a16f-9cc3d6a3899d\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CMin1veLsZQDEAI=",
-      "X-GUploader-UploadID" : "AAVLpEhNr3bpKKA8Nk0rjaFz5rHWui--o1X2nLfwga9XiXBQXho-6pTcA1BaweshpPBwv-c",
+      "ETag" : "CKDZsaGkuJQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEjzM16qI3OuAAapFIOP8Ext8bbBnR9rVRuX-IYq1IN6cwLefwRwpPfsbsm5bpv78PQXBvVR4Jk",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:03 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:03 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:31 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:31 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "47b8d36a-755e-498e-a560-3645f876a140",
+  "uuid" : "e421d08c-78d8-4086-868d-52c3d5a495f2",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass-3",
-  "insertionIndex" : 1275
+  "insertionIndex" : 1325
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-2.json
@@ -1,0 +1,40 @@
+{
+  "id" : "47b8d36a-755e-498e-a560-3645f876a140",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-2",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778497621431240\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778497621431240&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497621431240\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CMin1veLsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-02-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-02-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:01.487Z\",\n  \"updated\": \"2026-05-11T11:07:02.970Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:01.487Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CMin1veLsZQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEhNr3bpKKA8Nk0rjaFz5rHWui--o1X2nLfwga9XiXBQXho-6pTcA1BaweshpPBwv-c",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:03 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:03 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "47b8d36a-755e-498e-a560-3645f876a140",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass-3",
+  "insertionIndex" : 1275
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-4.json
@@ -1,0 +1,41 @@
+{
+  "id" : "9fa5535d-f59c-4604-96be-9a86830c059e",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-4",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778497621431240\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778497621431240&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497621431240\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CMin1veLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:01.487Z\",\n  \"updated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:01.487Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CMin1veLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhi4uJN18mfCaoRkLh1f98utBTnukm8_zHUVgaJIvjVCXC0OGcg1jtv6o8830VzhtIt",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:02 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:02 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "9fa5535d-f59c-4604-96be-9a86830c059e",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass-2",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass-3",
+  "insertionIndex" : 1277
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "9fa5535d-f59c-4604-96be-9a86830c059e",
+  "id" : "387ad73d-be05-48b8-8bfb-6d3d7a73764e",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-4",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778497621431240\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778497621431240&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497621431240\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CMin1veLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:01.487Z\",\n  \"updated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:01.487Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778744669531296\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778744669531296&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744669531296\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CKDZsaGkuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:29.597Z\",\n  \"updated\": \"2026-05-14T07:44:29.597Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:29.597Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:29.597Z\",\n  \"metadata\": {\n    \"correlation-id\": \"9e15b740-9325-4792-a16f-9cc3d6a3899d\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CMin1veLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEhi4uJN18mfCaoRkLh1f98utBTnukm8_zHUVgaJIvjVCXC0OGcg1jtv6o8830VzhtIt",
+      "ETag" : "CKDZsaGkuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEi_xoBzYtFLjt4QdFgoBVz8TCh7hTfPlAuDqZwAcDCSpNsGeSrkU2LIcLFAsYnVuEh0nQt2ghk",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:02 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:02 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:30 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:30 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "9fa5535d-f59c-4604-96be-9a86830c059e",
+  "uuid" : "387ad73d-be05-48b8-8bfb-6d3d7a73764e",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass-2",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass-3",
-  "insertionIndex" : 1277
+  "insertionIndex" : 1327
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-5.json
@@ -1,0 +1,41 @@
+{
+  "id" : "e595fb57-f5db-48a3-b1bf-f81ba7271422",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-5",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778497621431240\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778497621431240&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497621431240\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CMin1veLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:01.487Z\",\n  \"updated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:01.487Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CMin1veLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEitcp0MI1Z1IokHKTflqg0REZJaS31zqQvSZjlEtS27hJI2MeAWbe2LgX5S57BPCcM",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:01 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:01 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "e595fb57-f5db-48a3-b1bf-f81ba7271422",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass-2",
+  "insertionIndex" : 1278
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-5.json
@@ -1,5 +1,5 @@
 {
-  "id" : "e595fb57-f5db-48a3-b1bf-f81ba7271422",
+  "id" : "5f8d9855-7d4a-4128-93ea-983a106cd485",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-5",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778497621431240\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778497621431240&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497621431240\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CMin1veLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:01.487Z\",\n  \"updated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:01.487Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778744669531296\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778744669531296&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744669531296\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CKDZsaGkuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:29.597Z\",\n  \"updated\": \"2026-05-14T07:44:29.597Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:29.597Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:29.597Z\",\n  \"metadata\": {\n    \"correlation-id\": \"9e15b740-9325-4792-a16f-9cc3d6a3899d\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CMin1veLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEitcp0MI1Z1IokHKTflqg0REZJaS31zqQvSZjlEtS27hJI2MeAWbe2LgX5S57BPCcM",
+      "ETag" : "CKDZsaGkuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEgXD0bTnCwOobD6snzwRgjRXDLa3JaQ1d7SiNCJhLcub0BKcmU04KJlgMII4Hk2zq0vjLji_o8",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:01 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:01 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:29 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:29 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "e595fb57-f5db-48a3-b1bf-f81ba7271422",
+  "uuid" : "5f8d9855-7d4a-4128-93ea-983a106cd485",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-bypass-2",
-  "insertionIndex" : 1278
+  "insertionIndex" : 1328
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-post-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-post-3.json
@@ -1,0 +1,49 @@
+{
+  "id" : "0afcb99e-e3d8-4ec2-a14b-433b14593c3b",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-POST-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "overrideUnlockedRetention" : {
+        "hasExactly" : [ {
+          "equalTo" : "true"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778497621431240\",\"name\":\"conformance-tests/objectlock/update/gov-shorten-bypass\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-02-01T00:00:00.000Z\"}}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778497621431240\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778497621431240&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497621431240\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CMin1veLsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-02-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-02-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:01.487Z\",\n  \"updated\": \"2026-05-11T11:07:02.970Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:01.487Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CMin1veLsZQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEhkHtBGxxSZjcbSsGHvaBxwzB92Q4rg_8fKtvS6cQiCoePQEhKL--XGFg-bQChSwMM",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:02 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "0afcb99e-e3d8-4ec2-a14b-433b14593c3b",
+  "persistent" : true,
+  "insertionIndex" : 1276
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-post-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-post-3.json
@@ -1,49 +1,58 @@
 {
-  "id" : "0afcb99e-e3d8-4ec2-a14b-433b14593c3b",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-POST-3",
-  "request" : {
-    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "2"
+  "id": "b11db8b2-d624-4ad7-b4da-94e84772016b",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-POST-3",
+  "request": {
+    "urlPath": "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "2"
       }
     },
-    "queryParameters" : {
-      "overrideUnlockedRetention" : {
-        "hasExactly" : [ {
-          "equalTo" : "true"
-        } ]
+    "queryParameters": {
+      "overrideUnlockedRetention": {
+        "hasExactly": [
+          {
+            "equalTo": "true"
+          }
+        ]
       },
-      "projection" : {
-        "hasExactly" : [ {
-          "equalTo" : "full"
-        } ]
+      "projection": {
+        "hasExactly": [
+          {
+            "equalTo": "full"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778497621431240\",\"name\":\"conformance-tests/objectlock/update/gov-shorten-bypass\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-02-01T00:00:00.000Z\"}}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778744669531296\",\"name\":\"conformance-tests/objectlock/update/gov-shorten-bypass\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-02-01T00:00:00.000Z\"}}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778497621431240\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778497621431240&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497621431240\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CMin1veLsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-02-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-02-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:01.487Z\",\n  \"updated\": \"2026-05-11T11:07:02.970Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:01.487Z\"\n}\n",
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CMin1veLsZQDEAI=",
-      "X-GUploader-UploadID" : "AAVLpEhkHtBGxxSZjcbSsGHvaBxwzB92Q4rg_8fKtvS6cQiCoePQEhKL--XGFg-bQChSwMM",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:02 GMT",
-      "Content-Type" : "application/json; charset=UTF-8"
+  "response": {
+    "status": 200,
+    "body": "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778744669531296\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778744669531296&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744669531296\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CKDZsaGkuJQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-02-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-02-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:29.597Z\",\n  \"updated\": \"2026-05-14T07:44:30.843Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:29.597Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:29.597Z\",\n  \"metadata\": {\n    \"correlation-id\": \"9e15b740-9325-4792-a16f-9cc3d6a3899d\"\n  }\n}\n",
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag": "CKDZsaGkuJQDEAI=",
+      "X-GUploader-UploadID": "AAVLpEifpllH94zQHnEKd2jS_RQ3iZHSvqafcsrDKBJ4ONvFxanz1iLrpJpOw-17fax0f4W-dLfLWxM",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:44:30 GMT",
+      "Content-Type": "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "0afcb99e-e3d8-4ec2-a14b-433b14593c3b",
-  "persistent" : true,
-  "insertionIndex" : 1276
+  "uuid": "b11db8b2-d624-4ad7-b4da-94e84772016b",
+  "persistent": true,
+  "insertionIndex": 1326
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-post-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-post-7.json
@@ -1,48 +1,57 @@
 {
-  "id" : "e8c31645-c684-4208-ab91-9314e4f51238",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-POST-7",
-  "request" : {
-    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "2"
+  "id": "ff082f4b-e4bd-4b00-b1d7-45e6183fe23c",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-POST-7",
+  "request": {
+    "urlPath": "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "2"
       }
     },
-    "queryParameters" : {
-      "name" : {
-        "hasExactly" : [ {
-          "equalTo" : "conformance-tests/objectlock/update/gov-shorten-bypass"
-        } ]
+    "queryParameters": {
+      "name": {
+        "hasExactly": [
+          {
+            "equalTo": "conformance-tests/objectlock/update/gov-shorten-bypass"
+          }
+        ]
       },
-      "uploadType" : {
-        "hasExactly" : [ {
-          "equalTo" : "resumable"
-        } ]
+      "uploadType": {
+        "hasExactly": [
+          {
+            "equalTo": "resumable"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/gov-shorten-bypass\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"},\"temporaryHold\":false}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/gov-shorten-bypass\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEh34m9N4n9KplSX_9jLL5-NEwXXMLyMserBfBLpdE5354Fes2O7R8MtQmkdWuMA0JifkISdzmk6orL-8r-i4QHWwlzP4nSwWZIq-_6u1ic",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:00 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/gov-shorten-bypass&uploadType=resumable&upload_id=AAVLpEh34m9N4n9KplSX_9jLL5-NEwXXMLyMserBfBLpdE5354Fes2O7R8MtQmkdWuMA0JifkISdzmk6orL-8r-i4QHWwlzP4nSwWZIq-_6u1ic",
-      "Content-Type" : "text/plain; charset=utf-8"
+  "response": {
+    "status": 200,
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID": "AAVLpEipcAtg3e_6mvJ8-JGPx4ALdvtKtgGrAmyoN_tPD22aEoXvKF4-vD4cuVU48PwsS23CzvdLhR5kYNtI043XpnYQjT901XwzkHD5gVEOTKQ",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:44:29 GMT",
+      "Location": "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/gov-shorten-bypass&uploadType=resumable&upload_id=AAVLpEipcAtg3e_6mvJ8-JGPx4ALdvtKtgGrAmyoN_tPD22aEoXvKF4-vD4cuVU48PwsS23CzvdLhR5kYNtI043XpnYQjT901XwzkHD5gVEOTKQ",
+      "Content-Type": "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "e8c31645-c684-4208-ab91-9314e4f51238",
-  "persistent" : true,
-  "insertionIndex" : 1280
+  "uuid": "ff082f4b-e4bd-4b00-b1d7-45e6183fe23c",
+  "persistent": true,
+  "insertionIndex": 1330
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-post-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-post-7.json
@@ -1,0 +1,48 @@
+{
+  "id" : "e8c31645-c684-4208-ab91-9314e4f51238",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-POST-7",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/gov-shorten-bypass"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/gov-shorten-bypass\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEh34m9N4n9KplSX_9jLL5-NEwXXMLyMserBfBLpdE5354Fes2O7R8MtQmkdWuMA0JifkISdzmk6orL-8r-i4QHWwlzP4nSwWZIq-_6u1ic",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:00 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/gov-shorten-bypass&uploadType=resumable&upload_id=AAVLpEh34m9N4n9KplSX_9jLL5-NEwXXMLyMserBfBLpdE5354Fes2O7R8MtQmkdWuMA0JifkISdzmk6orL-8r-i4QHWwlzP4nSwWZIq-_6u1ic",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "e8c31645-c684-4208-ab91-9314e4f51238",
+  "persistent" : true,
+  "insertionIndex" : 1280
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-6.json
@@ -1,0 +1,53 @@
+{
+  "id" : "9fcea243-3977-44dd-ac74-6eb1ef15392d",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-PUT-6",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/gov-shorten-bypass"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AAVLpEh34m9N4n9KplSX_9jLL5-NEwXXMLyMserBfBLpdE5354Fes2O7R8MtQmkdWuMA0JifkISdzmk6orL-8r-i4QHWwlzP4nSwWZIq-_6u1ic"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "retention-update-conformance-tests/objectlock/update/gov-shorten-bypass",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778497621431240\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778497621431240&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497621431240\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CMin1veLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:01.487Z\",\n  \"updated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:01.487Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CMin1veLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEh34m9N4n9KplSX_9jLL5-NEwXXMLyMserBfBLpdE5354Fes2O7R8MtQmkdWuMA0JifkISdzmk6orL-8r-i4QHWwlzP4nSwWZIq-_6u1ic",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:01 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "9fcea243-3977-44dd-ac74-6eb1ef15392d",
+  "persistent" : true,
+  "insertionIndex" : 1279
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-6.json
@@ -1,5 +1,5 @@
 {
-  "id" : "9fcea243-3977-44dd-ac74-6eb1ef15392d",
+  "id" : "dd2c5d23-026e-48c6-872a-950f351c9b67",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-PUT-6",
   "request" : {
     "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -22,7 +22,7 @@
       },
       "upload_id" : {
         "hasExactly" : [ {
-          "equalTo" : "AAVLpEh34m9N4n9KplSX_9jLL5-NEwXXMLyMserBfBLpdE5354Fes2O7R8MtQmkdWuMA0JifkISdzmk6orL-8r-i4QHWwlzP4nSwWZIq-_6u1ic"
+          "equalTo" : "AAVLpEipcAtg3e_6mvJ8-JGPx4ALdvtKtgGrAmyoN_tPD22aEoXvKF4-vD4cuVU48PwsS23CzvdLhR5kYNtI043XpnYQjT901XwzkHD5gVEOTKQ"
         } ]
       }
     },
@@ -33,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778497621431240\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778497621431240&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497621431240\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CMin1veLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:01.487Z\",\n  \"updated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:01.487Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:01.487Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-bypass/1778744669531296\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-bypass?generation=1778744669531296&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744669531296\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"71\",\n  \"md5Hash\": \"9OwzxUlalNThlli5V88wjQ==\",\n  \"crc32c\": \"PxN3WA==\",\n  \"etag\": \"CKDZsaGkuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:29.597Z\",\n  \"updated\": \"2026-05-14T07:44:29.597Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:29.597Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:29.597Z\",\n  \"metadata\": {\n    \"correlation-id\": \"9e15b740-9325-4792-a16f-9cc3d6a3899d\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CMin1veLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEh34m9N4n9KplSX_9jLL5-NEwXXMLyMserBfBLpdE5354Fes2O7R8MtQmkdWuMA0JifkISdzmk6orL-8r-i4QHWwlzP4nSwWZIq-_6u1ic",
+      "ETag" : "CKDZsaGkuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEipcAtg3e_6mvJ8-JGPx4ALdvtKtgGrAmyoN_tPD22aEoXvKF4-vD4cuVU48PwsS23CzvdLhR5kYNtI043XpnYQjT901XwzkHD5gVEOTKQ",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:01 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:29 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "9fcea243-3977-44dd-ac74-6eb1ef15392d",
+  "uuid" : "dd2c5d23-026e-48c6-872a-950f351c9b67",
   "persistent" : true,
-  "insertionIndex" : 1279
+  "insertionIndex" : 1329
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "43639f69-109c-4560-88a0-826df72300b4",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEjfp76ikElfLt0BjrEsFa2yHNiTuGyC3Ohm4_P2qvtt4VQ0z0DEfCYB-p6nX4ZSI6k",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:11 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "43639f69-109c-4560-88a0-826df72300b4",
+  "persistent" : true,
+  "insertionIndex" : 1282
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "43639f69-109c-4560-88a0-826df72300b4",
+  "id" : "7ab5e4ae-fb32-456a-81ea-578616fe1970",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-DELETE-0",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEjfp76ikElfLt0BjrEsFa2yHNiTuGyC3Ohm4_P2qvtt4VQ0z0DEfCYB-p6nX4ZSI6k",
+      "X-GUploader-UploadID" : "AAVLpEiwqup_iH5FZKKabFNzOWyo5TQvPFPdgfFxGGeDkv2BjSs2ZJf8aS6LnP15CZx87QSfImipdvM",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:11 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:00 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "43639f69-109c-4560-88a0-826df72300b4",
+  "uuid" : "7ab5e4ae-fb32-456a-81ea-578616fe1970",
   "persistent" : true,
-  "insertionIndex" : 1282
+  "insertionIndex" : 1256
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "9c979ea4-cb0c-43d2-b788-9978d9f7d437",
+  "id" : "676c57aa-307f-47ae-8260-3dc4b32a1ad3",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-GET-1",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -29,14 +29,14 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AAVLpEif7Cx2ytYVAlCCJ0ousXye-PfV6ErHScdJbtgMfX4JVQB6fFWgkwEJS28-iqtj5JAC",
+      "X-GUploader-UploadID" : "AAVLpEiEKIW4LR4oHT_T2H9ETFNtRmMzf8jKd-DpY1da191NaIX4dAdRDOq9Bd3F-JLb1VeX",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:10 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:10 GMT",
+      "Expires" : "Thu, 14 May 2026 07:30:59 GMT",
+      "Date" : "Thu, 14 May 2026 07:30:59 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "9c979ea4-cb0c-43d2-b788-9978d9f7d437",
+  "uuid" : "676c57aa-307f-47ae-8260-3dc4b32a1ad3",
   "persistent" : true,
-  "insertionIndex" : 1283
+  "insertionIndex" : 1257
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "9c979ea4-cb0c-43d2-b788-9978d9f7d437",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEif7Cx2ytYVAlCCJ0ousXye-PfV6ErHScdJbtgMfX4JVQB6fFWgkwEJS28-iqtj5JAC",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:10 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:10 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "9c979ea4-cb0c-43d2-b788-9978d9f7d437",
+  "persistent" : true,
+  "insertionIndex" : 1283
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "0a3ce6a4-93b1-4d90-b4e1-0ea12994411d",
+  "id" : "5bc08ad2-f472-4212-9e29-e75a8f9f7545",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-GET-2",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass",
@@ -19,22 +19,22 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-no-bypass/1778497626651176\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass?generation=1778497626651176&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497626651176\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"74\",\n  \"md5Hash\": \"5fPO7mzM2pVogBmxvWfLhQ==\",\n  \"crc32c\": \"lIhFUQ==\",\n  \"etag\": \"CKj0lPqLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:06.708Z\",\n  \"updated\": \"2026-05-11T11:07:06.708Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:06.708Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:06.708Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-no-bypass/1778743858104145\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass?generation=1778743858104145&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743858104145\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"74\",\n  \"md5Hash\": \"5fPO7mzM2pVogBmxvWfLhQ==\",\n  \"crc32c\": \"lIhFUQ==\",\n  \"etag\": \"CNGOvJ6huJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:30:58.164Z\",\n  \"updated\": \"2026-05-14T07:30:58.164Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:30:58.164Z\",\n  \"timeFinalized\": \"2026-05-14T07:30:58.164Z\",\n  \"metadata\": {\n    \"correlation-id\": \"40f85fba-9437-4a12-94b4-b51739cdee92\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CKj0lPqLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEiBZUWUHwmR7-YLeMNrUdP7Kb-S_jVpKumC3X3eqIKeQepY_eWnV9r7VNNvezv4MZw",
+      "ETag" : "CNGOvJ6huJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEh2VKWpYzQpq7lN7SfzWlsHCBUCLXRJYtEz2GuKhzNni_bBOI7u7TRfiNk6bus-E6sq",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:09 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:09 GMT",
+      "Expires" : "Thu, 14 May 2026 07:30:58 GMT",
+      "Date" : "Thu, 14 May 2026 07:30:58 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "0a3ce6a4-93b1-4d90-b4e1-0ea12994411d",
+  "uuid" : "5bc08ad2-f472-4212-9e29-e75a8f9f7545",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-no-bypass",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-no-bypass-2",
-  "insertionIndex" : 1284
+  "insertionIndex" : 1258
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-2.json
@@ -1,0 +1,40 @@
+{
+  "id" : "0a3ce6a4-93b1-4d90-b4e1-0ea12994411d",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-GET-2",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-no-bypass/1778497626651176\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass?generation=1778497626651176&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497626651176\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"74\",\n  \"md5Hash\": \"5fPO7mzM2pVogBmxvWfLhQ==\",\n  \"crc32c\": \"lIhFUQ==\",\n  \"etag\": \"CKj0lPqLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:06.708Z\",\n  \"updated\": \"2026-05-11T11:07:06.708Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:06.708Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:06.708Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CKj0lPqLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEiBZUWUHwmR7-YLeMNrUdP7Kb-S_jVpKumC3X3eqIKeQepY_eWnV9r7VNNvezv4MZw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:09 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:09 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "0a3ce6a4-93b1-4d90-b4e1-0ea12994411d",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-no-bypass",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-no-bypass-2",
+  "insertionIndex" : 1284
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "7babca68-d5f3-4b4b-a53f-98bdb16374e3",
+  "id" : "34b00b81-ce55-4bd5-a9b2-827183cc9c9f",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-GET-3",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-no-bypass/1778497626651176\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass?generation=1778497626651176&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497626651176\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"74\",\n  \"md5Hash\": \"5fPO7mzM2pVogBmxvWfLhQ==\",\n  \"crc32c\": \"lIhFUQ==\",\n  \"etag\": \"CKj0lPqLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:06.708Z\",\n  \"updated\": \"2026-05-11T11:07:06.708Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:06.708Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:06.708Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-no-bypass/1778743858104145\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass?generation=1778743858104145&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743858104145\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"74\",\n  \"md5Hash\": \"5fPO7mzM2pVogBmxvWfLhQ==\",\n  \"crc32c\": \"lIhFUQ==\",\n  \"etag\": \"CNGOvJ6huJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:30:58.164Z\",\n  \"updated\": \"2026-05-14T07:30:58.164Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:30:58.164Z\",\n  \"timeFinalized\": \"2026-05-14T07:30:58.164Z\",\n  \"metadata\": {\n    \"correlation-id\": \"40f85fba-9437-4a12-94b4-b51739cdee92\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CKj0lPqLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEinIig6Xc4xMLO_k6JGTs4ZDbW9lx0KbTK1bzFMpvKMcOXh2hun-pW4XnP2Q3vQK2rc",
+      "ETag" : "CNGOvJ6huJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjJEpU9VEdDQqr2mCKGwP2B1Q3o6dSqxR-rB9N3Ovi5EwJO4tMDQwizqBA5_0xN7OyK8yDoi6E",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:08 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:08 GMT",
+      "Expires" : "Thu, 14 May 2026 07:30:58 GMT",
+      "Date" : "Thu, 14 May 2026 07:30:58 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "7babca68-d5f3-4b4b-a53f-98bdb16374e3",
+  "uuid" : "34b00b81-ce55-4bd5-a9b2-827183cc9c9f",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-no-bypass",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-no-bypass-2",
-  "insertionIndex" : 1285
+  "insertionIndex" : 1259
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-3.json
@@ -1,0 +1,41 @@
+{
+  "id" : "7babca68-d5f3-4b4b-a53f-98bdb16374e3",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-GET-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-no-bypass/1778497626651176\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass?generation=1778497626651176&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497626651176\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"74\",\n  \"md5Hash\": \"5fPO7mzM2pVogBmxvWfLhQ==\",\n  \"crc32c\": \"lIhFUQ==\",\n  \"etag\": \"CKj0lPqLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:06.708Z\",\n  \"updated\": \"2026-05-11T11:07:06.708Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:06.708Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:06.708Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CKj0lPqLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEinIig6Xc4xMLO_k6JGTs4ZDbW9lx0KbTK1bzFMpvKMcOXh2hun-pW4XnP2Q3vQK2rc",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:08 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:08 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "7babca68-d5f3-4b4b-a53f-98bdb16374e3",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-no-bypass",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-gov-shorten-no-bypass-2",
+  "insertionIndex" : 1285
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-post-5.json
@@ -1,0 +1,48 @@
+{
+  "id" : "f399224d-ad0b-4673-beb5-8f231964b0fd",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-POST-5",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/gov-shorten-no-bypass"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/gov-shorten-no-bypass\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEiYTnEEAyx7Rw6Z9u7qO9u7FjJ0UghCyoHqhIG2kpUKogoEEgRvngia8vkEawRjqomSWN6a9Y-VVdgAE08nT567Da56kLq7sBmYhWFW3L4",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:05 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/gov-shorten-no-bypass&uploadType=resumable&upload_id=AAVLpEiYTnEEAyx7Rw6Z9u7qO9u7FjJ0UghCyoHqhIG2kpUKogoEEgRvngia8vkEawRjqomSWN6a9Y-VVdgAE08nT567Da56kLq7sBmYhWFW3L4",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "f399224d-ad0b-4673-beb5-8f231964b0fd",
+  "persistent" : true,
+  "insertionIndex" : 1287
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-post-5.json
@@ -1,48 +1,57 @@
 {
-  "id" : "f399224d-ad0b-4673-beb5-8f231964b0fd",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-POST-5",
-  "request" : {
-    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "2"
+  "id": "8f5742a3-b58f-45fa-ae06-76b9c8668b6e",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-POST-5",
+  "request": {
+    "urlPath": "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "2"
       }
     },
-    "queryParameters" : {
-      "name" : {
-        "hasExactly" : [ {
-          "equalTo" : "conformance-tests/objectlock/update/gov-shorten-no-bypass"
-        } ]
+    "queryParameters": {
+      "name": {
+        "hasExactly": [
+          {
+            "equalTo": "conformance-tests/objectlock/update/gov-shorten-no-bypass"
+          }
+        ]
       },
-      "uploadType" : {
-        "hasExactly" : [ {
-          "equalTo" : "resumable"
-        } ]
+      "uploadType": {
+        "hasExactly": [
+          {
+            "equalTo": "resumable"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/gov-shorten-no-bypass\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"},\"temporaryHold\":false}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/gov-shorten-no-bypass\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEiYTnEEAyx7Rw6Z9u7qO9u7FjJ0UghCyoHqhIG2kpUKogoEEgRvngia8vkEawRjqomSWN6a9Y-VVdgAE08nT567Da56kLq7sBmYhWFW3L4",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:05 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/gov-shorten-no-bypass&uploadType=resumable&upload_id=AAVLpEiYTnEEAyx7Rw6Z9u7qO9u7FjJ0UghCyoHqhIG2kpUKogoEEgRvngia8vkEawRjqomSWN6a9Y-VVdgAE08nT567Da56kLq7sBmYhWFW3L4",
-      "Content-Type" : "text/plain; charset=utf-8"
+  "response": {
+    "status": 200,
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID": "AAVLpEif1TIm6d5GGBLheILgdI9cVdzQ1pVxkdKSpycAptKcb0WcmfOdEr5fCChuCwBiQDegCT1SSLLAaA_ZihDP-Oip9V_nGRYjp80kvmumrw",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:30:57 GMT",
+      "Location": "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/gov-shorten-no-bypass&uploadType=resumable&upload_id=AAVLpEif1TIm6d5GGBLheILgdI9cVdzQ1pVxkdKSpycAptKcb0WcmfOdEr5fCChuCwBiQDegCT1SSLLAaA_ZihDP-Oip9V_nGRYjp80kvmumrw",
+      "Content-Type": "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "f399224d-ad0b-4673-beb5-8f231964b0fd",
-  "persistent" : true,
-  "insertionIndex" : 1287
+  "uuid": "8f5742a3-b58f-45fa-ae06-76b9c8668b6e",
+  "persistent": true,
+  "insertionIndex": 1261
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-put-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "f97bc070-3d88-4594-946d-4818b14c4be2",
+  "id" : "8d546dca-ea28-4fd6-810f-aaef1d95fa0d",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-PUT-4",
   "request" : {
     "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -22,7 +22,7 @@
       },
       "upload_id" : {
         "hasExactly" : [ {
-          "equalTo" : "AAVLpEiYTnEEAyx7Rw6Z9u7qO9u7FjJ0UghCyoHqhIG2kpUKogoEEgRvngia8vkEawRjqomSWN6a9Y-VVdgAE08nT567Da56kLq7sBmYhWFW3L4"
+          "equalTo" : "AAVLpEif1TIm6d5GGBLheILgdI9cVdzQ1pVxkdKSpycAptKcb0WcmfOdEr5fCChuCwBiQDegCT1SSLLAaA_ZihDP-Oip9V_nGRYjp80kvmumrw"
         } ]
       }
     },
@@ -33,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-no-bypass/1778497626651176\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass?generation=1778497626651176&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497626651176\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"74\",\n  \"md5Hash\": \"5fPO7mzM2pVogBmxvWfLhQ==\",\n  \"crc32c\": \"lIhFUQ==\",\n  \"etag\": \"CKj0lPqLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:06.708Z\",\n  \"updated\": \"2026-05-11T11:07:06.708Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:06.708Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:06.708Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-no-bypass/1778743858104145\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass?generation=1778743858104145&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743858104145\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"74\",\n  \"md5Hash\": \"5fPO7mzM2pVogBmxvWfLhQ==\",\n  \"crc32c\": \"lIhFUQ==\",\n  \"etag\": \"CNGOvJ6huJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:30:58.164Z\",\n  \"updated\": \"2026-05-14T07:30:58.164Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:30:58.164Z\",\n  \"timeFinalized\": \"2026-05-14T07:30:58.164Z\",\n  \"metadata\": {\n    \"correlation-id\": \"40f85fba-9437-4a12-94b4-b51739cdee92\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CKj0lPqLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEiYTnEEAyx7Rw6Z9u7qO9u7FjJ0UghCyoHqhIG2kpUKogoEEgRvngia8vkEawRjqomSWN6a9Y-VVdgAE08nT567Da56kLq7sBmYhWFW3L4",
+      "ETag" : "CNGOvJ6huJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEif1TIm6d5GGBLheILgdI9cVdzQ1pVxkdKSpycAptKcb0WcmfOdEr5fCChuCwBiQDegCT1SSLLAaA_ZihDP-Oip9V_nGRYjp80kvmumrw",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:06 GMT",
+      "Date" : "Thu, 14 May 2026 07:30:58 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "f97bc070-3d88-4594-946d-4818b14c4be2",
+  "uuid" : "8d546dca-ea28-4fd6-810f-aaef1d95fa0d",
   "persistent" : true,
-  "insertionIndex" : 1286
+  "insertionIndex" : 1260
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-put-4.json
@@ -1,0 +1,53 @@
+{
+  "id" : "f97bc070-3d88-4594-946d-4818b14c4be2",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-PUT-4",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/gov-shorten-no-bypass"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AAVLpEiYTnEEAyx7Rw6Z9u7qO9u7FjJ0UghCyoHqhIG2kpUKogoEEgRvngia8vkEawRjqomSWN6a9Y-VVdgAE08nT567Da56kLq7sBmYhWFW3L4"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "retention-update-conformance-tests/objectlock/update/gov-shorten-no-bypass",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/gov-shorten-no-bypass/1778497626651176\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fgov-shorten-no-bypass?generation=1778497626651176&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/gov-shorten-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497626651176\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"74\",\n  \"md5Hash\": \"5fPO7mzM2pVogBmxvWfLhQ==\",\n  \"crc32c\": \"lIhFUQ==\",\n  \"etag\": \"CKj0lPqLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:06.708Z\",\n  \"updated\": \"2026-05-11T11:07:06.708Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:06.708Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:06.708Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CKj0lPqLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEiYTnEEAyx7Rw6Z9u7qO9u7FjJ0UghCyoHqhIG2kpUKogoEEgRvngia8vkEawRjqomSWN6a9Y-VVdgAE08nT567Da56kLq7sBmYhWFW3L4",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:06 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "f97bc070-3d88-4594-946d-4818b14c4be2",
+  "persistent" : true,
+  "insertionIndex" : 1286
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "5ff653fa-dae4-4944-8452-5197ab522870",
+  "id" : "a0eb279f-488a-446e-9a4a-ebc564ef0885",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-DELETE-0",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEgmQXW_oGBWwwZBhJQgPAyIsMSkfuWzIkn5CMBrmUdK-jlsLdRyGVo_BsF_cA5KdKqW",
+      "X-GUploader-UploadID" : "AAVLpEiq2-HHL7JI9itWXfvOG0uRAp7sXM4kPLL61C7TrCAxVzR23pdIJdgF8gucfmEu7Vex84JYhqI",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:27 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:08 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "5ff653fa-dae4-4944-8452-5197ab522870",
+  "uuid" : "a0eb279f-488a-446e-9a4a-ebc564ef0885",
   "persistent" : true,
-  "insertionIndex" : 1307
+  "insertionIndex" : 1272
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "5ff653fa-dae4-4944-8452-5197ab522870",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEgmQXW_oGBWwwZBhJQgPAyIsMSkfuWzIkn5CMBrmUdK-jlsLdRyGVo_BsF_cA5KdKqW",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:27 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "5ff653fa-dae4-4944-8452-5197ab522870",
+  "persistent" : true,
+  "insertionIndex" : 1307
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "271956a1-fecc-4d30-8e53-b7ceb35c4dfd",
+  "id" : "35014dce-9bdc-41fb-9138-18c035e6d327",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-1",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -29,14 +29,14 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AAVLpEjvUYU--MCRKKMKQITxvYaCux5MMW2rywOVr0L9mbNKL_b-APMcXaS4NhEVygrrNBln",
+      "X-GUploader-UploadID" : "AAVLpEj0fSTdySU09SWdNo4s6x62IMLX5D-7nddVkCe1ofDIQApx8oWoeChcifLGDdoOQaWIqilY0j8",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:26 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:26 GMT",
+      "Expires" : "Thu, 14 May 2026 07:31:08 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:08 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "271956a1-fecc-4d30-8e53-b7ceb35c4dfd",
+  "uuid" : "35014dce-9bdc-41fb-9138-18c035e6d327",
   "persistent" : true,
-  "insertionIndex" : 1308
+  "insertionIndex" : 1273
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "271956a1-fecc-4d30-8e53-b7ceb35c4dfd",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEjvUYU--MCRKKMKQITxvYaCux5MMW2rywOVr0L9mbNKL_b-APMcXaS4NhEVygrrNBln",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:26 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:26 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "271956a1-fecc-4d30-8e53-b7ceb35c4dfd",
+  "persistent" : true,
+  "insertionIndex" : 1308
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-3.json
@@ -1,0 +1,40 @@
+{
+  "id" : "845ef4a2-c96e-4207-a6f1-3e2be10dd7ce",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAI=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:24.481Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CPfV74CMsZQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEhgTP07nfGDgKjokThMNGEYX2UaGhkGJ8FNvZ5xH0Ajdebv31wvO6pk26eLfNSrxKqK",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:25 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:25 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "845ef4a2-c96e-4207-a6f1-3e2be10dd7ce",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved-4",
+  "insertionIndex" : 1310
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "845ef4a2-c96e-4207-a6f1-3e2be10dd7ce",
+  "id" : "5462e02d-68a4-40cc-b123-4a7c79e0e404",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-3",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
@@ -19,22 +19,22 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAI=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:24.481Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778743864676321\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778743864676321&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743864676321\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"COGfzaGhuJQDEAI=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:04.733Z\",\n  \"updated\": \"2026-05-14T07:31:06.762Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:04.733Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:04.733Z\",\n  \"metadata\": {\n    \"correlation-id\": \"f5d6ec96-d994-4774-afdb-3a6c6b9744d8\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CPfV74CMsZQDEAI=",
-      "X-GUploader-UploadID" : "AAVLpEhgTP07nfGDgKjokThMNGEYX2UaGhkGJ8FNvZ5xH0Ajdebv31wvO6pk26eLfNSrxKqK",
+      "ETag" : "COGfzaGhuJQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEjebiHg9JaAOhh455ZnovdFVSr7spgnm3WZmBOZwFD_CJbOHk5fLDRFDzenvF8pBT0Z",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:25 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:25 GMT",
+      "Expires" : "Thu, 14 May 2026 07:31:07 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:07 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "845ef4a2-c96e-4207-a6f1-3e2be10dd7ce",
+  "uuid" : "5462e02d-68a4-40cc-b123-4a7c79e0e404",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved-4",
-  "insertionIndex" : 1310
+  "insertionIndex" : 1275
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "6aba3f12-90ff-47e5-952d-4f61c3b940f6",
+  "id" : "f9321148-cec7-4416-93c7-90e018d7d52a",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-4",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAI=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:24.481Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778743864676321\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778743864676321&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743864676321\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"COGfzaGhuJQDEAI=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:04.733Z\",\n  \"updated\": \"2026-05-14T07:31:06.762Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:04.733Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:04.733Z\",\n  \"metadata\": {\n    \"correlation-id\": \"f5d6ec96-d994-4774-afdb-3a6c6b9744d8\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CPfV74CMsZQDEAI=",
-      "X-GUploader-UploadID" : "AAVLpEhbQR0z7wEsBgt7SJ9knECIxitdNzyrzizqGt8kvemJ1BNK1wP62nGmYQiyjUZpNYN0",
+      "ETag" : "COGfzaGhuJQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEgfxMsltFt6Lg1ykrUwmWRnfQ20y7eN0LQPhjsQyZUIyUTB41BxPSsuKLj47bXcIccywxMhA7c",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:24 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:24 GMT",
+      "Expires" : "Thu, 14 May 2026 07:31:07 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:07 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "6aba3f12-90ff-47e5-952d-4f61c3b940f6",
+  "uuid" : "f9321148-cec7-4416-93c7-90e018d7d52a",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved-3",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved-4",
-  "insertionIndex" : 1311
+  "insertionIndex" : 1276
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-4.json
@@ -1,0 +1,41 @@
+{
+  "id" : "6aba3f12-90ff-47e5-952d-4f61c3b940f6",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-4",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAI=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:24.481Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CPfV74CMsZQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEhbQR0z7wEsBgt7SJ9knECIxitdNzyrzizqGt8kvemJ1BNK1wP62nGmYQiyjUZpNYN0",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:24 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:24 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "6aba3f12-90ff-47e5-952d-4f61c3b940f6",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved-3",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved-4",
+  "insertionIndex" : 1311
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-6.json
@@ -1,5 +1,5 @@
 {
-  "id" : "37fb3792-fd54-441f-a68c-9a34dc199338",
+  "id" : "37e8013a-da29-434c-85a0-62b476ec717b",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-6",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAE=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778743864676321\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778743864676321&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743864676321\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"COGfzaGhuJQDEAE=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:04.733Z\",\n  \"updated\": \"2026-05-14T07:31:04.733Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:04.733Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:04.733Z\",\n  \"metadata\": {\n    \"correlation-id\": \"f5d6ec96-d994-4774-afdb-3a6c6b9744d8\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CPfV74CMsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEgXbXsedpU39A-E-RccxrXoFX0zzrhgemPEFG5Ea2leIjVy_6L9nMc0OEdIXrW9CuqI",
+      "ETag" : "COGfzaGhuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEgM7WxuaMy76hIe7LveKGjnb6uFlN4YtDSUL1crgtf9-cJ72PmrYjt50RLhZufw0fZVfjaHKVI",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:22 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:22 GMT",
+      "Expires" : "Thu, 14 May 2026 07:31:05 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:05 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "37fb3792-fd54-441f-a68c-9a34dc199338",
+  "uuid" : "37e8013a-da29-434c-85a0-62b476ec717b",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved-2",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved-3",
-  "insertionIndex" : 1313
+  "insertionIndex" : 1278
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-6.json
@@ -1,0 +1,41 @@
+{
+  "id" : "37fb3792-fd54-441f-a68c-9a34dc199338",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-6",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAE=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CPfV74CMsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEgXbXsedpU39A-E-RccxrXoFX0zzrhgemPEFG5Ea2leIjVy_6L9nMc0OEdIXrW9CuqI",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:22 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:22 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "37fb3792-fd54-441f-a68c-9a34dc199338",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved-2",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved-3",
+  "insertionIndex" : 1313
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-7.json
@@ -1,5 +1,5 @@
 {
-  "id" : "5db3dba6-ef39-4278-b4ed-cef96691e732",
+  "id" : "49641f1f-2d17-44ef-9dcb-2ed5b1ea2c98",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-7",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAE=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778743864676321\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778743864676321&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743864676321\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"COGfzaGhuJQDEAE=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:04.733Z\",\n  \"updated\": \"2026-05-14T07:31:04.733Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:04.733Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:04.733Z\",\n  \"metadata\": {\n    \"correlation-id\": \"f5d6ec96-d994-4774-afdb-3a6c6b9744d8\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CPfV74CMsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEjWSCfsdQ5zOf9ZVJ8KihzZUgeP1mwk2R6jnJ-bG4hxZT_rxTNWAl6aTqnaTurvyIlS",
+      "ETag" : "COGfzaGhuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjvoTrON4iVzUrEd0V1kP3OQsiL5Z3P_9PT2SrBNeOO3JBTm6rJFKzdVjGiqu4_jvCM",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:21 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:21 GMT",
+      "Expires" : "Thu, 14 May 2026 07:31:05 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:05 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "5db3dba6-ef39-4278-b4ed-cef96691e732",
+  "uuid" : "49641f1f-2d17-44ef-9dcb-2ed5b1ea2c98",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved-2",
-  "insertionIndex" : 1314
+  "insertionIndex" : 1279
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-7.json
@@ -1,0 +1,41 @@
+{
+  "id" : "5db3dba6-ef39-4278-b4ed-cef96691e732",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-7",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAE=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CPfV74CMsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjWSCfsdQ5zOf9ZVJ8KihzZUgeP1mwk2R6jnJ-bG4hxZT_rxTNWAl6aTqnaTurvyIlS",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:21 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:21 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "5db3dba6-ef39-4278-b4ed-cef96691e732",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-legalhold-preserved-2",
+  "insertionIndex" : 1314
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-post-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-post-2.json
@@ -1,0 +1,44 @@
+{
+  "id" : "3ef75f8d-84a9-4b6e-98e3-23de0384f211",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-POST-2",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778497640721143\",\"name\":\"conformance-tests/objectlock/update/legalhold-preserved\",\"temporaryHold\":false}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"3\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAM=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:25.919Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CPfV74CMsZQDEAM=",
+      "X-GUploader-UploadID" : "AAVLpEi4VnvL0T_xiRVUJRJBh8bNn7hGTyLLAjFyou8gnRc6AoquYGuo1ZBlJHOlrZSAQ00",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:25 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "3ef75f8d-84a9-4b6e-98e3-23de0384f211",
+  "persistent" : true,
+  "insertionIndex" : 1309
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-post-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-post-2.json
@@ -1,44 +1,51 @@
 {
-  "id" : "3ef75f8d-84a9-4b6e-98e3-23de0384f211",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-POST-2",
-  "request" : {
-    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "1"
+  "id": "eed7363e-bf89-41da-9453-d366367c27e7",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-POST-2",
+  "request": {
+    "urlPath": "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "1"
       }
     },
-    "queryParameters" : {
-      "projection" : {
-        "hasExactly" : [ {
-          "equalTo" : "full"
-        } ]
+    "queryParameters": {
+      "projection": {
+        "hasExactly": [
+          {
+            "equalTo": "full"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778497640721143\",\"name\":\"conformance-tests/objectlock/update/legalhold-preserved\",\"temporaryHold\":false}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778743864676321\",\"name\":\"conformance-tests/objectlock/update/legalhold-preserved\",\"temporaryHold\":false}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"3\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAM=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:25.919Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CPfV74CMsZQDEAM=",
-      "X-GUploader-UploadID" : "AAVLpEi4VnvL0T_xiRVUJRJBh8bNn7hGTyLLAjFyou8gnRc6AoquYGuo1ZBlJHOlrZSAQ00",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:25 GMT",
-      "Content-Type" : "application/json; charset=UTF-8"
+  "response": {
+    "status": 200,
+    "body": "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778743864676321\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778743864676321&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743864676321\",\n  \"metageneration\": \"3\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"COGfzaGhuJQDEAM=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:04.733Z\",\n  \"updated\": \"2026-05-14T07:31:07.961Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:04.733Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:04.733Z\",\n  \"metadata\": {\n    \"correlation-id\": \"f5d6ec96-d994-4774-afdb-3a6c6b9744d8\"\n  }\n}\n",
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag": "COGfzaGhuJQDEAM=",
+      "X-GUploader-UploadID": "AAVLpEiesFDBoHmuNg3p8viFumisdwGShQD2wmW3hSzrB0WY9XXSjLFIzvRFXsEFl0UMRA_M",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:31:07 GMT",
+      "Content-Type": "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "3ef75f8d-84a9-4b6e-98e3-23de0384f211",
-  "persistent" : true,
-  "insertionIndex" : 1309
+  "uuid": "eed7363e-bf89-41da-9453-d366367c27e7",
+  "persistent": true,
+  "insertionIndex": 1274
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-post-5.json
@@ -1,44 +1,51 @@
 {
-  "id" : "6bcb3869-053b-4643-84c2-767a8aaa349e",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-POST-5",
-  "request" : {
-    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "1"
+  "id": "5f438ec0-2cfc-4349-8550-2dc6fe9bb5ae",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-POST-5",
+  "request": {
+    "urlPath": "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "1"
       }
     },
-    "queryParameters" : {
-      "projection" : {
-        "hasExactly" : [ {
-          "equalTo" : "full"
-        } ]
+    "queryParameters": {
+      "projection": {
+        "hasExactly": [
+          {
+            "equalTo": "full"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778497640721143\",\"name\":\"conformance-tests/objectlock/update/legalhold-preserved\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"}}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778743864676321\",\"name\":\"conformance-tests/objectlock/update/legalhold-preserved\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"}}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAI=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:24.481Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CPfV74CMsZQDEAI=",
-      "X-GUploader-UploadID" : "AAVLpEjRnNkfKjAZoZj7zWxQfZZLfiD4VhnqMGS95Nc_svGMy0r4HSTqybUJWRACncsa51c",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:24 GMT",
-      "Content-Type" : "application/json; charset=UTF-8"
+  "response": {
+    "status": 200,
+    "body": "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778743864676321\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778743864676321&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743864676321\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"COGfzaGhuJQDEAI=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:04.733Z\",\n  \"updated\": \"2026-05-14T07:31:06.762Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:04.733Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:04.733Z\",\n  \"metadata\": {\n    \"correlation-id\": \"f5d6ec96-d994-4774-afdb-3a6c6b9744d8\"\n  }\n}\n",
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag": "COGfzaGhuJQDEAI=",
+      "X-GUploader-UploadID": "AAVLpEgVhoH_YGringtYGIL67dpoYREyZXuBOp99zBdxqwgB3TC61duZCCup2r3_oSPkcfcENkcOZS4",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:31:06 GMT",
+      "Content-Type": "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "6bcb3869-053b-4643-84c2-767a8aaa349e",
-  "persistent" : true,
-  "insertionIndex" : 1312
+  "uuid": "5f438ec0-2cfc-4349-8550-2dc6fe9bb5ae",
+  "persistent": true,
+  "insertionIndex": 1277
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-post-5.json
@@ -1,0 +1,44 @@
+{
+  "id" : "6bcb3869-053b-4643-84c2-767a8aaa349e",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-POST-5",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778497640721143\",\"name\":\"conformance-tests/objectlock/update/legalhold-preserved\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"}}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAI=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:24.481Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CPfV74CMsZQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEjRnNkfKjAZoZj7zWxQfZZLfiD4VhnqMGS95Nc_svGMy0r4HSTqybUJWRACncsa51c",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:24 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "6bcb3869-053b-4643-84c2-767a8aaa349e",
+  "persistent" : true,
+  "insertionIndex" : 1312
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-post-9.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-post-9.json
@@ -1,0 +1,48 @@
+{
+  "id" : "353b1302-788c-4661-89fb-7e2ac7b06065",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-POST-9",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/legalhold-preserved"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/legalhold-preserved\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":true}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEg0XF5E4wv5rIMvtd5KtJvG7TdKmweh2uYvrVfFu2RlAwskHXpb_64UWhNsQwbrE-5E8xLf5O_vdXBPJayRdMi15IwHbzpg7osgdkESVQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:20 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/legalhold-preserved&uploadType=resumable&upload_id=AAVLpEg0XF5E4wv5rIMvtd5KtJvG7TdKmweh2uYvrVfFu2RlAwskHXpb_64UWhNsQwbrE-5E8xLf5O_vdXBPJayRdMi15IwHbzpg7osgdkESVQ",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "353b1302-788c-4661-89fb-7e2ac7b06065",
+  "persistent" : true,
+  "insertionIndex" : 1316
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-post-9.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-post-9.json
@@ -1,48 +1,57 @@
 {
-  "id" : "353b1302-788c-4661-89fb-7e2ac7b06065",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-POST-9",
-  "request" : {
-    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "2"
+  "id": "9354c97a-675d-4e30-9df9-d6926de4f7e1",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-POST-9",
+  "request": {
+    "urlPath": "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "2"
       }
     },
-    "queryParameters" : {
-      "name" : {
-        "hasExactly" : [ {
-          "equalTo" : "conformance-tests/objectlock/update/legalhold-preserved"
-        } ]
+    "queryParameters": {
+      "name": {
+        "hasExactly": [
+          {
+            "equalTo": "conformance-tests/objectlock/update/legalhold-preserved"
+          }
+        ]
       },
-      "uploadType" : {
-        "hasExactly" : [ {
-          "equalTo" : "resumable"
-        } ]
+      "uploadType": {
+        "hasExactly": [
+          {
+            "equalTo": "resumable"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/legalhold-preserved\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":true}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/legalhold-preserved\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":true}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEg0XF5E4wv5rIMvtd5KtJvG7TdKmweh2uYvrVfFu2RlAwskHXpb_64UWhNsQwbrE-5E8xLf5O_vdXBPJayRdMi15IwHbzpg7osgdkESVQ",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:20 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/legalhold-preserved&uploadType=resumable&upload_id=AAVLpEg0XF5E4wv5rIMvtd5KtJvG7TdKmweh2uYvrVfFu2RlAwskHXpb_64UWhNsQwbrE-5E8xLf5O_vdXBPJayRdMi15IwHbzpg7osgdkESVQ",
-      "Content-Type" : "text/plain; charset=utf-8"
+  "response": {
+    "status": 200,
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID": "AAVLpEia1444eHCnqPS_bH7-JBbDv-AfozB4Tw8fkHjkjv89Tmerb-KjEX6X7VPF4XE9WCp9ZfzHbMXCM0qdPCUDthSdCTCpNabpi-tFQ82ovFE",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:31:04 GMT",
+      "Location": "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/legalhold-preserved&uploadType=resumable&upload_id=AAVLpEia1444eHCnqPS_bH7-JBbDv-AfozB4Tw8fkHjkjv89Tmerb-KjEX6X7VPF4XE9WCp9ZfzHbMXCM0qdPCUDthSdCTCpNabpi-tFQ82ovFE",
+      "Content-Type": "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "353b1302-788c-4661-89fb-7e2ac7b06065",
-  "persistent" : true,
-  "insertionIndex" : 1316
+  "uuid": "9354c97a-675d-4e30-9df9-d6926de4f7e1",
+  "persistent": true,
+  "insertionIndex": 1281
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-8.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-8.json
@@ -1,5 +1,5 @@
 {
-  "id" : "efcaf50f-2cea-4c99-8b34-d2d0192ff37a",
+  "id" : "cbd12a1d-295f-467f-9451-06cbcd9ef9c7",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-PUT-8",
   "request" : {
     "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -22,7 +22,7 @@
       },
       "upload_id" : {
         "hasExactly" : [ {
-          "equalTo" : "AAVLpEg0XF5E4wv5rIMvtd5KtJvG7TdKmweh2uYvrVfFu2RlAwskHXpb_64UWhNsQwbrE-5E8xLf5O_vdXBPJayRdMi15IwHbzpg7osgdkESVQ"
+          "equalTo" : "AAVLpEia1444eHCnqPS_bH7-JBbDv-AfozB4Tw8fkHjkjv89Tmerb-KjEX6X7VPF4XE9WCp9ZfzHbMXCM0qdPCUDthSdCTCpNabpi-tFQ82ovFE"
         } ]
       }
     },
@@ -33,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAE=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778743864676321\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778743864676321&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778743864676321\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"COGfzaGhuJQDEAE=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:31:04.733Z\",\n  \"updated\": \"2026-05-14T07:31:04.733Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:31:04.733Z\",\n  \"timeFinalized\": \"2026-05-14T07:31:04.733Z\",\n  \"metadata\": {\n    \"correlation-id\": \"f5d6ec96-d994-4774-afdb-3a6c6b9744d8\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CPfV74CMsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEg0XF5E4wv5rIMvtd5KtJvG7TdKmweh2uYvrVfFu2RlAwskHXpb_64UWhNsQwbrE-5E8xLf5O_vdXBPJayRdMi15IwHbzpg7osgdkESVQ",
+      "ETag" : "COGfzaGhuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEia1444eHCnqPS_bH7-JBbDv-AfozB4Tw8fkHjkjv89Tmerb-KjEX6X7VPF4XE9WCp9ZfzHbMXCM0qdPCUDthSdCTCpNabpi-tFQ82ovFE",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:20 GMT",
+      "Date" : "Thu, 14 May 2026 07:31:04 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "efcaf50f-2cea-4c99-8b34-d2d0192ff37a",
+  "uuid" : "cbd12a1d-295f-467f-9451-06cbcd9ef9c7",
   "persistent" : true,
-  "insertionIndex" : 1315
+  "insertionIndex" : 1280
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-8.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-8.json
@@ -1,0 +1,53 @@
+{
+  "id" : "efcaf50f-2cea-4c99-8b34-d2d0192ff37a",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-PUT-8",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/legalhold-preserved"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AAVLpEg0XF5E4wv5rIMvtd5KtJvG7TdKmweh2uYvrVfFu2RlAwskHXpb_64UWhNsQwbrE-5E8xLf5O_vdXBPJayRdMi15IwHbzpg7osgdkESVQ"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "legalhold-preserved",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/legalhold-preserved/1778497640721143\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Flegalhold-preserved?generation=1778497640721143&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/legalhold-preserved\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497640721143\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"19\",\n  \"md5Hash\": \"8w7gd2cGXJ+cwx0XvNaVCA==\",\n  \"crc32c\": \"VXd1+w==\",\n  \"etag\": \"CPfV74CMsZQDEAE=\",\n  \"temporaryHold\": true,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:20.779Z\",\n  \"updated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:20.779Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:20.779Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CPfV74CMsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEg0XF5E4wv5rIMvtd5KtJvG7TdKmweh2uYvrVfFu2RlAwskHXpb_64UWhNsQwbrE-5E8xLf5O_vdXBPJayRdMi15IwHbzpg7osgdkESVQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:20 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "efcaf50f-2cea-4c99-8b34-d2d0192ff37a",
+  "persistent" : true,
+  "insertionIndex" : 1315
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "e084a916-2fe5-4555-9989-54cc713ccb6e",
+  "id" : "ea9c4fb6-2e97-4ec1-8ae3-df37b887b5d1",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-DELETE-0",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEisT3rhLqG9nLCBv5dUoJMteQSk6uCOKUVA2Rwt7RvURw6PaaQKUiseQHvW3Rt_LBQa",
+      "X-GUploader-UploadID" : "AAVLpEiEJh1QQ0RKeE4IDy8MsleazKpNGDrpE7-BWdgLynOvVqXO_Q8GuTHjmOZn6RK2pSsIjUCoTCg",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:00 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:26 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "e084a916-2fe5-4555-9989-54cc713ccb6e",
+  "uuid" : "ea9c4fb6-2e97-4ec1-8ae3-df37b887b5d1",
   "persistent" : true,
-  "insertionIndex" : 1265
+  "insertionIndex" : 1309
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "e084a916-2fe5-4555-9989-54cc713ccb6e",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEisT3rhLqG9nLCBv5dUoJMteQSk6uCOKUVA2Rwt7RvURw6PaaQKUiseQHvW3Rt_LBQa",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:00 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "e084a916-2fe5-4555-9989-54cc713ccb6e",
+  "persistent" : true,
+  "insertionIndex" : 1265
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "597ec44f-2f41-42b0-90e9-8d9e49ecc16f",
+  "id" : "c4d1f953-c8d7-470e-8658-5a6db0c72537",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-GET-1",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -29,14 +29,14 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AAVLpEgHt7rWKhBJKALN7hegh2PqItxwaxmtwMHUc4ubrcuz9vhst1_lSj3y0bmTqCB1PQ8",
+      "X-GUploader-UploadID" : "AAVLpEgKYQ0LbRZBTL6EipeXlX1ds5pKCGcpgxKJ--xHklOWOOjqKVvCM-xa7uUbnOKLpaCB",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:06:59 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:59 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:25 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:25 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "597ec44f-2f41-42b0-90e9-8d9e49ecc16f",
+  "uuid" : "c4d1f953-c8d7-470e-8658-5a6db0c72537",
   "persistent" : true,
-  "insertionIndex" : 1266
+  "insertionIndex" : 1310
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "597ec44f-2f41-42b0-90e9-8d9e49ecc16f",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEgHt7rWKhBJKALN7hegh2PqItxwaxmtwMHUc4ubrcuz9vhst1_lSj3y0bmTqCB1PQ8",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:06:59 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:59 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "597ec44f-2f41-42b0-90e9-8d9e49ecc16f",
+  "persistent" : true,
+  "insertionIndex" : 1266
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "32873d40-4862-46b3-8459-53f05c10830f",
+  "id" : "b21d99e0-f922-4d2b-854c-6a83a715e257",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-GET-2",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade",
@@ -19,22 +19,22 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-downgrade/1778497617903436\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade?generation=1778497617903436&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-downgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497617903436\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"67\",\n  \"md5Hash\": \"O82ngmB/FsifDE071Umm0A==\",\n  \"crc32c\": \"4Q5YlQ==\",\n  \"etag\": \"CMz+/vWLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:57.960Z\",\n  \"updated\": \"2026-05-11T11:06:57.960Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:57.960Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:57.960Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-downgrade/1778744664392077\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade?generation=1778744664392077&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-downgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744664392077\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"67\",\n  \"md5Hash\": \"O82ngmB/FsifDE071Umm0A==\",\n  \"crc32c\": \"4Q5YlQ==\",\n  \"etag\": \"CI2D+J6kuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:24.457Z\",\n  \"updated\": \"2026-05-14T07:44:24.457Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:24.457Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:24.457Z\",\n  \"metadata\": {\n    \"correlation-id\": \"8745dc58-5a5d-4c0d-9583-891db00fbe1e\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CMz+/vWLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEg3LxVeYh_4xoAjKl2PaUtEyCzOYrS2bBEo9EO8TrBEykG1HNDcf7CJ7yxuEmJEKlc",
+      "ETag" : "CI2D+J6kuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhpRBYU8NErO6_FU9TzViKlwh7rMN3eeHrv27hjiLaqN47D12DRcWytGYefScCSWHJ7AgY9cmE",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:06:58 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:58 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:25 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:25 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "32873d40-4862-46b3-8459-53f05c10830f",
+  "uuid" : "b21d99e0-f922-4d2b-854c-6a83a715e257",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-downgrade",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-downgrade-2",
-  "insertionIndex" : 1267
+  "insertionIndex" : 1311
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-2.json
@@ -1,0 +1,40 @@
+{
+  "id" : "32873d40-4862-46b3-8459-53f05c10830f",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-GET-2",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-downgrade/1778497617903436\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade?generation=1778497617903436&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-downgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497617903436\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"67\",\n  \"md5Hash\": \"O82ngmB/FsifDE071Umm0A==\",\n  \"crc32c\": \"4Q5YlQ==\",\n  \"etag\": \"CMz+/vWLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:57.960Z\",\n  \"updated\": \"2026-05-11T11:06:57.960Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:57.960Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:57.960Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CMz+/vWLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEg3LxVeYh_4xoAjKl2PaUtEyCzOYrS2bBEo9EO8TrBEykG1HNDcf7CJ7yxuEmJEKlc",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:06:58 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:58 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "32873d40-4862-46b3-8459-53f05c10830f",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-downgrade",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-downgrade-2",
+  "insertionIndex" : 1267
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-3.json
@@ -1,0 +1,41 @@
+{
+  "id" : "a2c8098f-55d9-4893-8ab5-fdc74d5cb872",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-GET-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-downgrade/1778497617903436\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade?generation=1778497617903436&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-downgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497617903436\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"67\",\n  \"md5Hash\": \"O82ngmB/FsifDE071Umm0A==\",\n  \"crc32c\": \"4Q5YlQ==\",\n  \"etag\": \"CMz+/vWLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:57.960Z\",\n  \"updated\": \"2026-05-11T11:06:57.960Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:57.960Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:57.960Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CMz+/vWLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEiFdcoKBKHPAGQ3xbusBfz2bvoH2i05I0kuOpjp4858c-5vQAvUBahcvk1uX-zDqFpgzIUteqY",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:06:58 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:58 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "a2c8098f-55d9-4893-8ab5-fdc74d5cb872",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-downgrade",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-downgrade-2",
+  "insertionIndex" : 1268
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "a2c8098f-55d9-4893-8ab5-fdc74d5cb872",
+  "id" : "f573f442-cf7f-4098-a885-669ab7e24d96",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-GET-3",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-downgrade/1778497617903436\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade?generation=1778497617903436&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-downgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497617903436\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"67\",\n  \"md5Hash\": \"O82ngmB/FsifDE071Umm0A==\",\n  \"crc32c\": \"4Q5YlQ==\",\n  \"etag\": \"CMz+/vWLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:57.960Z\",\n  \"updated\": \"2026-05-11T11:06:57.960Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:57.960Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:57.960Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-downgrade/1778744664392077\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade?generation=1778744664392077&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-downgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744664392077\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"67\",\n  \"md5Hash\": \"O82ngmB/FsifDE071Umm0A==\",\n  \"crc32c\": \"4Q5YlQ==\",\n  \"etag\": \"CI2D+J6kuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:24.457Z\",\n  \"updated\": \"2026-05-14T07:44:24.457Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:24.457Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:24.457Z\",\n  \"metadata\": {\n    \"correlation-id\": \"8745dc58-5a5d-4c0d-9583-891db00fbe1e\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CMz+/vWLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEiFdcoKBKHPAGQ3xbusBfz2bvoH2i05I0kuOpjp4858c-5vQAvUBahcvk1uX-zDqFpgzIUteqY",
+      "ETag" : "CI2D+J6kuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjrtR0kqNNGNepxXQmbrmPWboxdxp1vVbZJc2zRbXZHVbjN0e-0CIt88W80pmRiwzJOCrJwBGU",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:06:58 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:58 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:24 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:24 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "a2c8098f-55d9-4893-8ab5-fdc74d5cb872",
+  "uuid" : "f573f442-cf7f-4098-a885-669ab7e24d96",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-downgrade",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-downgrade-2",
-  "insertionIndex" : 1268
+  "insertionIndex" : 1312
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-post-5.json
@@ -1,0 +1,48 @@
+{
+  "id" : "97900dc5-4285-47f6-95dc-05ce2e1633cc",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-POST-5",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/mode-downgrade"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/mode-downgrade\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEhNSQ8npDK57VnoZDIqIEO91oKLE6MPpYFmB1r76Gd7E0nYFm5AxRxHB2BnNhxUAgwkOUOXMiP0kqVkooqtFLk2JtBmJmNQL1UkvJ-38g",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:57 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/mode-downgrade&uploadType=resumable&upload_id=AAVLpEhNSQ8npDK57VnoZDIqIEO91oKLE6MPpYFmB1r76Gd7E0nYFm5AxRxHB2BnNhxUAgwkOUOXMiP0kqVkooqtFLk2JtBmJmNQL1UkvJ-38g",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "97900dc5-4285-47f6-95dc-05ce2e1633cc",
+  "persistent" : true,
+  "insertionIndex" : 1270
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-post-5.json
@@ -1,48 +1,57 @@
 {
-  "id" : "97900dc5-4285-47f6-95dc-05ce2e1633cc",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-POST-5",
-  "request" : {
-    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "2"
+  "id": "282f4642-93f7-47de-9cca-b9e6d2397f04",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-POST-5",
+  "request": {
+    "urlPath": "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "2"
       }
     },
-    "queryParameters" : {
-      "name" : {
-        "hasExactly" : [ {
-          "equalTo" : "conformance-tests/objectlock/update/mode-downgrade"
-        } ]
+    "queryParameters": {
+      "name": {
+        "hasExactly": [
+          {
+            "equalTo": "conformance-tests/objectlock/update/mode-downgrade"
+          }
+        ]
       },
-      "uploadType" : {
-        "hasExactly" : [ {
-          "equalTo" : "resumable"
-        } ]
+      "uploadType": {
+        "hasExactly": [
+          {
+            "equalTo": "resumable"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/mode-downgrade\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/mode-downgrade\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEhNSQ8npDK57VnoZDIqIEO91oKLE6MPpYFmB1r76Gd7E0nYFm5AxRxHB2BnNhxUAgwkOUOXMiP0kqVkooqtFLk2JtBmJmNQL1UkvJ-38g",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:57 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/mode-downgrade&uploadType=resumable&upload_id=AAVLpEhNSQ8npDK57VnoZDIqIEO91oKLE6MPpYFmB1r76Gd7E0nYFm5AxRxHB2BnNhxUAgwkOUOXMiP0kqVkooqtFLk2JtBmJmNQL1UkvJ-38g",
-      "Content-Type" : "text/plain; charset=utf-8"
+  "response": {
+    "status": 200,
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID": "AAVLpEgqqVZ7NeweJoXTWexJXhAmmqH4kScDMqHgscH3xJ-ksmZ_MzfMmyrYMCQFmPgN4nm4XZ28w2fHCI3dnUeHQuIot_3yiCvyNx2e_gny5Q",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:44:23 GMT",
+      "Location": "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/mode-downgrade&uploadType=resumable&upload_id=AAVLpEgqqVZ7NeweJoXTWexJXhAmmqH4kScDMqHgscH3xJ-ksmZ_MzfMmyrYMCQFmPgN4nm4XZ28w2fHCI3dnUeHQuIot_3yiCvyNx2e_gny5Q",
+      "Content-Type": "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "97900dc5-4285-47f6-95dc-05ce2e1633cc",
-  "persistent" : true,
-  "insertionIndex" : 1270
+  "uuid": "282f4642-93f7-47de-9cca-b9e6d2397f04",
+  "persistent": true,
+  "insertionIndex": 1314
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-put-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "d2964937-eb58-4942-9f97-ecfe394bbbdc",
+  "id" : "85b67bee-ad0a-46d9-a1c7-c70443ab72e1",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-PUT-4",
   "request" : {
     "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -22,7 +22,7 @@
       },
       "upload_id" : {
         "hasExactly" : [ {
-          "equalTo" : "AAVLpEhNSQ8npDK57VnoZDIqIEO91oKLE6MPpYFmB1r76Gd7E0nYFm5AxRxHB2BnNhxUAgwkOUOXMiP0kqVkooqtFLk2JtBmJmNQL1UkvJ-38g"
+          "equalTo" : "AAVLpEgqqVZ7NeweJoXTWexJXhAmmqH4kScDMqHgscH3xJ-ksmZ_MzfMmyrYMCQFmPgN4nm4XZ28w2fHCI3dnUeHQuIot_3yiCvyNx2e_gny5Q"
         } ]
       }
     },
@@ -33,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-downgrade/1778497617903436\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade?generation=1778497617903436&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-downgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497617903436\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"67\",\n  \"md5Hash\": \"O82ngmB/FsifDE071Umm0A==\",\n  \"crc32c\": \"4Q5YlQ==\",\n  \"etag\": \"CMz+/vWLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:57.960Z\",\n  \"updated\": \"2026-05-11T11:06:57.960Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:57.960Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:57.960Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-downgrade/1778744664392077\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade?generation=1778744664392077&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-downgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744664392077\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"67\",\n  \"md5Hash\": \"O82ngmB/FsifDE071Umm0A==\",\n  \"crc32c\": \"4Q5YlQ==\",\n  \"etag\": \"CI2D+J6kuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:24.457Z\",\n  \"updated\": \"2026-05-14T07:44:24.457Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:24.457Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:24.457Z\",\n  \"metadata\": {\n    \"correlation-id\": \"8745dc58-5a5d-4c0d-9583-891db00fbe1e\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CMz+/vWLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEhNSQ8npDK57VnoZDIqIEO91oKLE6MPpYFmB1r76Gd7E0nYFm5AxRxHB2BnNhxUAgwkOUOXMiP0kqVkooqtFLk2JtBmJmNQL1UkvJ-38g",
+      "ETag" : "CI2D+J6kuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEgqqVZ7NeweJoXTWexJXhAmmqH4kScDMqHgscH3xJ-ksmZ_MzfMmyrYMCQFmPgN4nm4XZ28w2fHCI3dnUeHQuIot_3yiCvyNx2e_gny5Q",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:57 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:24 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "d2964937-eb58-4942-9f97-ecfe394bbbdc",
+  "uuid" : "85b67bee-ad0a-46d9-a1c7-c70443ab72e1",
   "persistent" : true,
-  "insertionIndex" : 1269
+  "insertionIndex" : 1313
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-put-4.json
@@ -1,0 +1,53 @@
+{
+  "id" : "d2964937-eb58-4942-9f97-ecfe394bbbdc",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-PUT-4",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/mode-downgrade"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AAVLpEhNSQ8npDK57VnoZDIqIEO91oKLE6MPpYFmB1r76Gd7E0nYFm5AxRxHB2BnNhxUAgwkOUOXMiP0kqVkooqtFLk2JtBmJmNQL1UkvJ-38g"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "retention-update-conformance-tests/objectlock/update/mode-downgrade",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-downgrade/1778497617903436\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-downgrade?generation=1778497617903436&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-downgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497617903436\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"67\",\n  \"md5Hash\": \"O82ngmB/FsifDE071Umm0A==\",\n  \"crc32c\": \"4Q5YlQ==\",\n  \"etag\": \"CMz+/vWLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:57.960Z\",\n  \"updated\": \"2026-05-11T11:06:57.960Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:57.960Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:57.960Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CMz+/vWLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhNSQ8npDK57VnoZDIqIEO91oKLE6MPpYFmB1r76Gd7E0nYFm5AxRxHB2BnNhxUAgwkOUOXMiP0kqVkooqtFLk2JtBmJmNQL1UkvJ-38g",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:57 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "d2964937-eb58-4942-9f97-ecfe394bbbdc",
+  "persistent" : true,
+  "insertionIndex" : 1269
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "d3513bd2-bef8-422e-b1bf-bddd28d34337",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEiK9Yg-CXezm_8UM6eint20dEhmHpSKOwvqo8pRih2wn52dbXX0CLRHnMIe4mp8in4",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:56 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "d3513bd2-bef8-422e-b1bf-bddd28d34337",
+  "persistent" : true,
+  "insertionIndex" : 1256
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "d3513bd2-bef8-422e-b1bf-bddd28d34337",
+  "id" : "d3bf0c20-285f-4d78-8641-749c906dc757",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-DELETE-0",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEiK9Yg-CXezm_8UM6eint20dEhmHpSKOwvqo8pRih2wn52dbXX0CLRHnMIe4mp8in4",
+      "X-GUploader-UploadID" : "AAVLpEj8qDozd2MfXGMBPbHXD-RAV_18WmcJbFI2WGMB8vVAYBav4C_UfFNXa5PkiA08oLjd",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:56 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:23 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "d3513bd2-bef8-422e-b1bf-bddd28d34337",
+  "uuid" : "d3bf0c20-285f-4d78-8641-749c906dc757",
   "persistent" : true,
-  "insertionIndex" : 1256
+  "insertionIndex" : 1300
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "753ad341-5ce5-4645-92f1-0fffd56ff18b",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEgs8BwzmznTfsyliRL0fHmYtilN40CRdM2w56YEBx5qiUqzxVWcTEzGbPsHGpcqE0tA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:06:54 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:54 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "753ad341-5ce5-4645-92f1-0fffd56ff18b",
+  "persistent" : true,
+  "insertionIndex" : 1257
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "753ad341-5ce5-4645-92f1-0fffd56ff18b",
+  "id" : "d7d58b23-b076-4eeb-a252-7781a1f33a70",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-GET-1",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -29,14 +29,14 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AAVLpEgs8BwzmznTfsyliRL0fHmYtilN40CRdM2w56YEBx5qiUqzxVWcTEzGbPsHGpcqE0tA",
+      "X-GUploader-UploadID" : "AAVLpEj1STy9QUPuon4wg60bMdGkGXzqeyYhaP74kCCYRuGsPrSH5Ce62XKe2DdwYzffgtjvwSw9_RE",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:06:54 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:54 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:22 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:22 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "753ad341-5ce5-4645-92f1-0fffd56ff18b",
+  "uuid" : "d7d58b23-b076-4eeb-a252-7781a1f33a70",
   "persistent" : true,
-  "insertionIndex" : 1257
+  "insertionIndex" : 1301
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "522d2a6e-3374-433d-b58b-b566449892b7",
+  "id" : "d8ba2186-ac70-4fce-b4cf-5c60cdb768df",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-GET-2",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade",
@@ -19,22 +19,22 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778497610582343\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778497610582343&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497610582343\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CMeSwPKLsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:50.642Z\",\n  \"updated\": \"2026-05-11T11:06:52.224Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:50.642Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778744660948612\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778744660948612&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744660948612\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CITtpZ2kuJQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:21.011Z\",\n  \"updated\": \"2026-05-14T07:44:22.230Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:21.011Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:21.011Z\",\n  \"metadata\": {\n    \"correlation-id\": \"ab57bdf6-e334-4525-bfd7-d00d4c29642c\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CMeSwPKLsZQDEAI=",
-      "X-GUploader-UploadID" : "AAVLpEi5xUoA1T5R6yLAqi3aNM2WCppxFT3xo_46fwGxyaIO9ysBYtB2VbjbRSceI__z-BWlgTDIlpw",
+      "ETag" : "CITtpZ2kuJQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEhbwMbMOp-_Bz5RzEONozmtUaSnSkO14oNvPNHwS_EcHwLY7T3smUoAWonLhacVxHbhN-QeSdQ",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:06:52 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:52 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:22 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:22 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "522d2a6e-3374-433d-b58b-b566449892b7",
+  "uuid" : "d8ba2186-ac70-4fce-b4cf-5c60cdb768df",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-3",
-  "insertionIndex" : 1258
+  "insertionIndex" : 1302
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-2.json
@@ -1,0 +1,40 @@
+{
+  "id" : "522d2a6e-3374-433d-b58b-b566449892b7",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-GET-2",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778497610582343\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778497610582343&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497610582343\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CMeSwPKLsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:50.642Z\",\n  \"updated\": \"2026-05-11T11:06:52.224Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:50.642Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CMeSwPKLsZQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEi5xUoA1T5R6yLAqi3aNM2WCppxFT3xo_46fwGxyaIO9ysBYtB2VbjbRSceI__z-BWlgTDIlpw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:06:52 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:52 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "522d2a6e-3374-433d-b58b-b566449892b7",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-3",
+  "insertionIndex" : 1258
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-4.json
@@ -1,0 +1,41 @@
+{
+  "id" : "a1f38bf6-6dbd-4f4c-8453-88554731cd8b",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-GET-4",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778497610582343\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778497610582343&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497610582343\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CMeSwPKLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:50.642Z\",\n  \"updated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:50.642Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CMeSwPKLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEirxDCtCU_bK_XdBfbUxgJHm4wS1tHwsBHS2IfPVQjLDu9OcJ3M5y-VUN1kTP4dsvI",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:06:51 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:51 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "a1f38bf6-6dbd-4f4c-8453-88554731cd8b",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-2",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-3",
+  "insertionIndex" : 1260
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "a1f38bf6-6dbd-4f4c-8453-88554731cd8b",
+  "id" : "aea1a797-6a23-493b-9d00-4a10eaa42e85",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-GET-4",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778497610582343\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778497610582343&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497610582343\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CMeSwPKLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:50.642Z\",\n  \"updated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:50.642Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778744660948612\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778744660948612&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744660948612\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CITtpZ2kuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:21.011Z\",\n  \"updated\": \"2026-05-14T07:44:21.011Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:21.011Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:21.011Z\",\n  \"metadata\": {\n    \"correlation-id\": \"ab57bdf6-e334-4525-bfd7-d00d4c29642c\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CMeSwPKLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEirxDCtCU_bK_XdBfbUxgJHm4wS1tHwsBHS2IfPVQjLDu9OcJ3M5y-VUN1kTP4dsvI",
+      "ETag" : "CITtpZ2kuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjHwZ9VG3z9D8Hzlox03yUPrYGEY5zjGil2s7UDfeSAjZYMhuXrEHYZC9caxQ7cPldu",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:06:51 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:51 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:21 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:21 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "a1f38bf6-6dbd-4f4c-8453-88554731cd8b",
+  "uuid" : "aea1a797-6a23-493b-9d00-4a10eaa42e85",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-2",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-3",
-  "insertionIndex" : 1260
+  "insertionIndex" : 1304
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-5.json
@@ -1,5 +1,5 @@
 {
-  "id" : "c0e12876-09b5-4ff5-a371-a6d7419cda8f",
+  "id" : "c95eb64d-253f-4dce-8bd0-9b934d9255c7",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-GET-5",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778497610582343\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778497610582343&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497610582343\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CMeSwPKLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:50.642Z\",\n  \"updated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:50.642Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778744660948612\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778744660948612&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744660948612\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CITtpZ2kuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:21.011Z\",\n  \"updated\": \"2026-05-14T07:44:21.011Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:21.011Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:21.011Z\",\n  \"metadata\": {\n    \"correlation-id\": \"ab57bdf6-e334-4525-bfd7-d00d4c29642c\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CMeSwPKLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEigPSVmEiy50CQ4-AqTvBKNpXieer8pA1UoKG7NYPR9IIUiSgqgYB4o_R9LNkeLn6FwFAJVjIE",
+      "ETag" : "CITtpZ2kuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjCmO9c_KfcDPkaJvpHvsUcmrWC2xCMlTic-tj0RGf_UK6UR95VTZYvRLWZ9NBcIzhke7nVctY",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:06:51 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:51 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:21 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:21 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "c0e12876-09b5-4ff5-a371-a6d7419cda8f",
+  "uuid" : "c95eb64d-253f-4dce-8bd0-9b934d9255c7",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-2",
-  "insertionIndex" : 1261
+  "insertionIndex" : 1305
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-get-5.json
@@ -1,0 +1,41 @@
+{
+  "id" : "c0e12876-09b5-4ff5-a371-a6d7419cda8f",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-GET-5",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778497610582343\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778497610582343&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497610582343\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CMeSwPKLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:50.642Z\",\n  \"updated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:50.642Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CMeSwPKLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEigPSVmEiy50CQ4-AqTvBKNpXieer8pA1UoKG7NYPR9IIUiSgqgYB4o_R9LNkeLn6FwFAJVjIE",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:06:51 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:51 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "c0e12876-09b5-4ff5-a371-a6d7419cda8f",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-2",
+  "insertionIndex" : 1261
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-post-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-post-3.json
@@ -1,49 +1,58 @@
 {
-  "id" : "370fedc0-820a-475b-b7b7-8c945c8e9f73",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-POST-3",
-  "request" : {
-    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "2"
+  "id": "e3d80648-7720-42b4-a195-0dde94fb12c5",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-POST-3",
+  "request": {
+    "urlPath": "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "2"
       }
     },
-    "queryParameters" : {
-      "overrideUnlockedRetention" : {
-        "hasExactly" : [ {
-          "equalTo" : "true"
-        } ]
+    "queryParameters": {
+      "overrideUnlockedRetention": {
+        "hasExactly": [
+          {
+            "equalTo": "true"
+          }
+        ]
       },
-      "projection" : {
-        "hasExactly" : [ {
-          "equalTo" : "full"
-        } ]
+      "projection": {
+        "hasExactly": [
+          {
+            "equalTo": "full"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778497610582343\",\"name\":\"conformance-tests/objectlock/update/mode-upgrade\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"}}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778744660948612\",\"name\":\"conformance-tests/objectlock/update/mode-upgrade\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"}}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778497610582343\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778497610582343&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497610582343\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CMeSwPKLsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:50.642Z\",\n  \"updated\": \"2026-05-11T11:06:52.224Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:50.642Z\"\n}\n",
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CMeSwPKLsZQDEAI=",
-      "X-GUploader-UploadID" : "AAVLpEiG6zGn4Q9Kxze4kHYzWFZsNBsSzuv9gSwXpfeFiIS4QqJWhnvkvZbhSEmbW0Rw2vHR",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:52 GMT",
-      "Content-Type" : "application/json; charset=UTF-8"
+  "response": {
+    "status": 200,
+    "body": "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778744660948612\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778744660948612&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744660948612\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CITtpZ2kuJQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:21.011Z\",\n  \"updated\": \"2026-05-14T07:44:22.230Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:21.011Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:21.011Z\",\n  \"metadata\": {\n    \"correlation-id\": \"ab57bdf6-e334-4525-bfd7-d00d4c29642c\"\n  }\n}\n",
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag": "CITtpZ2kuJQDEAI=",
+      "X-GUploader-UploadID": "AAVLpEhw2o-CogsnhBsbgLyNI3M47wSwC-B2tpGShtKtnfWAYQjGBx45RooRbcgUb3Hmzl1B",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:44:22 GMT",
+      "Content-Type": "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "370fedc0-820a-475b-b7b7-8c945c8e9f73",
-  "persistent" : true,
-  "insertionIndex" : 1259
+  "uuid": "e3d80648-7720-42b4-a195-0dde94fb12c5",
+  "persistent": true,
+  "insertionIndex": 1303
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-post-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-post-3.json
@@ -1,0 +1,49 @@
+{
+  "id" : "370fedc0-820a-475b-b7b7-8c945c8e9f73",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-POST-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "overrideUnlockedRetention" : {
+        "hasExactly" : [ {
+          "equalTo" : "true"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"generation\":\"1778497610582343\",\"name\":\"conformance-tests/objectlock/update/mode-upgrade\",\"retention\":{\"mode\":\"Locked\",\"retainUntilTime\":\"2030-06-01T00:00:00.000Z\"}}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778497610582343\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778497610582343&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497610582343\",\n  \"metageneration\": \"2\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CMeSwPKLsZQDEAI=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-06-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-06-01T00:00:00.000Z\",\n    \"mode\": \"Locked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:50.642Z\",\n  \"updated\": \"2026-05-11T11:06:52.224Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:50.642Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CMeSwPKLsZQDEAI=",
+      "X-GUploader-UploadID" : "AAVLpEiG6zGn4Q9Kxze4kHYzWFZsNBsSzuv9gSwXpfeFiIS4QqJWhnvkvZbhSEmbW0Rw2vHR",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:52 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "370fedc0-820a-475b-b7b7-8c945c8e9f73",
+  "persistent" : true,
+  "insertionIndex" : 1259
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-post-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-post-7.json
@@ -1,0 +1,48 @@
+{
+  "id" : "80be36e8-d2cf-4d51-9baa-0d127e933885",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-POST-7",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/mode-upgrade"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/mode-upgrade\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEjpHI2zSuUxQMZKt391BlH-1uANNZYndTUC0Hcw6O961JXYlXiQH8vu6LLeJ02daMrvRypcD4M5YVTgf6GLLRyjbhfAZYoUn00tAOarvLg",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:50 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/mode-upgrade&uploadType=resumable&upload_id=AAVLpEjpHI2zSuUxQMZKt391BlH-1uANNZYndTUC0Hcw6O961JXYlXiQH8vu6LLeJ02daMrvRypcD4M5YVTgf6GLLRyjbhfAZYoUn00tAOarvLg",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "80be36e8-d2cf-4d51-9baa-0d127e933885",
+  "persistent" : true,
+  "insertionIndex" : 1263
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-post-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-post-7.json
@@ -1,48 +1,57 @@
 {
-  "id" : "80be36e8-d2cf-4d51-9baa-0d127e933885",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-POST-7",
-  "request" : {
-    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "2"
+  "id": "d57ba136-d47b-4c06-97ff-021f43203665",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-POST-7",
+  "request": {
+    "urlPath": "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "2"
       }
     },
-    "queryParameters" : {
-      "name" : {
-        "hasExactly" : [ {
-          "equalTo" : "conformance-tests/objectlock/update/mode-upgrade"
-        } ]
+    "queryParameters": {
+      "name": {
+        "hasExactly": [
+          {
+            "equalTo": "conformance-tests/objectlock/update/mode-upgrade"
+          }
+        ]
       },
-      "uploadType" : {
-        "hasExactly" : [ {
-          "equalTo" : "resumable"
-        } ]
+      "uploadType": {
+        "hasExactly": [
+          {
+            "equalTo": "resumable"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/mode-upgrade\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/mode-upgrade\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEjpHI2zSuUxQMZKt391BlH-1uANNZYndTUC0Hcw6O961JXYlXiQH8vu6LLeJ02daMrvRypcD4M5YVTgf6GLLRyjbhfAZYoUn00tAOarvLg",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:50 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/mode-upgrade&uploadType=resumable&upload_id=AAVLpEjpHI2zSuUxQMZKt391BlH-1uANNZYndTUC0Hcw6O961JXYlXiQH8vu6LLeJ02daMrvRypcD4M5YVTgf6GLLRyjbhfAZYoUn00tAOarvLg",
-      "Content-Type" : "text/plain; charset=utf-8"
+  "response": {
+    "status": 200,
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID": "AAVLpEhkRZK6Z1oMs0fGULkn8n7tP9NvtMz7OkGk3Jy4pfv588DATTZGE0YLtMNR5fcWLSrlU27ieaMJ2jvcJ5sUdAHiSqyviTKi7ZKId0ZSV80",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:44:20 GMT",
+      "Location": "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/mode-upgrade&uploadType=resumable&upload_id=AAVLpEhkRZK6Z1oMs0fGULkn8n7tP9NvtMz7OkGk3Jy4pfv588DATTZGE0YLtMNR5fcWLSrlU27ieaMJ2jvcJ5sUdAHiSqyviTKi7ZKId0ZSV80",
+      "Content-Type": "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "80be36e8-d2cf-4d51-9baa-0d127e933885",
-  "persistent" : true,
-  "insertionIndex" : 1263
+  "uuid": "d57ba136-d47b-4c06-97ff-021f43203665",
+  "persistent": true,
+  "insertionIndex": 1307
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-put-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-put-6.json
@@ -1,0 +1,53 @@
+{
+  "id" : "17a591c0-c624-4e07-be66-50ed9969b3ee",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-PUT-6",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/mode-upgrade"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AAVLpEjpHI2zSuUxQMZKt391BlH-1uANNZYndTUC0Hcw6O961JXYlXiQH8vu6LLeJ02daMrvRypcD4M5YVTgf6GLLRyjbhfAZYoUn00tAOarvLg"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "retention-update-conformance-tests/objectlock/update/mode-upgrade",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778497610582343\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778497610582343&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497610582343\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CMeSwPKLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:50.642Z\",\n  \"updated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:50.642Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CMeSwPKLsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjpHI2zSuUxQMZKt391BlH-1uANNZYndTUC0Hcw6O961JXYlXiQH8vu6LLeJ02daMrvRypcD4M5YVTgf6GLLRyjbhfAZYoUn00tAOarvLg",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:06:50 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "17a591c0-c624-4e07-be66-50ed9969b3ee",
+  "persistent" : true,
+  "insertionIndex" : 1262
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-put-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withbypass_succeeds-put-6.json
@@ -1,5 +1,5 @@
 {
-  "id" : "17a591c0-c624-4e07-be66-50ed9969b3ee",
+  "id" : "15d9010d-32d1-4d1f-9f5e-6b2d90009fd7",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds-PUT-6",
   "request" : {
     "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -22,7 +22,7 @@
       },
       "upload_id" : {
         "hasExactly" : [ {
-          "equalTo" : "AAVLpEjpHI2zSuUxQMZKt391BlH-1uANNZYndTUC0Hcw6O961JXYlXiQH8vu6LLeJ02daMrvRypcD4M5YVTgf6GLLRyjbhfAZYoUn00tAOarvLg"
+          "equalTo" : "AAVLpEhkRZK6Z1oMs0fGULkn8n7tP9NvtMz7OkGk3Jy4pfv588DATTZGE0YLtMNR5fcWLSrlU27ieaMJ2jvcJ5sUdAHiSqyviTKi7ZKId0ZSV80"
         } ]
       }
     },
@@ -33,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778497610582343\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778497610582343&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497610582343\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CMeSwPKLsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:06:50.642Z\",\n  \"updated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:06:50.642Z\",\n  \"timeFinalized\": \"2026-05-11T11:06:50.642Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade/1778744660948612\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade?generation=1778744660948612&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744660948612\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"65\",\n  \"md5Hash\": \"MLjk+GJKWHZkbJZ2dE1FeQ==\",\n  \"crc32c\": \"d5fzBw==\",\n  \"etag\": \"CITtpZ2kuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:44:21.011Z\",\n  \"updated\": \"2026-05-14T07:44:21.011Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:21.011Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:21.011Z\",\n  \"metadata\": {\n    \"correlation-id\": \"ab57bdf6-e334-4525-bfd7-d00d4c29642c\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CMeSwPKLsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEjpHI2zSuUxQMZKt391BlH-1uANNZYndTUC0Hcw6O961JXYlXiQH8vu6LLeJ02daMrvRypcD4M5YVTgf6GLLRyjbhfAZYoUn00tAOarvLg",
+      "ETag" : "CITtpZ2kuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhkRZK6Z1oMs0fGULkn8n7tP9NvtMz7OkGk3Jy4pfv588DATTZGE0YLtMNR5fcWLSrlU27ieaMJ2jvcJ5sUdAHiSqyviTKi7ZKId0ZSV80",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:06:50 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:21 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "17a591c0-c624-4e07-be66-50ed9969b3ee",
+  "uuid" : "15d9010d-32d1-4d1f-9f5e-6b2d90009fd7",
   "persistent" : true,
-  "insertionIndex" : 1262
+  "insertionIndex" : 1306
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "b3b76840-acf9-458c-90af-b128b3901ab9",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEh4utbqUp_mqiAdsNSmBcTZRnZwjoMzysCzw1yHtd__dRvk9EtrIOpEJ4G0DSbL6P0y",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:30 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "b3b76840-acf9-458c-90af-b128b3901ab9",
+  "persistent" : true,
+  "insertionIndex" : 1318
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "b3b76840-acf9-458c-90af-b128b3901ab9",
+  "id" : "38cc3991-9c28-4193-b765-ddfe799e76fd",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-DELETE-0",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEh4utbqUp_mqiAdsNSmBcTZRnZwjoMzysCzw1yHtd__dRvk9EtrIOpEJ4G0DSbL6P0y",
+      "X-GUploader-UploadID" : "AAVLpEjtfH-6Lcnte1SAw8eCb3kB8nluw4SPxf13Ev_vm_fJxXkCgV9ZcOCvSrg9EaGdetS__atV4bw",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:30 GMT",
+      "Date" : "Thu, 14 May 2026 07:40:08 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "b3b76840-acf9-458c-90af-b128b3901ab9",
+  "uuid" : "38cc3991-9c28-4193-b765-ddfe799e76fd",
   "persistent" : true,
-  "insertionIndex" : 1318
+  "insertionIndex" : 1295
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "e08f64c1-d9c4-4d1b-98a9-a2d8e4b81b94",
+  "id" : "c9343bd5-1b3f-4758-b3eb-f35d18a37641",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-GET-1",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -29,14 +29,14 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AAVLpEiltHNNGMdnAG30Xw7DfkjqmqjdvMom9zJsEHQmevqiJEO0VK4xe1lu9L_4kEzD-gU",
+      "X-GUploader-UploadID" : "AAVLpEjP8wC4jfKQh0MPj9BXQmmX4KdR8O5luYQ25WGlFjObdsNDWHh-v10ylCxdmky-DtvB",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:29 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:29 GMT",
+      "Expires" : "Thu, 14 May 2026 07:40:08 GMT",
+      "Date" : "Thu, 14 May 2026 07:40:08 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "e08f64c1-d9c4-4d1b-98a9-a2d8e4b81b94",
+  "uuid" : "c9343bd5-1b3f-4758-b3eb-f35d18a37641",
   "persistent" : true,
-  "insertionIndex" : 1319
+  "insertionIndex" : 1296
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "e08f64c1-d9c4-4d1b-98a9-a2d8e4b81b94",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEiltHNNGMdnAG30Xw7DfkjqmqjdvMom9zJsEHQmevqiJEO0VK4xe1lu9L_4kEzD-gU",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:29 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:29 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "e08f64c1-d9c4-4d1b-98a9-a2d8e4b81b94",
+  "persistent" : true,
+  "insertionIndex" : 1319
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "58af2f37-db5f-4a51-a270-e3a1212b69a9",
+  "id" : "c8e92a3b-5856-4115-b907-6bdb338d94d5",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-GET-2",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass",
@@ -19,22 +19,22 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade-no-bypass/1778497648370647\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass?generation=1778497648370647&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497648370647\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"75\",\n  \"md5Hash\": \"hX61zKdnAP6Mlk4JwbSBqg==\",\n  \"crc32c\": \"BYqjxg==\",\n  \"etag\": \"CNfHwoSMsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:28.427Z\",\n  \"updated\": \"2026-05-11T11:07:28.427Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:28.427Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:28.427Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade-no-bypass/1778744407034987\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass?generation=1778744407034987&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744407034987\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"75\",\n  \"md5Hash\": \"hX61zKdnAP6Mlk4JwbSBqg==\",\n  \"crc32c\": \"BYqjxg==\",\n  \"etag\": \"COuYnKSjuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:40:07.096Z\",\n  \"updated\": \"2026-05-14T07:40:07.096Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:40:07.096Z\",\n  \"timeFinalized\": \"2026-05-14T07:40:07.096Z\",\n  \"metadata\": {\n    \"correlation-id\": \"b097eb1c-7ce3-448e-a7b9-b0af482e3cb6\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CNfHwoSMsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEhvcsVGiQTxb5Y1Xdwfu1nCmQRq2PZIjHtqwJ2fRHqTZTuMbj7dSYNOPQ3ZrIvfLXE",
+      "ETag" : "COuYnKSjuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhuJFTRT-JCjtuh8xWz2kF-nWRI7W6vayvLjjtmUhgLf-DGpBZQsOxTLXNfSq8SlY0f",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:29 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:29 GMT",
+      "Expires" : "Thu, 14 May 2026 07:40:07 GMT",
+      "Date" : "Thu, 14 May 2026 07:40:07 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "58af2f37-db5f-4a51-a270-e3a1212b69a9",
+  "uuid" : "c8e92a3b-5856-4115-b907-6bdb338d94d5",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-no-bypass",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-no-bypass-2",
-  "insertionIndex" : 1320
+  "insertionIndex" : 1297
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-2.json
@@ -1,0 +1,40 @@
+{
+  "id" : "58af2f37-db5f-4a51-a270-e3a1212b69a9",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-GET-2",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade-no-bypass/1778497648370647\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass?generation=1778497648370647&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497648370647\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"75\",\n  \"md5Hash\": \"hX61zKdnAP6Mlk4JwbSBqg==\",\n  \"crc32c\": \"BYqjxg==\",\n  \"etag\": \"CNfHwoSMsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:28.427Z\",\n  \"updated\": \"2026-05-11T11:07:28.427Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:28.427Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:28.427Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CNfHwoSMsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhvcsVGiQTxb5Y1Xdwfu1nCmQRq2PZIjHtqwJ2fRHqTZTuMbj7dSYNOPQ3ZrIvfLXE",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:29 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:29 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "58af2f37-db5f-4a51-a270-e3a1212b69a9",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-no-bypass",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-no-bypass-2",
+  "insertionIndex" : 1320
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "380dd034-5513-4975-b3aa-1ace5c759f5f",
+  "id" : "ce991d35-0db0-46f2-b932-0fae84885e05",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-GET-3",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade-no-bypass/1778497648370647\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass?generation=1778497648370647&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497648370647\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"75\",\n  \"md5Hash\": \"hX61zKdnAP6Mlk4JwbSBqg==\",\n  \"crc32c\": \"BYqjxg==\",\n  \"etag\": \"CNfHwoSMsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:28.427Z\",\n  \"updated\": \"2026-05-11T11:07:28.427Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:28.427Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:28.427Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade-no-bypass/1778744407034987\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass?generation=1778744407034987&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744407034987\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"75\",\n  \"md5Hash\": \"hX61zKdnAP6Mlk4JwbSBqg==\",\n  \"crc32c\": \"BYqjxg==\",\n  \"etag\": \"COuYnKSjuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:40:07.096Z\",\n  \"updated\": \"2026-05-14T07:40:07.096Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:40:07.096Z\",\n  \"timeFinalized\": \"2026-05-14T07:40:07.096Z\",\n  \"metadata\": {\n    \"correlation-id\": \"b097eb1c-7ce3-448e-a7b9-b0af482e3cb6\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CNfHwoSMsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEiHjsiLlkrbzBfZdbpBe6qDkuyrayELMdozJl7WOndU6cpmTh8dqwuyFHufbNE_8ZQ",
+      "ETag" : "COuYnKSjuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhX5jhFmztFJI5_84bzf_bj61QweQ5Nw3HNQuT4OT4MbwWzuH4OD-YvcLNWnsrGDXdC",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Mon, 11 May 2026 11:07:28 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:28 GMT",
+      "Expires" : "Thu, 14 May 2026 07:40:07 GMT",
+      "Date" : "Thu, 14 May 2026 07:40:07 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "380dd034-5513-4975-b3aa-1ace5c759f5f",
+  "uuid" : "ce991d35-0db0-46f2-b932-0fae84885e05",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-no-bypass",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-no-bypass-2",
-  "insertionIndex" : 1321
+  "insertionIndex" : 1298
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-3.json
@@ -1,0 +1,41 @@
+{
+  "id" : "380dd034-5513-4975-b3aa-1ace5c759f5f",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-GET-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade-no-bypass/1778497648370647\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass?generation=1778497648370647&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497648370647\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"75\",\n  \"md5Hash\": \"hX61zKdnAP6Mlk4JwbSBqg==\",\n  \"crc32c\": \"BYqjxg==\",\n  \"etag\": \"CNfHwoSMsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:28.427Z\",\n  \"updated\": \"2026-05-11T11:07:28.427Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:28.427Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:28.427Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CNfHwoSMsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEiHjsiLlkrbzBfZdbpBe6qDkuyrayELMdozJl7WOndU6cpmTh8dqwuyFHufbNE_8ZQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 11 May 2026 11:07:28 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:28 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "380dd034-5513-4975-b3aa-1ace5c759f5f",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-no-bypass",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-mode-upgrade-no-bypass-2",
+  "insertionIndex" : 1321
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-post-5.json
@@ -1,48 +1,57 @@
 {
-  "id" : "3c949da5-655d-45c5-86ea-d56c3938390a",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-POST-5",
-  "request" : {
-    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "2"
+  "id": "4668ed5e-0ef6-484c-8645-803459c3a731",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-POST-5",
+  "request": {
+    "urlPath": "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "2"
       }
     },
-    "queryParameters" : {
-      "name" : {
-        "hasExactly" : [ {
-          "equalTo" : "conformance-tests/objectlock/update/mode-upgrade-no-bypass"
-        } ]
+    "queryParameters": {
+      "name": {
+        "hasExactly": [
+          {
+            "equalTo": "conformance-tests/objectlock/update/mode-upgrade-no-bypass"
+          }
+        ]
       },
-      "uploadType" : {
-        "hasExactly" : [ {
-          "equalTo" : "resumable"
-        } ]
+      "uploadType": {
+        "hasExactly": [
+          {
+            "equalTo": "resumable"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/mode-upgrade-no-bypass\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/mode-upgrade-no-bypass\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEhW67iXLBYGqyiwsMvZueGwxxtFjGYBJ0E1jiuD-ybLv7mZFi3zg1eq4-LWRTvX9RIA9AJh3aE1CjPt34ArA6yuWa0rQA_P1Y2E-dc7SQ",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:27 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/mode-upgrade-no-bypass&uploadType=resumable&upload_id=AAVLpEhW67iXLBYGqyiwsMvZueGwxxtFjGYBJ0E1jiuD-ybLv7mZFi3zg1eq4-LWRTvX9RIA9AJh3aE1CjPt34ArA6yuWa0rQA_P1Y2E-dc7SQ",
-      "Content-Type" : "text/plain; charset=utf-8"
+  "response": {
+    "status": 200,
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID": "AAVLpEha7g-4wrlg9Iq0NtuJF3CsP__odzs4F9mrSGsXBXA-onH4W3z4X2al8D7NTtvA4lxf4_bkiKu_-p_PhfXwb770qWg8snMHWPbeNARxRw",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:40:06 GMT",
+      "Location": "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/mode-upgrade-no-bypass&uploadType=resumable&upload_id=AAVLpEha7g-4wrlg9Iq0NtuJF3CsP__odzs4F9mrSGsXBXA-onH4W3z4X2al8D7NTtvA4lxf4_bkiKu_-p_PhfXwb770qWg8snMHWPbeNARxRw",
+      "Content-Type": "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "3c949da5-655d-45c5-86ea-d56c3938390a",
-  "persistent" : true,
-  "insertionIndex" : 1323
+  "uuid": "4668ed5e-0ef6-484c-8645-803459c3a731",
+  "persistent": true,
+  "insertionIndex": 1300
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-post-5.json
@@ -1,0 +1,48 @@
+{
+  "id" : "3c949da5-655d-45c5-86ea-d56c3938390a",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-POST-5",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/mode-upgrade-no-bypass"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/mode-upgrade-no-bypass\",\"retention\":{\"mode\":\"Unlocked\",\"retainUntilTime\":\"2030-01-01T00:00:00.000Z\"},\"temporaryHold\":false}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEhW67iXLBYGqyiwsMvZueGwxxtFjGYBJ0E1jiuD-ybLv7mZFi3zg1eq4-LWRTvX9RIA9AJh3aE1CjPt34ArA6yuWa0rQA_P1Y2E-dc7SQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:27 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/mode-upgrade-no-bypass&uploadType=resumable&upload_id=AAVLpEhW67iXLBYGqyiwsMvZueGwxxtFjGYBJ0E1jiuD-ybLv7mZFi3zg1eq4-LWRTvX9RIA9AJh3aE1CjPt34ArA6yuWa0rQA_P1Y2E-dc7SQ",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "3c949da5-655d-45c5-86ea-d56c3938390a",
+  "persistent" : true,
+  "insertionIndex" : 1323
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-put-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "7ec37f0c-dc18-4ba2-81dd-b36038a64513",
+  "id" : "f26d981b-278d-48b8-94f3-952accee30a6",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-PUT-4",
   "request" : {
     "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -22,7 +22,7 @@
       },
       "upload_id" : {
         "hasExactly" : [ {
-          "equalTo" : "AAVLpEhW67iXLBYGqyiwsMvZueGwxxtFjGYBJ0E1jiuD-ybLv7mZFi3zg1eq4-LWRTvX9RIA9AJh3aE1CjPt34ArA6yuWa0rQA_P1Y2E-dc7SQ"
+          "equalTo" : "AAVLpEha7g-4wrlg9Iq0NtuJF3CsP__odzs4F9mrSGsXBXA-onH4W3z4X2al8D7NTtvA4lxf4_bkiKu_-p_PhfXwb770qWg8snMHWPbeNARxRw"
         } ]
       }
     },
@@ -33,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade-no-bypass/1778497648370647\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass?generation=1778497648370647&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497648370647\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"75\",\n  \"md5Hash\": \"hX61zKdnAP6Mlk4JwbSBqg==\",\n  \"crc32c\": \"BYqjxg==\",\n  \"etag\": \"CNfHwoSMsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:28.427Z\",\n  \"updated\": \"2026-05-11T11:07:28.427Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:28.427Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:28.427Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade-no-bypass/1778744407034987\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass?generation=1778744407034987&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744407034987\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"75\",\n  \"md5Hash\": \"hX61zKdnAP6Mlk4JwbSBqg==\",\n  \"crc32c\": \"BYqjxg==\",\n  \"etag\": \"COuYnKSjuJQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-14T07:40:07.096Z\",\n  \"updated\": \"2026-05-14T07:40:07.096Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:40:07.096Z\",\n  \"timeFinalized\": \"2026-05-14T07:40:07.096Z\",\n  \"metadata\": {\n    \"correlation-id\": \"b097eb1c-7ce3-448e-a7b9-b0af482e3cb6\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CNfHwoSMsZQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEhW67iXLBYGqyiwsMvZueGwxxtFjGYBJ0E1jiuD-ybLv7mZFi3zg1eq4-LWRTvX9RIA9AJh3aE1CjPt34ArA6yuWa0rQA_P1Y2E-dc7SQ",
+      "ETag" : "COuYnKSjuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEha7g-4wrlg9Iq0NtuJF3CsP__odzs4F9mrSGsXBXA-onH4W3z4X2al8D7NTtvA4lxf4_bkiKu_-p_PhfXwb770qWg8snMHWPbeNARxRw",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Mon, 11 May 2026 11:07:28 GMT",
+      "Date" : "Thu, 14 May 2026 07:40:07 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "7ec37f0c-dc18-4ba2-81dd-b36038a64513",
+  "uuid" : "f26d981b-278d-48b8-94f3-952accee30a6",
   "persistent" : true,
-  "insertionIndex" : 1322
+  "insertionIndex" : 1299
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-put-4.json
@@ -1,0 +1,53 @@
+{
+  "id" : "7ec37f0c-dc18-4ba2-81dd-b36038a64513",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-PUT-4",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/mode-upgrade-no-bypass"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AAVLpEhW67iXLBYGqyiwsMvZueGwxxtFjGYBJ0E1jiuD-ybLv7mZFi3zg1eq4-LWRTvX9RIA9AJh3aE1CjPt34ArA6yuWa0rQA_P1Y2E-dc7SQ"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "retention-update-conformance-tests/objectlock/update/mode-upgrade-no-bypass",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/mode-upgrade-no-bypass/1778497648370647\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fmode-upgrade-no-bypass?generation=1778497648370647&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/mode-upgrade-no-bypass\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778497648370647\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"75\",\n  \"md5Hash\": \"hX61zKdnAP6Mlk4JwbSBqg==\",\n  \"crc32c\": \"BYqjxg==\",\n  \"etag\": \"CNfHwoSMsZQDEAE=\",\n  \"temporaryHold\": false,\n  \"retentionExpirationTime\": \"2030-01-01T00:00:00.000Z\",\n  \"retention\": {\n    \"retainUntilTime\": \"2030-01-01T00:00:00.000Z\",\n    \"mode\": \"Unlocked\"\n  },\n  \"timeCreated\": \"2026-05-11T11:07:28.427Z\",\n  \"updated\": \"2026-05-11T11:07:28.427Z\",\n  \"timeStorageClassUpdated\": \"2026-05-11T11:07:28.427Z\",\n  \"timeFinalized\": \"2026-05-11T11:07:28.427Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CNfHwoSMsZQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhW67iXLBYGqyiwsMvZueGwxxtFjGYBJ0E1jiuD-ybLv7mZFi3zg1eq4-LWRTvX9RIA9AJh3aE1CjPt34ArA6yuWa0rQA_P1Y2E-dc7SQ",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 11 May 2026 11:07:28 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "7ec37f0c-dc18-4ba2-81dd-b36038a64513",
+  "persistent" : true,
+  "insertionIndex" : 1322
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "e2b36bb0-4bc2-4f49-bffa-e0af0aec4403",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEjQ38CYTDCKkJSdyxwAmpbgFeptSDgNqOvOCSJ-0dHJqmnC7UP8nxRWtm9fGJYqZCt02RdP8a0",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Thu, 14 May 2026 07:08:29 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "e2b36bb0-4bc2-4f49-bffa-e0af0aec4403",
+  "persistent" : true,
+  "insertionIndex" : 1322
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "e2b36bb0-4bc2-4f49-bffa-e0af0aec4403",
+  "id" : "aeb9ca36-b237-4659-b54d-52f49d97a2e7",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-DELETE-0",
   "request" : {
     "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention",
@@ -11,15 +11,15 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEjQ38CYTDCKkJSdyxwAmpbgFeptSDgNqOvOCSJ-0dHJqmnC7UP8nxRWtm9fGJYqZCt02RdP8a0",
+      "X-GUploader-UploadID" : "AAVLpEjEAcN-IR083JqDhaLX4M7daTahlVycsvJRlIqB8FjN1DUd45gdtdUFaBbBYT4k98jAULhRYmo",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Thu, 14 May 2026 07:08:29 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:28 GMT",
       "Content-Type" : "application/json"
     }
   },
-  "uuid" : "e2b36bb0-4bc2-4f49-bffa-e0af0aec4403",
+  "uuid" : "aeb9ca36-b237-4659-b54d-52f49d97a2e7",
   "persistent" : true,
-  "insertionIndex" : 1322
+  "insertionIndex" : 1316
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "aefaa18d-813e-411d-ba35-731e428d32fb",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEjHPQtq1T081Mt-36x978jxsDWbtdZ79PNrKpvRoPFfca03Vo0UC1DhjknUcixAWLKXYFq54lw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Thu, 14 May 2026 07:08:28 GMT",
+      "Date" : "Thu, 14 May 2026 07:08:28 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "aefaa18d-813e-411d-ba35-731e428d32fb",
+  "persistent" : true,
+  "insertionIndex" : 1323
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "aefaa18d-813e-411d-ba35-731e428d32fb",
+  "id" : "a3c6de50-baa0-4cdc-8cc8-2a604f29497e",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-GET-1",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -29,14 +29,14 @@
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "X-GUploader-UploadID" : "AAVLpEjHPQtq1T081Mt-36x978jxsDWbtdZ79PNrKpvRoPFfca03Vo0UC1DhjknUcixAWLKXYFq54lw",
+      "X-GUploader-UploadID" : "AAVLpEgmKblV5XihSs-Rc0FbiL-W8NksJ358ZYgeDnq1D2OmEZU6fx9nhjWCOVDyWA13c1ay",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Thu, 14 May 2026 07:08:28 GMT",
-      "Date" : "Thu, 14 May 2026 07:08:28 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:28 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:28 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "aefaa18d-813e-411d-ba35-731e428d32fb",
+  "uuid" : "a3c6de50-baa0-4cdc-8cc8-2a604f29497e",
   "persistent" : true,
-  "insertionIndex" : 1323
+  "insertionIndex" : 1317
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-2.json
@@ -1,0 +1,40 @@
+{
+  "id" : "1f1a0250-7ffc-455d-84a2-a33aee3633f4",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-GET-2",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/no-current-retention/1778742507440258\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention?generation=1778742507440258&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/no-current-retention\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778742507440258\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"12\",\n  \"md5Hash\": \"v+EInLN0kaig9+UrnwO0qw==\",\n  \"crc32c\": \"mD6zIg==\",\n  \"etag\": \"CIKRtpqcuJQDEAE=\",\n  \"timeCreated\": \"2026-05-14T07:08:27.518Z\",\n  \"updated\": \"2026-05-14T07:08:27.518Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:08:27.518Z\",\n  \"timeFinalized\": \"2026-05-14T07:08:27.518Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CIKRtpqcuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhw52sl2CaSvXh8fIh0xWWYx45PBlDMxFouQi6MkQy2NzSd9ivwuTTXPklkD-pF7yko",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Thu, 14 May 2026 07:08:28 GMT",
+      "Date" : "Thu, 14 May 2026 07:08:28 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "1f1a0250-7ffc-455d-84a2-a33aee3633f4",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-no-current-retention",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-no-current-retention-2",
+  "insertionIndex" : 1324
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "1f1a0250-7ffc-455d-84a2-a33aee3633f4",
+  "id" : "2c8af626-4d89-43c8-8ae5-8ed7af2943ad",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-GET-2",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention",
@@ -19,22 +19,22 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/no-current-retention/1778742507440258\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention?generation=1778742507440258&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/no-current-retention\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778742507440258\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"12\",\n  \"md5Hash\": \"v+EInLN0kaig9+UrnwO0qw==\",\n  \"crc32c\": \"mD6zIg==\",\n  \"etag\": \"CIKRtpqcuJQDEAE=\",\n  \"timeCreated\": \"2026-05-14T07:08:27.518Z\",\n  \"updated\": \"2026-05-14T07:08:27.518Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:08:27.518Z\",\n  \"timeFinalized\": \"2026-05-14T07:08:27.518Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/no-current-retention/1778744666940450\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention?generation=1778744666940450&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/no-current-retention\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744666940450\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"12\",\n  \"md5Hash\": \"v+EInLN0kaig9+UrnwO0qw==\",\n  \"crc32c\": \"mD6zIg==\",\n  \"etag\": \"CKLIk6CkuJQDEAE=\",\n  \"timeCreated\": \"2026-05-14T07:44:27.006Z\",\n  \"updated\": \"2026-05-14T07:44:27.006Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:27.006Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:27.006Z\",\n  \"metadata\": {\n    \"correlation-id\": \"490722cb-b612-4f6c-b125-33d4ce7763ca\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CIKRtpqcuJQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEhw52sl2CaSvXh8fIh0xWWYx45PBlDMxFouQi6MkQy2NzSd9ivwuTTXPklkD-pF7yko",
+      "ETag" : "CKLIk6CkuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhVeuJqEN1RGeBi5DpMlG5HQYx6ia6Wk2lIIfGaJuCwYCDFTtUd6J1-4XRTFPNflkA6i-cpuyg",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Thu, 14 May 2026 07:08:28 GMT",
-      "Date" : "Thu, 14 May 2026 07:08:28 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:27 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:27 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "1f1a0250-7ffc-455d-84a2-a33aee3633f4",
+  "uuid" : "2c8af626-4d89-43c8-8ae5-8ed7af2943ad",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-no-current-retention",
   "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-no-current-retention-2",
-  "insertionIndex" : 1324
+  "insertionIndex" : 1318
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "f21ef992-597d-4fe3-8adf-1f03a90a66af",
+  "id" : "43b73026-e2b6-44cb-bc58-556dd6bb9cbc",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-GET-3",
   "request" : {
     "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention",
@@ -19,23 +19,23 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/no-current-retention/1778742507440258\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention?generation=1778742507440258&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/no-current-retention\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778742507440258\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"12\",\n  \"md5Hash\": \"v+EInLN0kaig9+UrnwO0qw==\",\n  \"crc32c\": \"mD6zIg==\",\n  \"etag\": \"CIKRtpqcuJQDEAE=\",\n  \"timeCreated\": \"2026-05-14T07:08:27.518Z\",\n  \"updated\": \"2026-05-14T07:08:27.518Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:08:27.518Z\",\n  \"timeFinalized\": \"2026-05-14T07:08:27.518Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/no-current-retention/1778744666940450\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention?generation=1778744666940450&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/no-current-retention\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744666940450\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"12\",\n  \"md5Hash\": \"v+EInLN0kaig9+UrnwO0qw==\",\n  \"crc32c\": \"mD6zIg==\",\n  \"etag\": \"CKLIk6CkuJQDEAE=\",\n  \"timeCreated\": \"2026-05-14T07:44:27.006Z\",\n  \"updated\": \"2026-05-14T07:44:27.006Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:27.006Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:27.006Z\",\n  \"metadata\": {\n    \"correlation-id\": \"490722cb-b612-4f6c-b125-33d4ce7763ca\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
-      "ETag" : "CIKRtpqcuJQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEjvqsXteBMtVlU3BbBTKv1TBrJg4mHp-eJ504OITUaMtMd9Ya63puQx__E_Qa04a7Jf",
+      "ETag" : "CKLIk6CkuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEhnkei4QepcxdK4hnc4qRIJKc3dzCFFmL5C4BoNa10BwZuJgrIzB9-D2kZ4pqowgXU-M5-AhVU",
       "Vary" : [ "Origin", "X-Origin" ],
-      "Expires" : "Thu, 14 May 2026 07:08:27 GMT",
-      "Date" : "Thu, 14 May 2026 07:08:27 GMT",
+      "Expires" : "Thu, 14 May 2026 07:44:27 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:27 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "f21ef992-597d-4fe3-8adf-1f03a90a66af",
+  "uuid" : "43b73026-e2b6-44cb-bc58-556dd6bb9cbc",
   "persistent" : true,
   "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-no-current-retention",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-no-current-retention-2",
-  "insertionIndex" : 1325
+  "insertionIndex" : 1319
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-3.json
@@ -1,0 +1,41 @@
+{
+  "id" : "f21ef992-597d-4fe3-8adf-1f03a90a66af",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-GET-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/no-current-retention/1778742507440258\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention?generation=1778742507440258&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/no-current-retention\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778742507440258\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"12\",\n  \"md5Hash\": \"v+EInLN0kaig9+UrnwO0qw==\",\n  \"crc32c\": \"mD6zIg==\",\n  \"etag\": \"CIKRtpqcuJQDEAE=\",\n  \"timeCreated\": \"2026-05-14T07:08:27.518Z\",\n  \"updated\": \"2026-05-14T07:08:27.518Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:08:27.518Z\",\n  \"timeFinalized\": \"2026-05-14T07:08:27.518Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CIKRtpqcuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjvqsXteBMtVlU3BbBTKv1TBrJg4mHp-eJ504OITUaMtMd9Ya63puQx__E_Qa04a7Jf",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Thu, 14 May 2026 07:08:27 GMT",
+      "Date" : "Thu, 14 May 2026 07:08:27 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "f21ef992-597d-4fe3-8adf-1f03a90a66af",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-no-current-retention",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-conformance-tests-objectlock-update-no-current-retention-2",
+  "insertionIndex" : 1325
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-post-5.json
@@ -1,0 +1,48 @@
+{
+  "id" : "a9abfc5b-a526-4df7-85de-109bb02fb12a",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-POST-5",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/no-current-retention"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/no-current-retention\"}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEihSGw5rgWMuj-wc6-CPrTe9xcevECkTY2u7IGJGwhbix_AwpUe8i9H6MGuYEIJEoIyenM5AXuX9ybkFGBdZ76R5uWU7ta4U3pbQW-jcw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Thu, 14 May 2026 07:08:26 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/no-current-retention&uploadType=resumable&upload_id=AAVLpEihSGw5rgWMuj-wc6-CPrTe9xcevECkTY2u7IGJGwhbix_AwpUe8i9H6MGuYEIJEoIyenM5AXuX9ybkFGBdZ76R5uWU7ta4U3pbQW-jcw",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "a9abfc5b-a526-4df7-85de-109bb02fb12a",
+  "persistent" : true,
+  "insertionIndex" : 1327
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-post-5.json
@@ -1,48 +1,57 @@
 {
-  "id" : "a9abfc5b-a526-4df7-85de-109bb02fb12a",
-  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-POST-5",
-  "request" : {
-    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
-    "method" : "POST",
-    "headers" : {
-      "X-Query-Param-Count" : {
-        "equalTo" : "2"
+  "id": "ebc4c819-ad08-4a1f-9ee0-3dd93d4787d2",
+  "name": "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-POST-5",
+  "request": {
+    "urlPath": "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method": "POST",
+    "headers": {
+      "X-Query-Param-Count": {
+        "equalTo": "2"
       }
     },
-    "queryParameters" : {
-      "name" : {
-        "hasExactly" : [ {
-          "equalTo" : "conformance-tests/objectlock/update/no-current-retention"
-        } ]
+    "queryParameters": {
+      "name": {
+        "hasExactly": [
+          {
+            "equalTo": "conformance-tests/objectlock/update/no-current-retention"
+          }
+        ]
       },
-      "uploadType" : {
-        "hasExactly" : [ {
-          "equalTo" : "resumable"
-        } ]
+      "uploadType": {
+        "hasExactly": [
+          {
+            "equalTo": "resumable"
+          }
+        ]
       }
     },
-    "bodyPatterns" : [ {
-      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/no-current-retention\"}",
-      "ignoreArrayOrder" : true,
-      "ignoreExtraElements" : false
-    } ]
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/objectlock/update/no-current-retention\"}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
   },
-  "response" : {
-    "status" : 200,
-    "headers" : {
-      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
-      "Server" : "UploadServer",
-      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "X-GUploader-UploadID" : "AAVLpEihSGw5rgWMuj-wc6-CPrTe9xcevECkTY2u7IGJGwhbix_AwpUe8i9H6MGuYEIJEoIyenM5AXuX9ybkFGBdZ76R5uWU7ta4U3pbQW-jcw",
-      "Vary" : [ "Origin", "X-Origin" ],
-      "Pragma" : "no-cache",
-      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Thu, 14 May 2026 07:08:26 GMT",
-      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/no-current-retention&uploadType=resumable&upload_id=AAVLpEihSGw5rgWMuj-wc6-CPrTe9xcevECkTY2u7IGJGwhbix_AwpUe8i9H6MGuYEIJEoIyenM5AXuX9ybkFGBdZ76R5uWU7ta4U3pbQW-jcw",
-      "Content-Type" : "text/plain; charset=utf-8"
+  "response": {
+    "status": 200,
+    "headers": {
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server": "UploadServer",
+      "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID": "AAVLpEjbsCWrpYsy1u1Kg5FrRJ2YPPrMUhAADLzN04i7kybQEra0ykGCWLMRhb1SvXLDBvXN_halPc3ACbwOh6snkB_jG4JUNl19hv212NcPs9g",
+      "Vary": [
+        "Origin",
+        "X-Origin"
+      ],
+      "Pragma": "no-cache",
+      "Expires": "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date": "Thu, 14 May 2026 07:44:26 GMT",
+      "Location": "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/objectlock/update/no-current-retention&uploadType=resumable&upload_id=AAVLpEjbsCWrpYsy1u1Kg5FrRJ2YPPrMUhAADLzN04i7kybQEra0ykGCWLMRhb1SvXLDBvXN_halPc3ACbwOh6snkB_jG4JUNl19hv212NcPs9g",
+      "Content-Type": "text/plain; charset=utf-8"
     }
   },
-  "uuid" : "a9abfc5b-a526-4df7-85de-109bb02fb12a",
-  "persistent" : true,
-  "insertionIndex" : 1327
+  "uuid": "ebc4c819-ad08-4a1f-9ee0-3dd93d4787d2",
+  "persistent": true,
+  "insertionIndex": 1321
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-put-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "564491f6-5b18-46ea-b632-d90611b07c73",
+  "id" : "8a393f73-4047-4bb4-9293-d663cba06d58",
   "name" : "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-PUT-4",
   "request" : {
     "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
@@ -22,7 +22,7 @@
       },
       "upload_id" : {
         "hasExactly" : [ {
-          "equalTo" : "AAVLpEihSGw5rgWMuj-wc6-CPrTe9xcevECkTY2u7IGJGwhbix_AwpUe8i9H6MGuYEIJEoIyenM5AXuX9ybkFGBdZ76R5uWU7ta4U3pbQW-jcw"
+          "equalTo" : "AAVLpEjbsCWrpYsy1u1Kg5FrRJ2YPPrMUhAADLzN04i7kybQEra0ykGCWLMRhb1SvXLDBvXN_halPc3ACbwOh6snkB_jG4JUNl19hv212NcPs9g"
         } ]
       }
     },
@@ -33,21 +33,21 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/no-current-retention/1778742507440258\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention?generation=1778742507440258&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/no-current-retention\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778742507440258\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"12\",\n  \"md5Hash\": \"v+EInLN0kaig9+UrnwO0qw==\",\n  \"crc32c\": \"mD6zIg==\",\n  \"etag\": \"CIKRtpqcuJQDEAE=\",\n  \"timeCreated\": \"2026-05-14T07:08:27.518Z\",\n  \"updated\": \"2026-05-14T07:08:27.518Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:08:27.518Z\",\n  \"timeFinalized\": \"2026-05-14T07:08:27.518Z\"\n}\n",
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/no-current-retention/1778744666940450\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention?generation=1778744666940450&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/no-current-retention\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778744666940450\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"12\",\n  \"md5Hash\": \"v+EInLN0kaig9+UrnwO0qw==\",\n  \"crc32c\": \"mD6zIg==\",\n  \"etag\": \"CKLIk6CkuJQDEAE=\",\n  \"timeCreated\": \"2026-05-14T07:44:27.006Z\",\n  \"updated\": \"2026-05-14T07:44:27.006Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:44:27.006Z\",\n  \"timeFinalized\": \"2026-05-14T07:44:27.006Z\",\n  \"metadata\": {\n    \"correlation-id\": \"490722cb-b612-4f6c-b125-33d4ce7763ca\"\n  }\n}\n",
     "headers" : {
       "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
       "Server" : "UploadServer",
       "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
-      "ETag" : "CIKRtpqcuJQDEAE=",
-      "X-GUploader-UploadID" : "AAVLpEihSGw5rgWMuj-wc6-CPrTe9xcevECkTY2u7IGJGwhbix_AwpUe8i9H6MGuYEIJEoIyenM5AXuX9ybkFGBdZ76R5uWU7ta4U3pbQW-jcw",
+      "ETag" : "CKLIk6CkuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEjbsCWrpYsy1u1Kg5FrRJ2YPPrMUhAADLzN04i7kybQEra0ykGCWLMRhb1SvXLDBvXN_halPc3ACbwOh6snkB_jG4JUNl19hv212NcPs9g",
       "Vary" : [ "Origin", "X-Origin" ],
       "Pragma" : "no-cache",
       "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
-      "Date" : "Thu, 14 May 2026 07:08:27 GMT",
+      "Date" : "Thu, 14 May 2026 07:44:27 GMT",
       "Content-Type" : "application/json; charset=UTF-8"
     }
   },
-  "uuid" : "564491f6-5b18-46ea-b632-d90611b07c73",
+  "uuid" : "8a393f73-4047-4bb4-9293-d663cba06d58",
   "persistent" : true,
-  "insertionIndex" : 1326
+  "insertionIndex" : 1320
 }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testupdateobjectretention_nocurrentretention_throws-put-4.json
@@ -1,0 +1,53 @@
+{
+  "id" : "564491f6-5b18-46ea-b632-d90611b07c73",
+  "name" : "GcpBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-PUT-4",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/objectlock/update/no-current-retention"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AAVLpEihSGw5rgWMuj-wc6-CPrTe9xcevECkTY2u7IGJGwhbix_AwpUe8i9H6MGuYEIJEoIyenM5AXuX9ybkFGBdZ76R5uWU7ta4U3pbQW-jcw"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "no-retention",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/objectlock/update/no-current-retention/1778742507440258\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fobjectlock%2Fupdate%2Fno-current-retention?generation=1778742507440258&alt=media\",\n  \"name\": \"conformance-tests/objectlock/update/no-current-retention\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1778742507440258\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"12\",\n  \"md5Hash\": \"v+EInLN0kaig9+UrnwO0qw==\",\n  \"crc32c\": \"mD6zIg==\",\n  \"etag\": \"CIKRtpqcuJQDEAE=\",\n  \"timeCreated\": \"2026-05-14T07:08:27.518Z\",\n  \"updated\": \"2026-05-14T07:08:27.518Z\",\n  \"timeStorageClassUpdated\": \"2026-05-14T07:08:27.518Z\",\n  \"timeFinalized\": \"2026-05-14T07:08:27.518Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CIKRtpqcuJQDEAE=",
+      "X-GUploader-UploadID" : "AAVLpEihSGw5rgWMuj-wc6-CPrTe9xcevECkTY2u7IGJGwhbix_AwpUe8i9H6MGuYEIJEoIyenM5AXuX9ybkFGBdZ76R5uWU7ta4U3pbQW-jcw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Thu, 14 May 2026 07:08:27 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "564491f6-5b18-46ea-b632-d90611b07c73",
+  "persistent" : true,
+  "insertionIndex" : 1326
+}

--- a/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
+++ b/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
@@ -21,6 +21,8 @@ import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration;
 import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
+import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
+import com.salesforce.multicloudj.blob.driver.ObjectRetentionRules;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
@@ -1037,6 +1039,30 @@ public class InMemoryBlobStore extends AbstractBlobStore {
         ObjectLockInfo.builder()
             .mode(existing != null ? existing.getMode() : null)
             .retainUntilDate(retainUntilDate)
+            .legalHold(existing != null && existing.isLegalHold())
+            .useEventBasedHold(existing != null ? existing.getUseEventBasedHold() : null)
+            .build());
+  }
+
+  @Override
+  protected void doUpdateObjectRetention(
+      String key, String versionId, ObjectRetentionConfig config) {
+    String versionedKey = resolveVersionedKey(key, versionId);
+    ObjectLockInfo existing = OBJECT_LOCKS.get(versionedKey);
+
+    RetentionMode currentMode = existing != null ? existing.getMode() : null;
+    Instant currentRetainUntil = existing != null ? existing.getRetainUntilDate() : null;
+
+    RetentionMode resolvedMode =
+        ObjectRetentionRules.resolveAndValidate(currentMode, currentRetainUntil, config);
+
+    // Legal hold and useEventBasedHold are preserved across retention updates — they have their
+    // own dedicated APIs and must not be cleared by this call.
+    OBJECT_LOCKS.put(
+        versionedKey,
+        ObjectLockInfo.builder()
+            .mode(resolvedMode)
+            .retainUntilDate(config.getRetainUntilDate())
             .legalHold(existing != null && existing.isLegalHold())
             .useEventBasedHold(existing != null ? existing.getUseEventBasedHold() : null)
             .build());

--- a/blob/blob-inmemory/src/test/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStoreRetentionTest.java
+++ b/blob/blob-inmemory/src/test/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStoreRetentionTest.java
@@ -1,0 +1,212 @@
+package com.salesforce.multicloudj.blob.inmemory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration;
+import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
+import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
+import com.salesforce.multicloudj.blob.driver.RetentionMode;
+import com.salesforce.multicloudj.blob.driver.UploadRequest;
+import com.salesforce.multicloudj.common.exceptions.FailedPreconditionException;
+import java.io.ByteArrayInputStream;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Rules-table tests for {@link InMemoryBlobStore#updateObjectRetention(String, String,
+ * ObjectRetentionConfig)}.
+ *
+ * <p>The in-memory provider must mirror the AWS/GCP server-side rules table exactly, so
+ * unit-test parity here is the cheapest way to validate the rules helper before wiring it
+ * into providers that talk to real clouds.
+ */
+class InMemoryBlobStoreRetentionTest {
+
+  private static final Instant INITIAL = Instant.parse("2030-01-01T00:00:00Z");
+  private static final Instant LATER = Instant.parse("2030-06-01T00:00:00Z");
+  private static final Instant EARLIER = Instant.parse("2029-06-01T00:00:00Z");
+
+  private InMemoryBlobStore store;
+
+  @BeforeEach
+  void setUp() {
+    store =
+        new InMemoryBlobStore.Builder()
+            .withBucket("bucket-1")
+            .withRegion("local")
+            .build();
+    InMemoryBlobStore.createBucket("bucket-1");
+  }
+
+  // ---- helpers -----------------------------------------------------------------
+
+  private void uploadWithRetention(String key, RetentionMode mode, Instant retainUntil) {
+    byte[] content = "x".getBytes();
+    store.upload(
+        new UploadRequest.Builder()
+            .withKey(key)
+            .withContentLength(content.length)
+            .withObjectLock(
+                ObjectLockConfiguration.builder()
+                    .mode(mode)
+                    .retainUntilDate(retainUntil)
+                    .legalHold(false)
+                    .build())
+            .build(),
+        new ByteArrayInputStream(content));
+  }
+
+  private ObjectRetentionConfig cfg(RetentionMode mode, Instant date, Boolean bypass) {
+    return ObjectRetentionConfig.builder()
+        .mode(mode)
+        .retainUntilDate(date)
+        .bypassGovernanceRetention(bypass)
+        .build();
+  }
+
+  // ---- rules table -------------------------------------------------------------
+
+  @Test
+  void noCurrentRetention_throws() {
+    String key = "k/no-retention";
+    byte[] content = "x".getBytes();
+    store.upload(
+        new UploadRequest.Builder().withKey(key).withContentLength(content.length).build(),
+        new ByteArrayInputStream(content));
+
+    assertThrows(
+        FailedPreconditionException.class,
+        () -> store.updateObjectRetention(key, null, cfg(RetentionMode.GOVERNANCE, LATER, null)));
+  }
+
+  @Test
+  void governance_extending_succeeds() {
+    String key = "k/gov-extend";
+    uploadWithRetention(key, RetentionMode.GOVERNANCE, INITIAL);
+
+    store.updateObjectRetention(key, null, cfg(RetentionMode.GOVERNANCE, LATER, null));
+
+    ObjectLockInfo info = store.getObjectLock(key, null);
+    assertEquals(RetentionMode.GOVERNANCE, info.getMode());
+    assertEquals(LATER, info.getRetainUntilDate());
+  }
+
+  @Test
+  void compliance_extending_succeeds() {
+    String key = "k/comp-extend";
+    uploadWithRetention(key, RetentionMode.COMPLIANCE, INITIAL);
+
+    store.updateObjectRetention(key, null, cfg(RetentionMode.COMPLIANCE, LATER, null));
+
+    assertEquals(LATER, store.getObjectLock(key, null).getRetainUntilDate());
+  }
+
+  @Test
+  void governance_shortening_withoutBypass_throws() {
+    String key = "k/gov-shorten-no-bypass";
+    uploadWithRetention(key, RetentionMode.GOVERNANCE, LATER);
+
+    assertThrows(
+        FailedPreconditionException.class,
+        () ->
+            store.updateObjectRetention(
+                key, null, cfg(RetentionMode.GOVERNANCE, EARLIER, Boolean.FALSE)));
+  }
+
+  @Test
+  void governance_shortening_withBypass_succeeds() {
+    String key = "k/gov-shorten-bypass";
+    uploadWithRetention(key, RetentionMode.GOVERNANCE, LATER);
+
+    store.updateObjectRetention(
+        key, null, cfg(RetentionMode.GOVERNANCE, EARLIER, Boolean.TRUE));
+
+    assertEquals(EARLIER, store.getObjectLock(key, null).getRetainUntilDate());
+  }
+
+  @Test
+  void compliance_shortening_evenWithBypass_throws() {
+    // Bypass is meaningless on the immutable mode in both AWS and GCP — mirror that here.
+    String key = "k/comp-shorten-bypass";
+    uploadWithRetention(key, RetentionMode.COMPLIANCE, LATER);
+
+    assertThrows(
+        FailedPreconditionException.class,
+        () ->
+            store.updateObjectRetention(
+                key, null, cfg(RetentionMode.COMPLIANCE, EARLIER, Boolean.TRUE)));
+  }
+
+  @Test
+  void modeUpgrade_governanceToCompliance_withBypass_succeeds() {
+    // Mode upgrade requires bypassGovernanceRetention=true on both AWS and GCP — the cloud
+    // treats the lock-mode change as a modification of the existing lock. We mirror that here.
+    String key = "k/upgrade";
+    uploadWithRetention(key, RetentionMode.GOVERNANCE, INITIAL);
+
+    store.updateObjectRetention(key, null, cfg(RetentionMode.COMPLIANCE, LATER, Boolean.TRUE));
+
+    ObjectLockInfo info = store.getObjectLock(key, null);
+    assertEquals(RetentionMode.COMPLIANCE, info.getMode());
+    assertEquals(LATER, info.getRetainUntilDate());
+  }
+
+  @Test
+  void modeUpgrade_governanceToCompliance_withoutBypass_throws() {
+    String key = "k/upgrade-no-bypass";
+    uploadWithRetention(key, RetentionMode.GOVERNANCE, INITIAL);
+
+    assertThrows(
+        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        () ->
+            store.updateObjectRetention(
+                key, null, cfg(RetentionMode.COMPLIANCE, LATER, null)));
+  }
+
+  @Test
+  void modeDowngrade_complianceToGovernance_throws() {
+    String key = "k/downgrade";
+    uploadWithRetention(key, RetentionMode.COMPLIANCE, INITIAL);
+
+    assertThrows(
+        FailedPreconditionException.class,
+        () ->
+            store.updateObjectRetention(
+                key, null, cfg(RetentionMode.GOVERNANCE, LATER, Boolean.TRUE)));
+  }
+
+  @Test
+  void modeNull_preservesCurrentMode_extending() {
+    String key = "k/null-mode";
+    uploadWithRetention(key, RetentionMode.COMPLIANCE, INITIAL);
+
+    store.updateObjectRetention(key, null, cfg(null, LATER, null));
+
+    assertEquals(RetentionMode.COMPLIANCE, store.getObjectLock(key, null).getMode());
+    assertEquals(LATER, store.getObjectLock(key, null).getRetainUntilDate());
+  }
+
+  @Test
+  void legalHoldPreservedAcrossUpdate() {
+    String key = "k/legalhold";
+    byte[] content = "x".getBytes();
+    store.upload(
+        new UploadRequest.Builder()
+            .withKey(key)
+            .withContentLength(content.length)
+            .withObjectLock(
+                ObjectLockConfiguration.builder()
+                    .mode(RetentionMode.GOVERNANCE)
+                    .retainUntilDate(INITIAL)
+                    .legalHold(true)
+                    .build())
+            .build(),
+        new ByteArrayInputStream(content));
+
+    store.updateObjectRetention(key, null, cfg(RetentionMode.GOVERNANCE, LATER, null));
+
+    org.junit.jupiter.api.Assertions.assertTrue(store.getObjectLock(key, null).isLegalHold());
+  }
+}


### PR DESCRIPTION
## Summary

< Provide a brief description of the changes in this PR >

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
