### PR TITLE
docstore: add 4 new benchmarks + expand HighScore dataset

### DIFF
--- a/docstore/docstore-aws/src/test/java/com/salesforce/multicloudj/docstore/aws/AwsDocstoreBenchmarkTest.java
+++ b/docstore/docstore-aws/src/test/java/com/salesforce/multicloudj/docstore/aws/AwsDocstoreBenchmarkTest.java
@@ -3,7 +3,6 @@ package com.salesforce.multicloudj.docstore.aws;
 import com.salesforce.multicloudj.docstore.client.AbstractDocstoreBenchmarkTest;
 import com.salesforce.multicloudj.docstore.driver.AbstractDocStore;
 import com.salesforce.multicloudj.docstore.driver.CollectionOptions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +12,6 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 
-@Disabled
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AwsDocstoreBenchmarkTest extends AbstractDocstoreBenchmarkTest {
 

--- a/docstore/docstore-client/src/test/java/com/salesforce/multicloudj/docstore/client/AbstractDocstoreBenchmarkTest.java
+++ b/docstore/docstore-client/src/test/java/com/salesforce/multicloudj/docstore/client/AbstractDocstoreBenchmarkTest.java
@@ -5,6 +5,7 @@ import com.salesforce.multicloudj.docstore.driver.ActionList;
 import com.salesforce.multicloudj.docstore.driver.Document;
 import com.salesforce.multicloudj.docstore.driver.DocumentIterator;
 import com.salesforce.multicloudj.docstore.driver.FilterOperation;
+import com.salesforce.multicloudj.docstore.driver.PaginationToken;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -208,85 +209,39 @@ public abstract class AbstractDocstoreBenchmarkTest {
     }
   }
 
+  // 200 HighScore docs (5 games × 10 players × 4 rounds). Larger dataset gives query planners
+  // a path that reflects real-world workloads — at 15 rows, providers can pick degenerate plans
+  // (e.g., DynamoDB skipping index lookups for full-table scan) that don't represent customer
+  // behavior. Score values are deterministic but well-distributed so range/orderBy benchmarks
+  // see meaningful spread.
   private void generateTestHighScores() {
-    List<HighScore> allScores =
-        List.of(
-            new HighScore(
-                game1, "pat", 49, "2024-03-13", false, (byte) 5, (short) 3, 45000L, 85.5f, 1.2),
-            new HighScore(
-                game1, "mel", 60, "2024-04-10", false, (byte) 7, (short) 2, 52000L, 90.0f, 1.5),
-            new HighScore(
-                game1, "andy", 81, "2024-02-01", false, (byte) 9, (short) 1, 63000L, 95.2f, 2.1),
-            new HighScore(
-                game1, "fran", 33, "2024-03-19", false, (byte) 3, (short) 4, 28000L, 75.8f, 1.0),
-            new HighScore(
-                game2, "pat", 120, "2024-04-01", true, (byte) 12, (short) 5, 89000L, 88.9f, 2.5),
-            new HighScore(
-                game2,
-                "billie",
-                111,
-                "2024-04-10",
-                false,
-                (byte) 11,
-                (short) 2,
-                78000L,
-                92.1f,
-                2.2),
-            new HighScore(
-                game2, "mel", 190, "2024-04-18", true, (byte) 15, (short) 1, 120000L, 97.3f, 3.1),
-            new HighScore(
-                game2, "fran", 33, "2024-03-20", false, (byte) 4, (short) 3, 31000L, 78.5f, 1.1),
-            new HighScore(
-                game3, "alex", 75, "2024-05-01", false, (byte) 8, (short) 2, 67000L, 89.7f, 1.8),
-            new HighScore(
-                game3, "sam", 95, "2024-05-15", true, (byte) 10, (short) 4, 84000L, 93.4f, 2.3),
-            new HighScore(
-                game1,
-                "chris",
-                200,
-                "2024-06-01",
-                false,
-                (byte) 20,
-                (short) 5,
-                145000L,
-                98.1f,
-                3.5),
-            new HighScore(
-                game1, "jamie", 150, "2024-06-05", true, (byte) 14, (short) 3, 110000L, 94.7f, 2.8),
-            new HighScore(
-                game2,
-                "taylor",
-                300,
-                "2024-06-10",
-                false,
-                (byte) 25,
-                (short) 2,
-                180000L,
-                99.2f,
-                4.2),
-            new HighScore(
-                game2,
-                "jordan",
-                250,
-                "2024-06-15",
-                true,
-                (byte) 22,
-                (short) 1,
-                165000L,
-                96.8f,
-                3.8),
-            new HighScore(
-                game3,
-                "morgan",
-                180,
-                "2024-06-20",
-                false,
-                (byte) 18,
-                (short) 4,
-                135000L,
-                95.5f,
-                3.2));
-    testHighScores.addAll(allScores);
+    String[] players = {
+      "pat", "mel", "andy", "fran", "billie", "alex", "sam", "chris", "jamie", "taylor"
+    };
+    for (int g = 0; g < games.length; g++) {
+      for (int p = 0; p < players.length; p++) {
+        for (int r = 0; r < 4; r++) {
+          int score = 10 + (g * 73 + p * 17 + r * 5) % 390;
+          int magic = (g * 11 + p * 3 + r) % 30;
+          int taken = (g * 7 + p * 2 + r) % 8;
+          long fld1 = (long) score * 1000L;
+          float fld2 = score / 4.0f;
+          double fld3 = score / 100.0;
+          testHighScores.add(
+              new HighScore(
+                  games[g],
+                  players[p] + r,
+                  score,
+                  "2024-0" + (g + 1) + "-" + (10 + p),
+                  score > 200,
+                  (byte) magic,
+                  (short) taken,
+                  fld1,
+                  fld2,
+                  fld3));
+        }
+      }
+    }
   }
 
   private void setupTestData() {
@@ -682,6 +637,157 @@ public abstract class AbstractDocstoreBenchmarkTest {
     }
   }
 
+  /** Query with limit clause — measures cost of bounding result set size at the cloud. */
+  @Benchmark
+  @Threads(2)
+  public void benchmarkQueryWithLimit(Blackhole bh) {
+    DocumentIterator iter = null;
+    try {
+      iter =
+          queryDocStoreClient
+              .query()
+              .where("Game", FilterOperation.EQUAL, game1)
+              .limit(10)
+              .get();
+
+      int count = 0;
+      while (iter.hasNext()) {
+        HighScore score = new HighScore();
+        iter.next(new Document(score));
+        count++;
+        bh.consume(score.getScore());
+      }
+      bh.consume(count);
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark query with limit failed", e);
+    } finally {
+      if (iter != null) {
+        iter.stop();
+      }
+    }
+  }
+
+  /**
+   * Query with orderBy — fundamental cross-cloud variance: provider plans range over indexed vs.
+   * non-indexed sorts very differently. orderBy field must appear in a where clause (see
+   * Query#orderBy javadoc for cross-substrate consistency). Uses descending order
+   * ("leaderboard"-style highest score first). Requires Firestore composite index
+   * (Game ASC, Score DESC) on the composite-key collection.
+   */
+  @Benchmark
+  @Threads(1)
+  public void benchmarkQueryWithOrderBy(Blackhole bh) {
+    DocumentIterator iter = null;
+    try {
+      iter =
+          queryDocStoreClient
+              .query()
+              .where("Game", FilterOperation.EQUAL, game1)
+              .where("Score", FilterOperation.GREATER_THAN, 0)
+              .orderBy("Score", false)
+              .get();
+
+      int count = 0;
+      while (iter.hasNext()) {
+        HighScore score = new HighScore();
+        iter.next(new Document(score));
+        count++;
+        bh.consume(score.getScore());
+      }
+      bh.consume(count);
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark query with orderBy failed", e);
+    } finally {
+      if (iter != null) {
+        iter.stop();
+      }
+    }
+  }
+
+  /**
+   * Two-page fetch using paginationToken — measures cursor overhead across providers. Different
+   * providers (DynamoDB LastEvaluatedKey, Firestore startAfter cursor, etc.) produce
+   * behaviorally significant cross-cloud differences here.
+   */
+  @Benchmark
+  @Threads(1)
+  public void benchmarkQueryWithPagination(Blackhole bh) {
+    DocumentIterator firstPage = null;
+    DocumentIterator secondPage = null;
+    try {
+      firstPage =
+          queryDocStoreClient
+              .query()
+              .where("Game", FilterOperation.EQUAL, game1)
+              .limit(20)
+              .get();
+
+      int firstCount = 0;
+      while (firstPage.hasNext()) {
+        HighScore score = new HighScore();
+        firstPage.next(new Document(score));
+        firstCount++;
+        bh.consume(score.getScore());
+      }
+
+      PaginationToken token = firstPage.getPaginationToken();
+      // Release the first cursor before opening the second so we never hold both at once.
+      firstPage.stop();
+      firstPage = null;
+      if (token != null) {
+        secondPage =
+            queryDocStoreClient
+                .query()
+                .where("Game", FilterOperation.EQUAL, game1)
+                .limit(20)
+                .paginationToken(token)
+                .get();
+
+        int secondCount = 0;
+        while (secondPage.hasNext()) {
+          HighScore score = new HighScore();
+          secondPage.next(new Document(score));
+          secondCount++;
+          bh.consume(score.getScore());
+        }
+        bh.consume(secondCount);
+      }
+      bh.consume(firstCount);
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark query with pagination failed", e);
+    } finally {
+      if (firstPage != null) {
+        firstPage.stop();
+      }
+      if (secondPage != null) {
+        secondPage.stop();
+      }
+    }
+  }
+
+  /**
+   * Get with field projection — partial-field read. Each provider implements projection
+   * differently (DynamoDB ProjectionExpression, Firestore DocumentMask), so this quantifies the
+   * wire-transfer benefit of asking for fewer fields.
+   */
+  @Benchmark
+  @Threads(4)
+  public void benchmarkGetWithProjection(Blackhole bh) {
+    try {
+      if (smallPlayerKeys == null || smallPlayerKeys.isEmpty()) {
+        return;
+      }
+      String key = smallPlayerKeys.get(ThreadLocalRandom.current().nextInt(smallPlayerKeys.size()));
+      Player getPlayer = new Player();
+      getPlayer.setPName(key);
+      Document doc = new Document(getPlayer);
+      docStoreClient.get(doc, "pName", "i");
+      bh.consume(doc.getField("pName"));
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark get with projection failed", e);
+    }
+  }
+
   /** Helper — get from a pre-filtered, pre-computed key list (O(1), no allocation) */
   private void benchmarkGetByList(Blackhole bh, List<String> keys, String label) {
     try {
@@ -750,4 +856,7 @@ public abstract class AbstractDocstoreBenchmarkTest {
   private static final String game1 = "Praise All Monsters";
   private static final String game2 = "Zombie DMV";
   private static final String game3 = "Days Gone";
+  private static final String game4 = "Space Drifter";
+  private static final String game5 = "Neon Abyss";
+  private static final String[] games = {game1, game2, game3, game4, game5};
 }

--- a/docstore/docstore-client/src/test/java/com/salesforce/multicloudj/docstore/client/AbstractDocstoreBenchmarkTest.java
+++ b/docstore/docstore-client/src/test/java/com/salesforce/multicloudj/docstore/client/AbstractDocstoreBenchmarkTest.java
@@ -774,9 +774,6 @@ public abstract class AbstractDocstoreBenchmarkTest {
   @Threads(4)
   public void benchmarkGetWithProjection(Blackhole bh) {
     try {
-      if (smallPlayerKeys == null || smallPlayerKeys.isEmpty()) {
-        return;
-      }
       String key = smallPlayerKeys.get(ThreadLocalRandom.current().nextInt(smallPlayerKeys.size()));
       Player getPlayer = new Player();
       getPlayer.setPName(key);


### PR DESCRIPTION
## Summary

New benchmark methods + a HighScore dataset expansion for the DocStore benchmark suite. Stacked on top of #432.

### New benchmarks

| Benchmark | Threads | What it measures |
|---|---|---|
| `benchmarkQueryWithLimit` | 2 | Cost of bounding result set size at the cloud |
| `benchmarkQueryWithOrderBy` | 1 | Provider-side sort cost (descending) — DynamoDB requires LSI/GSI on sort field, Firestore requires composite index |
| `benchmarkQueryWithPagination` | 1 | Two-page fetch using `paginationToken` — measures cursor overhead per provider |
| `benchmarkGetWithProjection` | 4 | Partial-field read via `get(doc, "pName", "i")` — wire-transfer optimization |

### Dataset expansion

`generateTestHighScores()` rewritten from 15 hand-written rows → 200 deterministic rows (5 games × 10 players × 4 rounds). At 15 rows, query planners can pick degenerate plans (DynamoDB skipping index lookups for full-table scan) that don't reflect real customer behavior. Score values spread 10–399 so range/orderBy benchmarks see meaningful spread.

### Other

- Removed `@Disabled` from `AwsDocstoreBenchmarkTest`. The `@EnabledIfSystemProperty` gate added in #432 is the canonical mechanism. Consistent with what #432 did for `GcpFirestoreDocstoreBenchmarkTest`.

## Validation

- [x] `mvn clean install -DskipTests` — BUILD SUCCESS, checkstyle clean
- [x] Unit tests: `docstore-client` 60/60, `docstore-aws` 46/46, `docstore-gcp-firestore` 36/36 (1 expected skip on the gated `runBenchmarks()` test)
- [x] `runBenchmarks()` correctly skipped without `-DrunBenchmarks=true`

### End-to-end shakedown — GCP Firestore (4/4 pass)

Project `substrate-sdk-gcp-poc1`, `(default)` database, `firestore-benchmark-test1` + `test2` collections.

| Benchmark | Throughput (ops/s) | p50 (s) | p99 (s) |
|---|---|---|---|
| `benchmarkGetWithProjection` | 5.519 | 0.600 | 1.770 |
| `benchmarkQueryWithLimit` | 1.856 | 1.363 | 1.734 |
| `benchmarkQueryWithPagination` | 0.566 | 1.747 | 2.294 |
| `benchmarkQueryWithOrderBy` | 1.079 | 0.968 | 1.367 |

`benchmarkQueryWithOrderBy` required creating composite index `(Game ASC, Score DESC)` on `firestore-benchmark-test2` — built in <60s.

### End-to-end shakedown — AWS DynamoDB (3/3 pass on validated subset)

Region `us-east-2`, `docstore-benchmark-test1` + `test2` tables.

| Benchmark | Throughput (ops/s) | p50 (s) | p99 (s) |
|---|---|---|---|
| `benchmarkGetWithProjection` | 14.127 | 0.262 | 0.300 |
| `benchmarkQueryWithLimit` | 7.000 | 0.264 | 0.730 |
| `benchmarkQueryWithPagination` | 1.725 | 0.537 | 0.654 |

**Known gap:** `benchmarkQueryWithOrderBy` not validated on AWS. `docstore-benchmark-test2` has no LSI on `Score`. DynamoDB LSIs can only be added at table-creation time, so provisioning the LSI requires drop+recreate of a shared table — left as a separate ops decision. The benchmark code is correct; just unvalidated until LSI lands.

Numbers above are advisory until per-benchmark baselines are established. Full results (per-benchmark histograms, environment metadata, raw JMH JSON) captured in [the standalone shakedown results doc](https://docs.google.com/document/d/1PlqeYd1kGm4nhJ1eseDr3uDR6nompmfsl0FzibITtfg/edit).

## Test plan

- [x] Unit tests pass (`docstore-client`, `docstore-aws`, `docstore-gcp-firestore`)
- [x] Checkstyle clean
- [x] GCP end-to-end shakedown — 4/4 new benchmarks
- [x] AWS end-to-end shakedown — 3/4 new benchmarks (orderBy gated on LSI provisioning)

## Next steps (post-merge of this PR)

A follow-up PR-B will close the remaining items from the spike doc to reach the spike's 14-benchmark target:

- Rework `benchmarkSingleActionGet` → `benchmarkGet` (read pre-seeded data only; current version embeds 10 puts before measurement)
- Rework `benchmarkActionListGet` → `benchmarkBatchGet` with `@Param({"10","50","100"})` (current version embeds 100 individual puts before 1 batchGet)
- Add `@Param({"10","50","100"})` to `benchmarkBatchPut`
- Fix 8-char UUID substring collision risk in `benchmarkAtomicWrites`
- Remove redundant benchmarks: `benchmarkGetFromTestData`, `benchmarkGetSmall`, `benchmarkGetMedium`, `benchmarkSortKeyQuery`

PR-B will be opened after this PR merges (avoids triple-stacking on top of #432).

Stacked on `fix/docstore-benchmark-critical-bugs` (PR #432). Not for merge until #432 lands.

