### PR TITLE
blobstore: implement async delete and copy operations for Ali OSS

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -4,6 +4,8 @@ import com.aliyun.sdk.service.oss2.OSSAsyncClient;
 import com.aliyun.sdk.service.oss2.OSSClient;
 import com.aliyun.sdk.service.oss2.OperationOptions;
 import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
+import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
+import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectResult;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
@@ -290,12 +292,24 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
 
   @Override
   protected CompletableFuture<Void> doDelete(String key, String versionId) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    DeleteObjectRequest request =
+        transformer.toDeleteObjectRequest(key, versionId);
+    return asyncClient
+        .deleteObjectAsync(request, OperationOptions.defaults())
+        .thenAccept(result -> {});
   }
 
   @Override
-  protected CompletableFuture<Void> doDelete(Collection<BlobIdentifier> objects) {
-    throw new UnsupportedOperationException("Not yet implemented");
+  protected CompletableFuture<Void> doDelete(
+      Collection<BlobIdentifier> objects) {
+    if (objects.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+    DeleteMultipleObjectsRequest request =
+        transformer.toDeleteMultipleObjectsRequest(objects);
+    return asyncClient
+        .deleteMultipleObjectsAsync(request, OperationOptions.defaults())
+        .thenAccept(result -> {});
   }
 
   @Override

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -302,9 +302,6 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
   @Override
   protected CompletableFuture<Void> doDelete(
       Collection<BlobIdentifier> objects) {
-    if (objects.isEmpty()) {
-      return CompletableFuture.completedFuture(null);
-    }
     DeleteMultipleObjectsRequest request =
         transformer.toDeleteMultipleObjectsRequest(objects);
     return asyncClient

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -314,7 +314,12 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
 
   @Override
   protected CompletableFuture<CopyResponse> doCopy(CopyRequest request) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return asyncClient
+        .copyObjectAsync(
+            transformer.toCopyObjectRequest(request),
+            OperationOptions.defaults())
+        .thenApply(result ->
+            transformer.toCopyResponse(request.getDestKey(), result));
   }
 
   @Override

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -376,4 +376,51 @@ public class AliAsyncBlobStoreTest {
     assertEquals("v-copy", response.getVersionId());
     assertEquals("etag-copy", response.getETag());
   }
+
+  @Test
+  void testDeleteSingleObjectFailed() {
+    RuntimeException cause = new RuntimeException("access denied");
+    when(mockAsyncClient.deleteObjectAsync(
+        any(DeleteObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.delete("forbidden-key", null).get());
+    assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testDeleteMultipleObjectsFailed() {
+    RuntimeException cause = new RuntimeException("batch delete error");
+    when(mockAsyncClient.deleteMultipleObjectsAsync(
+        any(DeleteMultipleObjectsRequest.class),
+        any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    List<BlobIdentifier> objects = List.of(
+        new BlobIdentifier("key1", null),
+        new BlobIdentifier("key2", null));
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.delete(objects).get());
+    assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testCopyFailed() {
+    RuntimeException cause = new RuntimeException("source not found");
+    when(mockAsyncClient.copyObjectAsync(
+        any(CopyObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    CopyRequest request = CopyRequest.builder()
+        .srcKey("missing-key")
+        .destBucket("dest-bucket")
+        .destKey("dest-key")
+        .build();
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.copy(request).get());
+    assertNotNull(ex.getCause());
+  }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -375,6 +375,7 @@ public class AliAsyncBlobStoreTest {
     assertEquals("dest-key", response.getKey());
     assertEquals("v-copy", response.getVersionId());
     assertEquals("etag-copy", response.getETag());
+    assertNotNull(response.getLastModified());
   }
 
   @Test

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -15,6 +15,8 @@ import static org.mockito.Mockito.when;
 import com.aliyun.sdk.service.oss2.OSSAsyncClient;
 import com.aliyun.sdk.service.oss2.OSSClient;
 import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.models.CopyObjectRequest;
+import com.aliyun.sdk.service.oss2.models.CopyObjectResult;
 import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
 import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsResult;
 import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
@@ -32,6 +34,8 @@ import com.salesforce.multicloudj.blob.ali.AliTransformerSupplier;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.BlobStoreValidator;
+import com.salesforce.multicloudj.blob.driver.CopyRequest;
+import com.salesforce.multicloudj.blob.driver.CopyResponse;
 import com.salesforce.multicloudj.blob.driver.DownloadRequest;
 import com.salesforce.multicloudj.blob.driver.DownloadResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
@@ -348,5 +352,28 @@ public class AliAsyncBlobStoreTest {
   void testDeleteEmptyCollection() {
     assertThrows(IllegalArgumentException.class,
         () -> store.delete(List.of()));
+  }
+
+  @Test
+  void testCopy() throws Exception {
+    CopyObjectResult mockResult = mock(CopyObjectResult.class);
+    when(mockResult.versionId()).thenReturn("v-copy");
+    when(mockResult.eTag()).thenReturn("\"etag-copy\"");
+    when(mockResult.lastModified()).thenReturn("Wed, 27 May 2026 00:00:00 GMT");
+    when(mockAsyncClient.copyObjectAsync(
+        any(CopyObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    CopyRequest request = CopyRequest.builder()
+        .srcKey("src-key")
+        .destBucket("dest-bucket")
+        .destKey("dest-key")
+        .build();
+    CopyResponse response = store.copy(request).get();
+
+    assertNotNull(response);
+    assertEquals("dest-key", response.getKey());
+    assertEquals("v-copy", response.getVersionId());
+    assertEquals("etag-copy", response.getETag());
   }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -15,6 +15,10 @@ import static org.mockito.Mockito.when;
 import com.aliyun.sdk.service.oss2.OSSAsyncClient;
 import com.aliyun.sdk.service.oss2.OSSClient;
 import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
+import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsResult;
+import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
+import com.aliyun.sdk.service.oss2.models.DeleteObjectResult;
 import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectResult;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
@@ -25,6 +29,7 @@ import com.aliyun.sdk.service.oss2.transfermanager.DownloadError;
 import com.aliyun.sdk.service.oss2.transfermanager.DownloadResult;
 import com.aliyun.sdk.service.oss2.transfermanager.Downloader;
 import com.salesforce.multicloudj.blob.ali.AliTransformerSupplier;
+import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.BlobStoreValidator;
 import com.salesforce.multicloudj.blob.driver.DownloadRequest;
@@ -36,6 +41,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
@@ -311,5 +317,36 @@ public class AliAsyncBlobStoreTest {
     ExecutionException ex = assertThrows(ExecutionException.class,
         () -> store.download(request, file).get());
     assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testDeleteSingleObject() throws Exception {
+    DeleteObjectResult mockResult = mock(DeleteObjectResult.class);
+    when(mockAsyncClient.deleteObjectAsync(
+        any(DeleteObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    store.delete("key-to-delete", null).get();
+  }
+
+  @Test
+  void testDeleteMultipleObjects() throws Exception {
+    DeleteMultipleObjectsResult mockResult =
+        mock(DeleteMultipleObjectsResult.class);
+    when(mockAsyncClient.deleteMultipleObjectsAsync(
+        any(DeleteMultipleObjectsRequest.class),
+        any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    List<BlobIdentifier> objects = List.of(
+        new BlobIdentifier("key1", null),
+        new BlobIdentifier("key2", "v1"));
+    store.delete(objects).get();
+  }
+
+  @Test
+  void testDeleteEmptyCollection() {
+    assertThrows(IllegalArgumentException.class,
+        () -> store.delete(List.of()));
   }
 }


### PR DESCRIPTION
## Summary

Add async delete and copy object operation support for Ali.

Includes unit tests with mocked SDK client. Performed manual integration testing against live Ali environment to verify functionality.

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
