### PR TITLE
Add SHA256 and crc32c for objectLockmode and checksum validation

### DIFF
--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -56,6 +56,7 @@ import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
+import software.amazon.awssdk.services.s3.model.ChecksumMode;
 import software.amazon.awssdk.services.s3.model.CommonPrefix;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
@@ -317,6 +318,9 @@ public class AwsTransformer {
     if (request.getStart() != null || request.getEnd() != null) {
       builder.range(createRangeString(request.getStart(), request.getEnd()));
     }
+    if (request.isChecksumValidation()) {
+      builder.checksumMode(ChecksumMode.ENABLED);
+    }
     return builder.build();
   }
 
@@ -344,17 +348,7 @@ public class AwsTransformer {
       DownloadRequest downloadRequest, GetObjectResponse response) {
     return DownloadResponse.builder()
         .key(downloadRequest.getKey())
-        .metadata(
-            BlobMetadata.builder()
-                .key(downloadRequest.getKey())
-                .versionId(response.versionId())
-                .eTag(response.eTag())
-                .lastModified(response.lastModified())
-                .createdTime(response.lastModified())
-                .metadata(response.metadata())
-                .objectSize(response.contentLength())
-                .contentType(response.contentType())
-                .build())
+        .metadata(toBlobMetadata(downloadRequest.getKey(), response))
         .build();
   }
 
@@ -364,18 +358,31 @@ public class AwsTransformer {
       ResponseInputStream<GetObjectResponse> responseInputStream) {
     return DownloadResponse.builder()
         .key(downloadRequest.getKey())
-        .metadata(
-            BlobMetadata.builder()
-                .key(downloadRequest.getKey())
-                .versionId(response.versionId())
-                .eTag(response.eTag())
-                .lastModified(response.lastModified())
-                .createdTime(response.lastModified())
-                .metadata(response.metadata())
-                .objectSize(response.contentLength())
-                .contentType(response.contentType())
-                .build())
+        .metadata(toBlobMetadata(downloadRequest.getKey(), response))
         .inputStream(responseInputStream)
+        .build();
+  }
+
+  /**
+   * Builds {@link BlobMetadata} from a {@link GetObjectResponse}. Flexible-checksum fields
+   * ({@link BlobMetadata#getCrc32c()} etc.) are populated only when S3 returned them, which only
+   * happens when the originating request was sent with {@code ChecksumMode.ENABLED} (i.e., the
+   * {@link DownloadRequest} had {@code withChecksumValidation(true)}).
+   */
+  private BlobMetadata toBlobMetadata(String key, GetObjectResponse response) {
+    return BlobMetadata.builder()
+        .key(key)
+        .versionId(response.versionId())
+        .eTag(response.eTag())
+        .lastModified(response.lastModified())
+        .createdTime(response.lastModified())
+        .metadata(response.metadata())
+        .objectSize(response.contentLength())
+        .contentType(response.contentType())
+        .crc32c(response.checksumCRC32C())
+        .sha256(response.checksumSHA256())
+        .crc32(response.checksumCRC32())
+        .sha1(response.checksumSHA1())
         .build();
   }
 
@@ -449,6 +456,10 @@ public class AwsTransformer {
         .lastModified(response.lastModified())
         .createdTime(response.lastModified())
         .md5(eTagToMD5(eTag))
+        .crc32c(response.checksumCRC32C())
+        .sha256(response.checksumSHA256())
+        .crc32(response.checksumCRC32())
+        .sha1(response.checksumSHA1())
         .contentType(response.contentType())
         .objectLockInfo(objectLockInfo)
         .build();

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
@@ -358,6 +358,20 @@ public class AwsTransformerTest {
     assertEquals(request.getVersionId(), actual.versionId());
     assertEquals(request.getStart(), 0);
     assertEquals(request.getEnd(), 500);
+    // checksumValidation defaults to false → no ChecksumMode header is set.
+    assertNull(actual.checksumMode());
+  }
+
+  @Test
+  void testToGetObjectRequest_checksumValidationEnabled() {
+    var request =
+        DownloadRequest.builder()
+            .withKey("k")
+            .withChecksumValidation(true)
+            .build();
+    var actual = transformer.toRequest(request);
+    assertEquals(
+        software.amazon.awssdk.services.s3.model.ChecksumMode.ENABLED, actual.checksumMode());
   }
 
   @Test
@@ -390,6 +404,29 @@ public class AwsTransformerTest {
     assertEquals(now, response.getMetadata().getLastModified());
     assertEquals(metadata, response.getMetadata().getMetadata());
     assertEquals(1024L, response.getMetadata().getObjectSize());
+    // No flexible-checksum values were stubbed, so they should not appear on the metadata.
+    assertNull(response.getMetadata().getCrc32c());
+    assertNull(response.getMetadata().getSha256());
+    assertNull(response.getMetadata().getCrc32());
+    assertNull(response.getMetadata().getSha1());
+  }
+
+  @Test
+  void testToDownloadObjectResponse_flexibleChecksumsPropagated() {
+    var request = DownloadRequest.builder().withKey("k").withChecksumValidation(true).build();
+    GetObjectResponse getObjectResponse = mock(GetObjectResponse.class);
+    doReturn(0L).when(getObjectResponse).contentLength();
+    doReturn("base64-crc32c").when(getObjectResponse).checksumCRC32C();
+    doReturn("base64-sha256").when(getObjectResponse).checksumSHA256();
+    doReturn("base64-crc32").when(getObjectResponse).checksumCRC32();
+    doReturn("base64-sha1").when(getObjectResponse).checksumSHA1();
+
+    DownloadResponse response = transformer.toDownloadResponse(request, getObjectResponse);
+
+    assertEquals("base64-crc32c", response.getMetadata().getCrc32c());
+    assertEquals("base64-sha256", response.getMetadata().getSha256());
+    assertEquals("base64-crc32", response.getMetadata().getCrc32());
+    assertEquals("base64-sha1", response.getMetadata().getSha1());
   }
 
   @Test
@@ -463,6 +500,23 @@ public class AwsTransformerTest {
     assertEquals(metadata, actual.getMetadata());
     assertEquals(1024L, actual.getObjectSize());
     assertEquals(now, actual.getLastModified());
+  }
+
+  @Test
+  void testToMetadata_flexibleChecksumsPropagated() {
+    var response =
+        HeadObjectResponse.builder()
+            .contentLength(0L)
+            .checksumCRC32C("base64-crc32c")
+            .checksumSHA256("base64-sha256")
+            .checksumCRC32("base64-crc32")
+            .checksumSHA1("base64-sha1")
+            .build();
+    var actual = transformer.toMetadata(response, "k");
+    assertEquals("base64-crc32c", actual.getCrc32c());
+    assertEquals("base64-sha256", actual.getSha256());
+    assertEquals("base64-crc32", actual.getCrc32());
+    assertEquals("base64-sha1", actual.getSha1());
   }
 
   @Test

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobMetadata.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobMetadata.java
@@ -33,6 +33,34 @@ public class BlobMetadata {
 
   private final byte[] md5;
 
+  /**
+   * Base64-encoded CRC32C checksum of the object as reported by the substrate, or {@code null} if
+   * the substrate did not surface one. Populated by GCS for every object (including composite
+   * objects, which have no MD5) and by AWS when the {@code GetObject} request was issued with
+   * checksum validation enabled (see {@link DownloadRequest.Builder#withChecksumValidation}).
+   */
+  private final String crc32c;
+
+  /**
+   * Base64-encoded SHA-256 checksum of the object as reported by the substrate, or {@code null} if
+   * the substrate did not surface one. On AWS this is populated only when the object was uploaded
+   * with {@code SHA256} as the flexible-checksum algorithm and {@code GetObject} was issued with
+   * checksum validation enabled.
+   */
+  private final String sha256;
+
+  /**
+   * Base64-encoded CRC32 checksum of the object as reported by the substrate, or {@code null} if
+   * not surfaced.
+   */
+  private final String crc32;
+
+  /**
+   * Base64-encoded SHA-1 checksum of the object as reported by the substrate, or {@code null} if
+   * not surfaced.
+   */
+  private final String sha1;
+
   /** The content type of the blob (e.g., "application/octet-stream", "application/x-directory") */
   private final String contentType;
 

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/DownloadRequest.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/DownloadRequest.java
@@ -15,6 +15,7 @@ public class DownloadRequest {
   private final boolean parallelDownload;
   private final boolean createParentPath;
   private final boolean checkArchived;
+  private final boolean checksumValidation;
 
   /**
    * (Optional) Per-call observability context carrying the correlation ID. If null or if its
@@ -32,6 +33,7 @@ public class DownloadRequest {
     this.createParentPath = builder.createParentPath;
     this.operationContext = builder.operationContext;
     this.checkArchived = builder.checkArchived;
+    this.checksumValidation = builder.checksumValidation;
   }
 
   public static Builder builder() {
@@ -48,6 +50,7 @@ public class DownloadRequest {
     private boolean createParentPath;
     private OperationContext operationContext;
     private boolean checkArchived;
+    private boolean checksumValidation;
 
     /** Specifies the key of the Blob to download. */
     public Builder withKey(String key) {
@@ -151,6 +154,29 @@ public class DownloadRequest {
      */
     public Builder withCheckArchived(boolean checkArchived) {
       this.checkArchived = checkArchived;
+      return this;
+    }
+
+    /**
+     * (Optional) When true, asks the substrate to surface stored checksums on the response so the
+     * caller (or a future SDK-side wrapper) can verify the downloaded bytes against the algorithm
+     * the object was originally stored with.
+     *
+     * <p>Provider behavior:
+     *
+     * <ul>
+     *   <li>AWS: enables {@code ChecksumMode.ENABLED} on the underlying {@code GetObjectRequest},
+     *       which causes S3 to return {@code x-amz-checksum-*} headers populated with whichever
+     *       algorithm the object was stored with (SHA-256, CRC32C, CRC32, or SHA-1). Those values
+     *       are then exposed via {@code BlobMetadata.getSha256()} / {@code getCrc32c()} / etc.
+     *   <li>GCS: no-op on the request side because GCS already returns the CRC32C unconditionally.
+     *       {@code BlobMetadata.getCrc32c()} is populated regardless of this flag.
+     * </ul>
+     *
+     * <p>Defaults to {@code false} to preserve existing behavior.
+     */
+    public Builder withChecksumValidation(boolean checksumValidation) {
+      this.checksumValidation = checksumValidation;
       return this;
     }
 

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpTransformer.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpTransformer.java
@@ -228,6 +228,7 @@ public class GcpTransformer {
                 ? blob.getCreateTimeOffsetDateTime().toInstant()
                 : null)
         .md5(HexUtil.convertToBytes(blob.getMd5()))
+        .crc32c(blob.getCrc32c())
         .contentType(blob.getContentType())
         .objectLockInfo(objectLockInfo)
         .build();

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpTransformerTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpTransformerTest.java
@@ -678,6 +678,20 @@ class GcpTransformerTest {
     assertTrue(blobMetadata.getMetadata().isEmpty());
     assertNull(blobMetadata.getLastModified());
     assertArrayEquals(new byte[0], blobMetadata.getMd5());
+    assertNull(blobMetadata.getCrc32c());
+  }
+
+  @Test
+  void testToBlobMetadata_PropagatesCrc32c() {
+    // Composite GCS objects have no MD5 but always have CRC32C.
+    when(mockBlob.getName()).thenReturn(TEST_KEY);
+    when(mockBlob.getMd5()).thenReturn(null);
+    when(mockBlob.getCrc32c()).thenReturn("base64-crc32c");
+
+    BlobMetadata blobMetadata = transformer.toBlobMetadata(mockBlob);
+
+    assertEquals("base64-crc32c", blobMetadata.getCrc32c());
+    assertArrayEquals(new byte[0], blobMetadata.getMd5());
   }
 
   @Test


### PR DESCRIPTION
## Summary

< Provide a brief description of the changes in this PR >

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
