### PR TITLE
blobstore: implement async upload and download operations for Ali OSS

### DIFF
--- a/blob/blob-ali/pom.xml
+++ b/blob/blob-ali/pom.xml
@@ -198,7 +198,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.5</version>
+            <version>5.5.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -209,7 +209,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>
             <artifactId>httpcore5</artifactId>
-            <version>5.3.3</version>
+            <version>5.3.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -220,7 +220,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>
             <artifactId>httpcore5-h2</artifactId>
-            <version>5.3.3</version>
+            <version>5.3.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -2,7 +2,12 @@ package com.salesforce.multicloudj.blob.ali.async;
 
 import com.aliyun.sdk.service.oss2.OSSAsyncClient;
 import com.aliyun.sdk.service.oss2.OSSClient;
+import com.aliyun.sdk.service.oss2.OperationOptions;
 import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
+import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectResult;
+import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
+import com.aliyun.sdk.service.oss2.transport.BinaryData;
 import com.salesforce.multicloudj.blob.ali.AliSdkService;
 import com.salesforce.multicloudj.blob.ali.AliTransformer;
 import com.salesforce.multicloudj.blob.ali.AliTransformerSupplier;
@@ -37,10 +42,13 @@ import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.ali.AliConstants;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -98,54 +106,123 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
   @Override
   protected CompletableFuture<UploadResponse> doUpload(
       UploadRequest uploadRequest, InputStream inputStream) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    long contentLength = uploadRequest.getContentLength();
+    BinaryData body = BinaryData.fromStream(
+        inputStream, contentLength > 0 ? contentLength : null);
+    return doUploadInternal(uploadRequest, body);
   }
 
   @Override
   protected CompletableFuture<UploadResponse> doUpload(
       UploadRequest uploadRequest, byte[] content) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    BinaryData body = BinaryData.fromBytes(content);
+    return doUploadInternal(uploadRequest, body);
   }
 
   @Override
   protected CompletableFuture<UploadResponse> doUpload(
       UploadRequest uploadRequest, File file) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    try {
+      BinaryData body = BinaryData.fromStream(
+          Files.newInputStream(file.toPath()),
+          file.length());
+      return doUploadInternal(uploadRequest, body);
+    } catch (IOException e) {
+      return CompletableFuture.failedFuture(
+          new SubstrateSdkException(
+              "Failed to read file for upload: "
+                  + file.getPath(), e));
+    }
   }
 
   @Override
   protected CompletableFuture<UploadResponse> doUpload(
       UploadRequest uploadRequest, Path path) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return doUpload(uploadRequest, path.toFile());
+  }
+
+  private CompletableFuture<UploadResponse> doUploadInternal(
+      UploadRequest uploadRequest, BinaryData body) {
+    PutObjectRequest request =
+        transformer.toPutObjectRequest(uploadRequest, body);
+    return asyncClient
+        .putObjectAsync(request, OperationOptions.defaults())
+        .thenApply(
+            result ->
+                transformer.toUploadResponse(uploadRequest, result));
   }
 
   @Override
   protected CompletableFuture<DownloadResponse> doDownload(
       DownloadRequest request, OutputStream outputStream) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return doDownloadInternal(request).thenApply(result -> {
+      try (InputStream body = result.body()) {
+        copyStream(body, outputStream);
+        return transformer.toDownloadResponse(request.getKey(), result);
+      } catch (IOException e) {
+        throw new SubstrateSdkException(
+            "Failed to download blob: " + request.getKey(), e);
+      }
+    });
   }
 
   @Override
   protected CompletableFuture<DownloadResponse> doDownload(
       DownloadRequest request, ByteArray byteArray) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    return doDownload(request, outputStream).thenApply(response -> {
+      byteArray.setBytes(outputStream.toByteArray());
+      return response;
+    });
   }
 
   @Override
   protected CompletableFuture<DownloadResponse> doDownload(
       DownloadRequest request, File file) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return doDownload(request, file.toPath());
   }
 
   @Override
   protected CompletableFuture<DownloadResponse> doDownload(
       DownloadRequest request, Path path) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    Path destinationPath = createDownloadDestinationPath(request, path);
+    return doDownloadInternal(request).thenApply(result -> {
+      try (InputStream body = result.body()) {
+        Files.copy(body, destinationPath);
+        return transformer.toDownloadResponse(request.getKey(), result);
+      } catch (IOException e) {
+        throw new SubstrateSdkException(
+            "Failed to download blob: " + request.getKey(), e);
+      }
+    });
   }
 
   @Override
-  protected CompletableFuture<DownloadResponse> doDownload(DownloadRequest request) {
-    throw new UnsupportedOperationException("Not yet implemented");
+  protected CompletableFuture<DownloadResponse> doDownload(
+      DownloadRequest request) {
+    return doDownloadInternal(request).thenApply(result ->
+        transformer.toDownloadResponse(
+            request.getKey(), result, result.body()));
+  }
+
+  private CompletableFuture<GetObjectResult> doDownloadInternal(
+      DownloadRequest request) {
+    GetObjectRequest getRequest =
+        transformer.toGetObjectRequest(request);
+    return asyncClient
+        .getObjectAsync(getRequest, OperationOptions.defaults());
+  }
+
+  private void copyStream(InputStream in, OutputStream out) {
+    try {
+      byte[] buffer = new byte[1024];
+      int bytesRead;
+      while ((bytesRead = in.read(buffer)) != -1) {
+        out.write(buffer, 0, bytesRead);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -6,7 +6,11 @@ import com.aliyun.sdk.service.oss2.OperationOptions;
 import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
 import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectResult;
+import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
+import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
 import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
+import com.aliyun.sdk.service.oss2.transfermanager.DownloadError;
+import com.aliyun.sdk.service.oss2.transfermanager.Downloader;
 import com.aliyun.sdk.service.oss2.transport.BinaryData;
 import com.salesforce.multicloudj.blob.ali.AliSdkService;
 import com.salesforce.multicloudj.blob.ali.AliTransformer;
@@ -63,10 +67,14 @@ import lombok.Getter;
 public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkService {
 
   private final OSSAsyncClient asyncClient;
-  // syncClient is needed for presigned URLs — OSSAsyncClient does not implement Presignable
+  // syncClient is required for operations not available on OSSAsyncClient:
+  // 1. Presigned URLs — only OSSClient implements Presignable
+  // 2. Parallel downloads — the SDK's Downloader (transfer manager) only accepts OSSClient
+  // These sync operations are wrapped in supplyAsync/thenApplyAsync to remain non-blocking.
   private final OSSClient syncClient;
   private final AliTransformer transformer;
   private final ExecutorService executorService;
+  private final Downloader downloader;
 
   public AliAsyncBlobStore(
       String bucket,
@@ -77,12 +85,28 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
       OSSClient syncClient,
       AliTransformerSupplier transformerSupplier,
       ExecutorService executorService) {
+    this(bucket, region, credentialsOverrider, validator, asyncClient,
+        syncClient, transformerSupplier, executorService,
+        syncClient != null ? new Downloader(syncClient) : null);
+  }
+
+  AliAsyncBlobStore(
+      String bucket,
+      String region,
+      CredentialsOverrider credentialsOverrider,
+      BlobStoreValidator validator,
+      OSSAsyncClient asyncClient,
+      OSSClient syncClient,
+      AliTransformerSupplier transformerSupplier,
+      ExecutorService executorService,
+      Downloader downloader) {
     super(AliConstants.PROVIDER_ID, bucket, region, credentialsOverrider, validator);
     this.asyncClient = asyncClient;
     this.syncClient = syncClient;
     this.transformer = transformerSupplier.get(bucket);
     this.executorService =
         executorService != null ? executorService : ForkJoinPool.commonPool();
+    this.downloader = downloader;
   }
 
   @Override
@@ -186,6 +210,11 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
   protected CompletableFuture<DownloadResponse> doDownload(
       DownloadRequest request, Path path) {
     Path destinationPath = createDownloadDestinationPath(request, path);
+    if (request.isParallelDownload()
+        && request.getStart() == null
+        && request.getEnd() == null) {
+      return doParallelDownload(request, destinationPath);
+    }
     return doDownloadInternal(request).thenApply(result -> {
       try (InputStream body = result.body()) {
         Files.copy(body, destinationPath);
@@ -195,6 +224,40 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
             "Failed to download blob: " + request.getKey(), e);
       }
     });
+  }
+
+  /**
+   * Parallel download using the OSS SDK's Downloader (transfer manager). The Downloader internally
+   * splits the object into chunks based on partSize, issues concurrent Range GET requests using its
+   * own thread pool, and writes each chunk at the correct offset via positional FileChannel writes.
+   * It also supports checkpointing for resumable downloads and CRC64 integrity verification.
+   *
+   * <p>Because the Downloader is sync-only (requires OSSClient), the blocking call is offloaded to
+   * the executorService via thenApplyAsync. A preceding async HEAD request fetches object metadata
+   * for the response, since the Downloader's DownloadResult only reports bytes written.
+   */
+  private CompletableFuture<DownloadResponse> doParallelDownload(
+      DownloadRequest request, Path destinationPath) {
+    HeadObjectRequest headRequest =
+        transformer.toHeadObjectRequest(request.getKey(), null);
+    return asyncClient
+        .headObjectAsync(headRequest, OperationOptions.defaults())
+        .thenApplyAsync(headResult -> {
+          GetObjectRequest getRequest =
+              transformer.toGetObjectRequest(request);
+          try {
+            downloader.downloadFile(getRequest,
+                destinationPath.toString());
+          } catch (DownloadError e) {
+            throw new SubstrateSdkException(
+                "Parallel download failed: " + request.getKey(), e);
+          }
+          return DownloadResponse.builder()
+              .key(request.getKey())
+              .metadata(transformer.toBlobMetadata(
+                  request.getKey(), headResult))
+              .build();
+        }, executorService);
   }
 
   @Override
@@ -215,7 +278,7 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
 
   private void copyStream(InputStream in, OutputStream out) {
     try {
-      byte[] buffer = new byte[1024];
+      byte[] buffer = new byte[8192];
       int bytesRead;
       while ((bytesRead = in.read(buffer)) != -1) {
         out.write(buffer, 0, bytesRead);
@@ -381,6 +444,9 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
               getProxyEndpoint().getHost()
                   + ":" + getProxyEndpoint().getPort());
         }
+        if (getSocketTimeout() != null) {
+          asyncBuilder.readWriteTimeout(getSocketTimeout());
+        }
         async = asyncBuilder.build();
       }
 
@@ -396,6 +462,9 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
           syncBuilder.proxyHost(
               getProxyEndpoint().getHost()
                   + ":" + getProxyEndpoint().getPort());
+        }
+        if (getSocketTimeout() != null) {
+          syncBuilder.readWriteTimeout(getSocketTimeout());
         }
         sync = syncBuilder.build();
       }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -3,8 +3,13 @@ package com.salesforce.multicloudj.blob.ali.async;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.aliyun.sdk.service.oss2.OSSAsyncClient;
@@ -12,9 +17,15 @@ import com.aliyun.sdk.service.oss2.OSSClient;
 import com.aliyun.sdk.service.oss2.OperationOptions;
 import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectResult;
+import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
+import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
 import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
 import com.aliyun.sdk.service.oss2.models.PutObjectResult;
+import com.aliyun.sdk.service.oss2.transfermanager.DownloadError;
+import com.aliyun.sdk.service.oss2.transfermanager.DownloadResult;
+import com.aliyun.sdk.service.oss2.transfermanager.Downloader;
 import com.salesforce.multicloudj.blob.ali.AliTransformerSupplier;
+import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.BlobStoreValidator;
 import com.salesforce.multicloudj.blob.driver.DownloadRequest;
 import com.salesforce.multicloudj.blob.driver.DownloadResponse;
@@ -26,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -37,6 +49,7 @@ public class AliAsyncBlobStoreTest {
 
   private OSSAsyncClient mockAsyncClient;
   private OSSClient mockSyncClient;
+  private Downloader mockDownloader;
   private AliAsyncBlobStore store;
   private final BlobStoreValidator validator = new BlobStoreValidator();
 
@@ -44,9 +57,11 @@ public class AliAsyncBlobStoreTest {
   void setup() {
     mockAsyncClient = mock(OSSAsyncClient.class);
     mockSyncClient = mock(OSSClient.class);
+    mockDownloader = mock(Downloader.class);
     store = new AliAsyncBlobStore(
         BUCKET, REGION, null, validator, mockAsyncClient,
-        mockSyncClient, new AliTransformerSupplier(), null);
+        mockSyncClient, new AliTransformerSupplier(), null,
+        mockDownloader);
   }
 
   @Test
@@ -177,5 +192,124 @@ public class AliAsyncBlobStoreTest {
     assertNotNull(response);
     assertNotNull(response.getInputStream());
     assertArrayEquals(content, response.getInputStream().readAllBytes());
+  }
+
+  @Test
+  void testUploadFailedAsyncClient() {
+    RuntimeException cause = new RuntimeException("network error");
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    UploadRequest request = UploadRequest.builder()
+        .withKey("fail-key")
+        .withContentLength(5)
+        .build();
+    byte[] content = "hello".getBytes(StandardCharsets.UTF_8);
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.upload(request, content).get());
+    assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testDownloadFailedAsyncClient() {
+    RuntimeException cause = new RuntimeException("connection refused");
+    when(mockAsyncClient.getObjectAsync(
+        any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey("fail-key")
+        .build();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.download(request, outputStream).get());
+    assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testParallelDownloadToFile(@TempDir Path tempDir) throws Exception {
+    HeadObjectResult mockHeadResult = mock(HeadObjectResult.class);
+    when(mockHeadResult.contentLength()).thenReturn(1024L);
+    when(mockHeadResult.eTag()).thenReturn("\"etag-parallel\"");
+    when(mockHeadResult.versionId()).thenReturn("v-parallel");
+    when(mockHeadResult.contentType()).thenReturn("application/octet-stream");
+    when(mockAsyncClient.headObjectAsync(
+        any(HeadObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockHeadResult));
+
+    DownloadResult mockDownloadResult = new DownloadResult(1024L);
+    when(mockDownloader.downloadFile(
+        any(GetObjectRequest.class), anyString()))
+        .thenReturn(mockDownloadResult);
+
+    Path file = tempDir.resolve("parallel-dl.bin");
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey("parallel-key")
+        .withParallelDownload(true)
+        .build();
+    DownloadResponse response = store.download(request, file).get();
+
+    assertNotNull(response);
+    assertEquals("parallel-key", response.getKey());
+    BlobMetadata metadata = response.getMetadata();
+    assertNotNull(metadata);
+    assertEquals("etag-parallel", metadata.getETag());
+    assertEquals(1024L, metadata.getObjectSize());
+    verify(mockDownloader).downloadFile(
+        any(GetObjectRequest.class), anyString());
+  }
+
+  @Test
+  void testParallelDownloadWithRangeFallsBackToNormal(
+      @TempDir Path tempDir) throws Exception {
+    byte[] content = "range content".getBytes(StandardCharsets.UTF_8);
+    GetObjectResult mockResult = mock(GetObjectResult.class);
+    when(mockResult.body())
+        .thenReturn(new ByteArrayInputStream(content));
+    when(mockResult.contentLength()).thenReturn((long) content.length);
+    when(mockResult.eTag()).thenReturn("\"etag-range\"");
+    when(mockAsyncClient.getObjectAsync(
+        any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    Path file = tempDir.resolve("range-dl.bin");
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey("range-key")
+        .withParallelDownload(true)
+        .withRange(0L, 10L)
+        .build();
+    DownloadResponse response = store.download(request, file).get();
+
+    assertNotNull(response);
+    verify(mockAsyncClient, never()).headObjectAsync(
+        any(HeadObjectRequest.class), any(OperationOptions.class));
+    assertTrue(Files.exists(file));
+  }
+
+  @Test
+  void testParallelDownloadFailure(@TempDir Path tempDir) throws Exception {
+    HeadObjectResult mockHeadResult = mock(HeadObjectResult.class);
+    when(mockHeadResult.contentLength()).thenReturn(2048L);
+    when(mockAsyncClient.headObjectAsync(
+        any(HeadObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockHeadResult));
+
+    when(mockDownloader.downloadFile(
+        any(GetObjectRequest.class), anyString()))
+        .thenThrow(new DownloadError("download failed",
+            new RuntimeException("network error")));
+
+    Path file = tempDir.resolve("fail-parallel.bin");
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey("fail-parallel-key")
+        .withParallelDownload(true)
+        .build();
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.download(request, file).get());
+    assertNotNull(ex.getCause());
   }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -1,0 +1,181 @@
+package com.salesforce.multicloudj.blob.ali.async;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.aliyun.sdk.service.oss2.OSSAsyncClient;
+import com.aliyun.sdk.service.oss2.OSSClient;
+import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectResult;
+import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
+import com.aliyun.sdk.service.oss2.models.PutObjectResult;
+import com.salesforce.multicloudj.blob.ali.AliTransformerSupplier;
+import com.salesforce.multicloudj.blob.driver.BlobStoreValidator;
+import com.salesforce.multicloudj.blob.driver.DownloadRequest;
+import com.salesforce.multicloudj.blob.driver.DownloadResponse;
+import com.salesforce.multicloudj.blob.driver.UploadRequest;
+import com.salesforce.multicloudj.blob.driver.UploadResponse;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class AliAsyncBlobStoreTest {
+
+  private static final String BUCKET = "test-bucket";
+  private static final String REGION = "cn-shanghai";
+
+  private OSSAsyncClient mockAsyncClient;
+  private OSSClient mockSyncClient;
+  private AliAsyncBlobStore store;
+  private final BlobStoreValidator validator = new BlobStoreValidator();
+
+  @BeforeEach
+  void setup() {
+    mockAsyncClient = mock(OSSAsyncClient.class);
+    mockSyncClient = mock(OSSClient.class);
+    store = new AliAsyncBlobStore(
+        BUCKET, REGION, null, validator, mockAsyncClient,
+        mockSyncClient, new AliTransformerSupplier(), null);
+  }
+
+  @Test
+  void testUploadInputStream() throws Exception {
+    PutObjectResult mockResult = mock(PutObjectResult.class);
+    when(mockResult.versionId()).thenReturn("v1");
+    when(mockResult.eTag()).thenReturn("\"etag123\"");
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    UploadRequest request = UploadRequest.builder()
+        .withKey("test-key")
+        .withContentLength(11)
+        .build();
+    byte[] content = "hello world".getBytes(StandardCharsets.UTF_8);
+    UploadResponse response = store.upload(request,
+        new ByteArrayInputStream(content)).get();
+
+    assertNotNull(response);
+    assertEquals("test-key", response.getKey());
+    assertEquals("v1", response.getVersionId());
+  }
+
+  @Test
+  void testUploadBytes() throws Exception {
+    PutObjectResult mockResult = mock(PutObjectResult.class);
+    when(mockResult.versionId()).thenReturn("v2");
+    when(mockResult.eTag()).thenReturn("\"etag456\"");
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    UploadRequest request = UploadRequest.builder()
+        .withKey("byte-key")
+        .build();
+    UploadResponse response = store.upload(request,
+        "content".getBytes(StandardCharsets.UTF_8)).get();
+
+    assertEquals("byte-key", response.getKey());
+    assertEquals("v2", response.getVersionId());
+  }
+
+  @Test
+  void testUploadFile(@TempDir Path tempDir) throws Exception {
+    Path file = tempDir.resolve("upload.txt");
+    Files.writeString(file, "file content");
+
+    PutObjectResult mockResult = mock(PutObjectResult.class);
+    when(mockResult.versionId()).thenReturn("v3");
+    when(mockResult.eTag()).thenReturn("\"etag789\"");
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    UploadRequest request = UploadRequest.builder()
+        .withKey("file-key")
+        .build();
+    UploadResponse response = store.upload(request, file.toFile()).get();
+
+    assertEquals("file-key", response.getKey());
+    assertEquals("v3", response.getVersionId());
+  }
+
+  @Test
+  void testDownloadToOutputStream() throws Exception {
+    byte[] content = "downloaded content".getBytes(StandardCharsets.UTF_8);
+    GetObjectResult mockResult = mock(GetObjectResult.class);
+    when(mockResult.body())
+        .thenReturn(new ByteArrayInputStream(content));
+    when(mockResult.contentLength()).thenReturn((long) content.length);
+    when(mockResult.eTag()).thenReturn("\"etag-dl\"");
+    when(mockAsyncClient.getObjectAsync(
+        any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey("dl-key")
+        .build();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    DownloadResponse response =
+        store.download(request, outputStream).get();
+
+    assertNotNull(response);
+    assertArrayEquals(content, outputStream.toByteArray());
+  }
+
+  @Test
+  void testDownloadToFile(@TempDir Path tempDir) throws Exception {
+    byte[] content = "file download".getBytes(StandardCharsets.UTF_8);
+    GetObjectResult mockResult = mock(GetObjectResult.class);
+    when(mockResult.body())
+        .thenReturn(new ByteArrayInputStream(content));
+    when(mockResult.contentLength()).thenReturn((long) content.length);
+    when(mockResult.eTag()).thenReturn("\"etag-file\"");
+    when(mockAsyncClient.getObjectAsync(
+        any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    Path file = tempDir.resolve("download.txt");
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey("dl-file-key")
+        .build();
+    DownloadResponse response =
+        store.download(request, file).get();
+
+    assertNotNull(response);
+    assertArrayEquals(content, Files.readAllBytes(file));
+  }
+
+  @Test
+  void testDownloadAsInputStream() throws Exception {
+    byte[] content = "stream download".getBytes(StandardCharsets.UTF_8);
+    GetObjectResult mockResult = mock(GetObjectResult.class);
+    when(mockResult.body())
+        .thenReturn(new ByteArrayInputStream(content));
+    when(mockResult.contentLength()).thenReturn((long) content.length);
+    when(mockResult.eTag()).thenReturn("\"etag-stream\"");
+    when(mockAsyncClient.getObjectAsync(
+        any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey("dl-stream-key")
+        .build();
+    DownloadResponse response = store.download(request).get();
+
+    assertNotNull(response);
+    assertNotNull(response.getInputStream());
+    assertArrayEquals(content, response.getInputStream().readAllBytes());
+  }
+}


### PR DESCRIPTION
## Summary

Add native async upload via OSSAsyncClient.putObjectAsync() and download via getObjectAsync() for all doUpload/doDownload variants (InputStream, byte[], File, Path).

Bumping httpclient5 and httpcore5 version as needed by async client.

Includes unit tests with mocked SDK client. Performed manual testing against live Ali environment to verify upload and download operation.

<img width="1168" height="496" alt="image" src="https://github.com/user-attachments/assets/427b795a-3933-446f-9e86-5a0b15be9999" />


## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
