### PR TITLE
blobstore: implement async metadata operations for Ali OSS

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -6,6 +6,7 @@ import com.aliyun.sdk.service.oss2.OperationOptions;
 import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
 import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
 import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectResult;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
@@ -322,7 +323,11 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
   @Override
   protected CompletableFuture<BlobMetadata> doGetMetadata(
       String key, String versionId) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return asyncClient
+        .headObjectAsync(
+            transformer.toHeadObjectRequest(key, versionId),
+            OperationOptions.defaults())
+        .thenApply(result -> transformer.toBlobMetadata(key, result));
   }
 
   @Override
@@ -386,12 +391,19 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
   @Override
   protected CompletableFuture<Boolean> doDoesObjectExist(
       String key, String versionId) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    GetObjectMetaRequest.Builder reqBuilder =
+        GetObjectMetaRequest.newBuilder()
+            .bucket(getBucket())
+            .key(key);
+    if (versionId != null) {
+      reqBuilder.versionId(versionId);
+    }
+    return asyncClient.doesObjectExistAsync(reqBuilder.build());
   }
 
   @Override
   protected CompletableFuture<Boolean> doDoesBucketExist() {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return asyncClient.doesBucketExistAsync(getBucket());
   }
 
   @Override

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -489,4 +489,39 @@ public class AliAsyncBlobStoreTest {
     boolean exists = store.doesBucketExist().get();
     assertEquals(false, exists);
   }
+
+  @Test
+  void testGetMetadataFailed() {
+    RuntimeException cause = new RuntimeException("object not found");
+    when(mockAsyncClient.headObjectAsync(
+        any(HeadObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.getMetadata("missing-key", null).get());
+    assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testDoesObjectExistFailed() {
+    RuntimeException cause = new RuntimeException("access denied");
+    when(mockAsyncClient.doesObjectExistAsync(
+        any(GetObjectMetaRequest.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.doesObjectExist("forbidden-key", null).get());
+    assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testDoesBucketExistFailed() {
+    RuntimeException cause = new RuntimeException("service unavailable");
+    when(mockAsyncClient.doesBucketExistAsync(BUCKET))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.doesBucketExist().get());
+    assertNotNull(ex.getCause());
+  }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -21,6 +21,7 @@ import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
 import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsResult;
 import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
 import com.aliyun.sdk.service.oss2.models.DeleteObjectResult;
+import com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectResult;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
@@ -46,6 +47,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
@@ -423,5 +425,68 @@ public class AliAsyncBlobStoreTest {
     ExecutionException ex = assertThrows(ExecutionException.class,
         () -> store.copy(request).get());
     assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testGetMetadata() throws Exception {
+    HeadObjectResult mockResult = mock(HeadObjectResult.class);
+    when(mockResult.versionId()).thenReturn("v-meta");
+    when(mockResult.eTag()).thenReturn("\"etag-meta\"");
+    when(mockResult.contentLength()).thenReturn(1024L);
+    when(mockResult.lastModified()).thenReturn("Wed, 27 May 2026 00:00:00 GMT");
+    when(mockResult.contentType()).thenReturn("application/octet-stream");
+    when(mockResult.contentMd5()).thenReturn(null);
+    when(mockResult.metadata()).thenReturn(Map.of());
+    when(mockAsyncClient.headObjectAsync(
+        any(HeadObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    BlobMetadata metadata = store.getMetadata("meta-key", null).get();
+
+    assertNotNull(metadata);
+    assertEquals("meta-key", metadata.getKey());
+    assertEquals("v-meta", metadata.getVersionId());
+    assertEquals("etag-meta", metadata.getETag());
+    assertEquals(1024L, metadata.getObjectSize());
+    assertEquals("application/octet-stream", metadata.getContentType());
+    assertNotNull(metadata.getLastModified());
+  }
+
+  @Test
+  void testDoesObjectExistTrue() throws Exception {
+    when(mockAsyncClient.doesObjectExistAsync(
+        any(GetObjectMetaRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(true));
+
+    boolean exists = store.doesObjectExist("existing-key", null).get();
+    assertEquals(true, exists);
+  }
+
+  @Test
+  void testDoesObjectExistFalse() throws Exception {
+    when(mockAsyncClient.doesObjectExistAsync(
+        any(GetObjectMetaRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(false));
+
+    boolean exists = store.doesObjectExist("missing-key", null).get();
+    assertEquals(false, exists);
+  }
+
+  @Test
+  void testDoesBucketExistTrue() throws Exception {
+    when(mockAsyncClient.doesBucketExistAsync(BUCKET))
+        .thenReturn(CompletableFuture.completedFuture(true));
+
+    boolean exists = store.doesBucketExist().get();
+    assertEquals(true, exists);
+  }
+
+  @Test
+  void testDoesBucketExistFalse() throws Exception {
+    when(mockAsyncClient.doesBucketExistAsync(BUCKET))
+        .thenReturn(CompletableFuture.completedFuture(false));
+
+    boolean exists = store.doesBucketExist().get();
+    assertEquals(false, exists);
   }
 }


### PR DESCRIPTION
## Summary

Add metadata related operation support for Ali through the following:

- GetMetadata
- DoesObjectExist
- DoesBucketExist

Includes unit tests with mocked SDK client. Performed manual integration testing against live Ali environment to verify functionality.

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
