### PR TITLE
blobstore: implement listBlobVersions for Ali OSS using v2 SDK paginator

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -22,10 +22,13 @@ import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
 import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult;
+import com.aliyun.sdk.service.oss2.models.ListObjectVersionsRequest;
+import com.aliyun.sdk.service.oss2.models.ListObjectVersionsResult;
 import com.aliyun.sdk.service.oss2.models.ListObjectsV2Request;
 import com.aliyun.sdk.service.oss2.models.ListObjectsV2Result;
 import com.aliyun.sdk.service.oss2.models.ListPartsRequest;
 import com.aliyun.sdk.service.oss2.models.ListPartsResult;
+import com.aliyun.sdk.service.oss2.models.ObjectVersion;
 import com.aliyun.sdk.service.oss2.models.PresignResult;
 import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
 import com.aliyun.sdk.service.oss2.models.PutObjectResult;
@@ -74,6 +77,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import lombok.Getter;
 
@@ -485,6 +489,62 @@ public class AliBlobStore extends AbstractBlobStore {
         blobs, commonPrefixes,
         Boolean.TRUE.equals(response.isTruncated()),
         response.nextContinuationToken());
+  }
+
+  @Override
+  protected Iterator<BlobMetadata> doListBlobVersions(String key) {
+    ListObjectVersionsRequest request = ListObjectVersionsRequest.newBuilder()
+        .bucket(getBucket())
+        .prefix(key)
+        .build();
+
+    Iterator<ListObjectVersionsResult> pages =
+        ossClient.listObjectVersionsPaginator(request).iterator();
+
+    return new Iterator<>() {
+      private Iterator<ObjectVersion> current = List.<ObjectVersion>of().iterator();
+      private BlobMetadata next;
+
+      @Override
+      public boolean hasNext() {
+        if (next != null) {
+          return true;
+        }
+        next = advance();
+        return next != null;
+      }
+
+      @Override
+      public BlobMetadata next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        BlobMetadata result = next;
+        next = null;
+        return result;
+      }
+
+      private BlobMetadata advance() {
+        while (true) {
+          while (current.hasNext()) {
+            ObjectVersion v = current.next();
+            if (key.equals(v.key())) {
+              return BlobMetadata.builder()
+                  .key(v.key())
+                  .versionId(v.versionId())
+                  .eTag(v.eTag())
+                  .objectSize(v.size() != null ? v.size() : 0L)
+                  .lastModified(v.lastModified())
+                  .build();
+            }
+          }
+          if (!pages.hasNext()) {
+            return null;
+          }
+          current = pages.next().versions().iterator();
+        }
+      }
+    };
   }
 
   /**

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -22,13 +22,10 @@ import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
 import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult;
-import com.aliyun.sdk.service.oss2.models.ListObjectVersionsRequest;
-import com.aliyun.sdk.service.oss2.models.ListObjectVersionsResult;
 import com.aliyun.sdk.service.oss2.models.ListObjectsV2Request;
 import com.aliyun.sdk.service.oss2.models.ListObjectsV2Result;
 import com.aliyun.sdk.service.oss2.models.ListPartsRequest;
 import com.aliyun.sdk.service.oss2.models.ListPartsResult;
-import com.aliyun.sdk.service.oss2.models.ObjectVersion;
 import com.aliyun.sdk.service.oss2.models.PresignResult;
 import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
 import com.aliyun.sdk.service.oss2.models.PutObjectResult;
@@ -77,7 +74,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import lombok.Getter;
 
@@ -493,58 +489,7 @@ public class AliBlobStore extends AbstractBlobStore {
 
   @Override
   protected Iterator<BlobMetadata> doListBlobVersions(String key) {
-    ListObjectVersionsRequest request = ListObjectVersionsRequest.newBuilder()
-        .bucket(getBucket())
-        .prefix(key)
-        .build();
-
-    Iterator<ListObjectVersionsResult> pages =
-        ossClient.listObjectVersionsPaginator(request).iterator();
-
-    return new Iterator<>() {
-      private Iterator<ObjectVersion> current = List.<ObjectVersion>of().iterator();
-      private BlobMetadata next;
-
-      @Override
-      public boolean hasNext() {
-        if (next != null) {
-          return true;
-        }
-        next = advance();
-        return next != null;
-      }
-
-      @Override
-      public BlobMetadata next() {
-        if (!hasNext()) {
-          throw new NoSuchElementException();
-        }
-        BlobMetadata result = next;
-        next = null;
-        return result;
-      }
-
-      private BlobMetadata advance() {
-        while (true) {
-          while (current.hasNext()) {
-            ObjectVersion v = current.next();
-            if (key.equals(v.key())) {
-              return BlobMetadata.builder()
-                  .key(v.key())
-                  .versionId(v.versionId())
-                  .eTag(v.eTag())
-                  .objectSize(v.size() != null ? v.size() : 0L)
-                  .lastModified(v.lastModified())
-                  .build();
-            }
-          }
-          if (!pages.hasNext()) {
-            return null;
-          }
-          current = pages.next().versions().iterator();
-        }
-      }
-    };
+    return new BlobMetadataIterator(ossClient, getBucket(), key);
   }
 
   /**

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/BlobMetadataIterator.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/BlobMetadataIterator.java
@@ -1,0 +1,69 @@
+package com.salesforce.multicloudj.blob.ali;
+
+import com.aliyun.sdk.service.oss2.OSSClient;
+import com.aliyun.sdk.service.oss2.models.ListObjectVersionsRequest;
+import com.aliyun.sdk.service.oss2.models.ListObjectVersionsResult;
+import com.aliyun.sdk.service.oss2.models.ObjectVersion;
+import com.salesforce.multicloudj.blob.driver.BlobMetadata;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/** Iterator object to retrieve BlobMetadata versions for an exact key. */
+public class BlobMetadataIterator implements Iterator<BlobMetadata> {
+
+  private final String key;
+  private final Iterator<ListObjectVersionsResult> responseIterator;
+  private Iterator<ObjectVersion> current = List.<ObjectVersion>of().iterator();
+  private BlobMetadata next;
+
+  public BlobMetadataIterator(OSSClient ossClient, String bucket, String key) {
+    this.key = key;
+    this.responseIterator =
+        ossClient
+            .listObjectVersionsPaginator(
+                ListObjectVersionsRequest.newBuilder().bucket(bucket).prefix(key).build())
+            .iterator();
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (next != null) {
+      return true;
+    }
+
+    while (true) {
+      while (current.hasNext()) {
+        ObjectVersion version = current.next();
+        if (!key.equals(version.key())) {
+          continue;
+        }
+
+        next =
+            BlobMetadata.builder()
+                .key(version.key())
+                .versionId(version.versionId())
+                .eTag(version.eTag())
+                .objectSize(version.size() != null ? version.size() : 0L)
+                .lastModified(version.lastModified())
+                .build();
+        return true;
+      }
+
+      if (!responseIterator.hasNext()) {
+        return false;
+      }
+      current = responseIterator.next().versions().iterator();
+    }
+  }
+
+  @Override
+  public BlobMetadata next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    BlobMetadata result = next;
+    next = null;
+    return result;
+  }
+}

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -19,6 +19,10 @@ import com.aliyun.sdk.service.oss2.exceptions.OperationException;
 import com.aliyun.sdk.service.oss2.exceptions.ServiceException;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
 import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
+import com.aliyun.sdk.service.oss2.models.ListObjectVersionsRequest;
+import com.aliyun.sdk.service.oss2.models.ListObjectVersionsResult;
+import com.aliyun.sdk.service.oss2.models.ObjectVersion;
+import com.aliyun.sdk.service.oss2.paginator.ListObjectVersionsIterable;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
@@ -1141,5 +1145,113 @@ public class AliBlobStoreTest {
         () -> {
           ali.updateLegalHold(key, versionId, true);
         });
+  }
+
+  @Test
+  void testListBlobVersions() {
+    String key = "my-object";
+    ObjectVersion v1 = ObjectVersion.newBuilder()
+        .key(key).versionId("v1").eTag("etag1").size(100L)
+        .lastModified(Instant.now()).build();
+    ObjectVersion v2 = ObjectVersion.newBuilder()
+        .key(key).versionId("v2").eTag("etag2").size(200L)
+        .lastModified(Instant.now()).build();
+
+    ListObjectVersionsResult result = mock(ListObjectVersionsResult.class);
+    when(result.versions()).thenReturn(List.of(v1, v2));
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(result).iterator());
+    when(mockOssClient.listObjectVersionsPaginator(
+        any(ListObjectVersionsRequest.class))).thenReturn(iterable);
+
+    Iterator<BlobMetadata> iter = ali.listBlobVersions(key);
+
+    assertTrue(iter.hasNext());
+    BlobMetadata first = iter.next();
+    assertEquals(key, first.getKey());
+    assertEquals("v1", first.getVersionId());
+    assertEquals("etag1", first.getETag());
+    assertEquals(100L, first.getObjectSize());
+
+    assertTrue(iter.hasNext());
+    BlobMetadata second = iter.next();
+    assertEquals("v2", second.getVersionId());
+    assertEquals(200L, second.getObjectSize());
+
+    assertFalse(iter.hasNext());
+  }
+
+  @Test
+  void testListBlobVersionsFiltersPrefixMatches() {
+    String key = "obj-1";
+    ObjectVersion matching = ObjectVersion.newBuilder()
+        .key(key).versionId("v1").eTag("e1").size(10L)
+        .lastModified(Instant.now()).build();
+    ObjectVersion nonMatching = ObjectVersion.newBuilder()
+        .key("obj-1-extra").versionId("v2").eTag("e2").size(20L)
+        .lastModified(Instant.now()).build();
+
+    ListObjectVersionsResult result = mock(ListObjectVersionsResult.class);
+    when(result.versions()).thenReturn(List.of(matching, nonMatching));
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(result).iterator());
+    when(mockOssClient.listObjectVersionsPaginator(
+        any(ListObjectVersionsRequest.class))).thenReturn(iterable);
+
+    Iterator<BlobMetadata> iter = ali.listBlobVersions(key);
+
+    assertTrue(iter.hasNext());
+    BlobMetadata metadata = iter.next();
+    assertEquals(key, metadata.getKey());
+    assertEquals("v1", metadata.getVersionId());
+    assertFalse(iter.hasNext());
+  }
+
+  @Test
+  void testListBlobVersionsMultiplePages() {
+    String key = "paged-obj";
+    ObjectVersion v1 = ObjectVersion.newBuilder()
+        .key(key).versionId("v1").eTag("e1").size(10L)
+        .lastModified(Instant.now()).build();
+    ObjectVersion v2 = ObjectVersion.newBuilder()
+        .key(key).versionId("v2").eTag("e2").size(20L)
+        .lastModified(Instant.now()).build();
+
+    ListObjectVersionsResult page1 = mock(ListObjectVersionsResult.class);
+    when(page1.versions()).thenReturn(List.of(v1));
+    ListObjectVersionsResult page2 = mock(ListObjectVersionsResult.class);
+    when(page2.versions()).thenReturn(List.of(v2));
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(page1, page2).iterator());
+    when(mockOssClient.listObjectVersionsPaginator(
+        any(ListObjectVersionsRequest.class))).thenReturn(iterable);
+
+    Iterator<BlobMetadata> iter = ali.listBlobVersions(key);
+    List<BlobMetadata> all = new ArrayList<>();
+    iter.forEachRemaining(all::add);
+
+    assertEquals(2, all.size());
+    assertEquals("v1", all.get(0).getVersionId());
+    assertEquals("v2", all.get(1).getVersionId());
+  }
+
+  @Test
+  void testListBlobVersionsEmpty() {
+    String key = "no-versions";
+
+    ListObjectVersionsResult result = mock(ListObjectVersionsResult.class);
+    when(result.versions()).thenReturn(List.of());
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(result).iterator());
+    when(mockOssClient.listObjectVersionsPaginator(
+        any(ListObjectVersionsRequest.class))).thenReturn(iterable);
+
+    Iterator<BlobMetadata> iter = ali.listBlobVersions(key);
+    assertFalse(iter.hasNext());
+    assertThrows(NoSuchElementException.class, iter::next);
   }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/BlobMetadataIteratorTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/BlobMetadataIteratorTest.java
@@ -1,0 +1,114 @@
+package com.salesforce.multicloudj.blob.ali;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.aliyun.sdk.service.oss2.OSSClient;
+import com.aliyun.sdk.service.oss2.models.ListObjectVersionsRequest;
+import com.aliyun.sdk.service.oss2.models.ListObjectVersionsResult;
+import com.aliyun.sdk.service.oss2.models.ObjectVersion;
+import com.aliyun.sdk.service.oss2.paginator.ListObjectVersionsIterable;
+import com.salesforce.multicloudj.blob.driver.BlobMetadata;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for BlobMetadataIterator. */
+public class BlobMetadataIteratorTest {
+
+  private static final String TEST_BUCKET = "test-bucket";
+  private OSSClient mockOssClient;
+
+  @BeforeEach
+  void setUp() {
+    mockOssClient = mock(OSSClient.class);
+  }
+
+  @Test
+  void testSingleMatchingVersionFiltersPrefixOnlyMatches() {
+    String key = "obj-1";
+    ObjectVersion matching = version(key, "v1", 123L);
+    ObjectVersion nonMatching = version("obj-1-extra", "v2", 456L);
+
+    ListObjectVersionsResult result = mock(ListObjectVersionsResult.class);
+    when(result.versions()).thenReturn(List.of(matching, nonMatching));
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(result).iterator());
+    when(mockOssClient.listObjectVersionsPaginator(
+        any(ListObjectVersionsRequest.class))).thenReturn(iterable);
+
+    Iterator<BlobMetadata> iterator =
+        new BlobMetadataIterator(mockOssClient, TEST_BUCKET, key);
+
+    assertTrue(iterator.hasNext());
+    BlobMetadata metadata = iterator.next();
+    assertEquals(key, metadata.getKey());
+    assertEquals("v1", metadata.getVersionId());
+    assertEquals("etag-v1", metadata.getETag());
+    assertEquals(123L, metadata.getObjectSize());
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void testMultiplePages() {
+    String key = "obj-1";
+    ObjectVersion version1 = version(key, "v1", 100L);
+    ObjectVersion version2 = version(key, "v2", 200L);
+    ObjectVersion version3 = version(key, "v3", 300L);
+
+    ListObjectVersionsResult page1 = mock(ListObjectVersionsResult.class);
+    when(page1.versions()).thenReturn(List.of(version1));
+
+    ListObjectVersionsResult page2 = mock(ListObjectVersionsResult.class);
+    when(page2.versions()).thenReturn(List.of(version2, version3));
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(page1, page2).iterator());
+    when(mockOssClient.listObjectVersionsPaginator(
+        any(ListObjectVersionsRequest.class))).thenReturn(iterable);
+
+    Iterator<BlobMetadata> iterator =
+        new BlobMetadataIterator(mockOssClient, TEST_BUCKET, key);
+    List<BlobMetadata> all = new ArrayList<>();
+    iterator.forEachRemaining(all::add);
+
+    assertEquals(3, all.size());
+    assertEquals("v1", all.get(0).getVersionId());
+    assertEquals("v2", all.get(1).getVersionId());
+    assertEquals("v3", all.get(2).getVersionId());
+  }
+
+  @Test
+  void testEmptyResult() {
+    String key = "obj-1";
+    ListObjectVersionsResult emptyResult = mock(ListObjectVersionsResult.class);
+    when(emptyResult.versions()).thenReturn(List.of());
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(emptyResult).iterator());
+    when(mockOssClient.listObjectVersionsPaginator(
+        any(ListObjectVersionsRequest.class))).thenReturn(iterable);
+
+    Iterator<BlobMetadata> iterator =
+        new BlobMetadataIterator(mockOssClient, TEST_BUCKET, key);
+    assertFalse(iterator.hasNext());
+  }
+
+  private static ObjectVersion version(String key, String versionId, long size) {
+    ObjectVersion v = mock(ObjectVersion.class);
+    when(v.key()).thenReturn(key);
+    when(v.versionId()).thenReturn(versionId);
+    when(v.eTag()).thenReturn("etag-" + versionId);
+    when(v.size()).thenReturn(size);
+    when(v.lastModified()).thenReturn(Instant.now());
+    return v;
+  }
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-get-1.json
@@ -1,0 +1,49 @@
+{
+  "id" : "a8ab5481-cd09-4df9-b3df-7778b2c32be6",
+  "name" : "AliBlobStoreIT_testListBlobVersions_happy-GET-1",
+  "request" : {
+    "urlPath" : "/",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "versions" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      },
+      "prefix" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/exact-three-versions-blob"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListVersionsResult>\n  <Name>chameleon-multicloudj-test-versioned</Name>\n  <Prefix>conformance-tests%2Flist-object-versions%2Fexact-three-versions-blob</Prefix>\n  <KeyMarker></KeyMarker>\n  <VersionIdMarker></VersionIdMarker>\n  <MaxKeys>100</MaxKeys>\n  <Delimiter></Delimiter>\n  <EncodingType>url</EncodingType>\n  <IsTruncated>false</IsTruncated>\n  <Version>\n    <Key>conformance-tests%2Flist-object-versions%2Fexact-three-versions-blob</Key>\n    <VersionId>CAEQ6wYYiZflyrmH1fMZIiA3OGU0ZTQyNDNhYmE0NTMyYWM2ZjA2MDZhMzAzODI0ZA--</VersionId>\n    <IsLatest>true</IsLatest>\n    <LastModified>2026-05-29T19:43:53.000Z</LastModified>\n    <ETag>\"E05F0ABEBC0C2132019426823E3B1923\"</ETag>\n    <Type>Normal</Type>\n    <Size>19</Size>\n    <StorageClass>Standard</StorageClass>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </Version>\n  <Version>\n    <Key>conformance-tests%2Flist-object-versions%2Fexact-three-versions-blob</Key>\n    <VersionId>CAEQ6wYYnJjqtbaH1fMZIiBjNDQxODFlZGU0OGQ0YjIwODEzZDU5NWNjMjI2MzI4OA--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-05-29T19:43:52.000Z</LastModified>\n    <ETag>\"AB9782DD75210385218989F982BE54EB\"</ETag>\n    <Type>Normal</Type>\n    <Size>19</Size>\n    <StorageClass>Standard</StorageClass>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </Version>\n  <Version>\n    <Key>conformance-tests%2Flist-object-versions%2Fexact-three-versions-blob</Key>\n    <VersionId>CAEQ6wYYo8S6kLOH1fMZIiA5NjcyNzg0Yjc5ODk0OTNjODQyNzRhNTE4OWZmY2Y0NA--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-05-29T19:43:51.000Z</LastModified>\n    <ETag>\"D62C85C9A3B1CAC2ED2DF2B9811D2891\"</ETag>\n    <Type>Normal</Type>\n    <Size>19</Size>\n    <StorageClass>Standard</StorageClass>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </Version>\n</ListVersionsResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A19EC7DDCEE8233399C53C9",
+      "x-oss-server-time" : "16",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 29 May 2026 19:43:57 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "a8ab5481-cd09-4df9-b3df-7778b2c32be6",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-",
+  "requiredScenarioState" : "scenario-1--2",
+  "insertionIndex" : 770
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-get-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-get-2.json
@@ -1,0 +1,45 @@
+{
+  "id" : "eae4ffcf-5562-47c4-a3fb-a1e763124549",
+  "name" : "AliBlobStoreIT_testListBlobVersions_happy-GET-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/list-object-versions/exact-three-versions-blob",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQ6wYYo8S6kLOH1fMZIiA5NjcyNzg0Yjc5ODk0OTNjODQyNzRhNTE4OWZmY2Y0NA--"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "YXJjaGl2ZWQgY29udGVudCB2MQ==",
+    "headers" : {
+      "x-oss-version-id" : "CAEQ6wYYo8S6kLOH1fMZIiA5NjcyNzg0Yjc5ODk0OTNjODQyNzRhNTE4OWZmY2Y0NA--",
+      "x-oss-request-id" : "6A19EC7CB37E813632C10A78",
+      "x-oss-server-time" : "32",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Fri, 29 May 2026 19:43:51 GMT",
+      "Date" : "Fri, 29 May 2026 19:43:56 GMT",
+      "Content-MD5" : "1iyFyaOxysLtLfK5gR0okQ==",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "10724884600550701769",
+      "ETag" : "\"D62C85C9A3B1CAC2ED2DF2B9811D2891\"",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "eae4ffcf-5562-47c4-a3fb-a1e763124549",
+  "persistent" : true,
+  "insertionIndex" : 771
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-get-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-get-3.json
@@ -1,0 +1,45 @@
+{
+  "id" : "247c81e9-a21b-435f-ba87-2aea4d941c82",
+  "name" : "AliBlobStoreIT_testListBlobVersions_happy-GET-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/list-object-versions/exact-three-versions-blob",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQ6wYYnJjqtbaH1fMZIiBjNDQxODFlZGU0OGQ0YjIwODEzZDU5NWNjMjI2MzI4OA--"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "YXJjaGl2ZWQgY29udGVudCB2Mg==",
+    "headers" : {
+      "x-oss-version-id" : "CAEQ6wYYnJjqtbaH1fMZIiBjNDQxODFlZGU0OGQ0YjIwODEzZDU5NWNjMjI2MzI4OA--",
+      "x-oss-request-id" : "6A19EC7B4896753938CF5894",
+      "x-oss-server-time" : "22",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Fri, 29 May 2026 19:43:52 GMT",
+      "Date" : "Fri, 29 May 2026 19:43:55 GMT",
+      "Content-MD5" : "q5eC3XUhA4UhiYn5gr5U6w==",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "15239067681685915133",
+      "ETag" : "\"AB9782DD75210385218989F982BE54EB\"",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "247c81e9-a21b-435f-ba87-2aea4d941c82",
+  "persistent" : true,
+  "insertionIndex" : 772
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-get-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-get-4.json
@@ -1,0 +1,45 @@
+{
+  "id" : "fbdfd79d-4988-4adc-94fb-9aad9daae96a",
+  "name" : "AliBlobStoreIT_testListBlobVersions_happy-GET-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/list-object-versions/exact-three-versions-blob",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQ6wYYiZflyrmH1fMZIiA3OGU0ZTQyNDNhYmE0NTMyYWM2ZjA2MDZhMzAzODI0ZA--"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "YXJjaGl2ZWQgY29udGVudCB2Mw==",
+    "headers" : {
+      "x-oss-version-id" : "CAEQ6wYYiZflyrmH1fMZIiA3OGU0ZTQyNDNhYmE0NTMyYWM2ZjA2MDZhMzAzODI0ZA--",
+      "x-oss-request-id" : "6A19EC7AD8915334373FFB7E",
+      "x-oss-server-time" : "30",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Fri, 29 May 2026 19:43:53 GMT",
+      "Date" : "Fri, 29 May 2026 19:43:54 GMT",
+      "Content-MD5" : "4F8KvrwMITIBlCaCPjsZIw==",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "6940689067564669586",
+      "ETag" : "\"E05F0ABEBC0C2132019426823E3B1923\"",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "fbdfd79d-4988-4adc-94fb-9aad9daae96a",
+  "persistent" : true,
+  "insertionIndex" : 773
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-get-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-get-5.json
@@ -1,0 +1,50 @@
+{
+  "id" : "6edfc9cd-8f2a-4c93-8f5d-08c9937c6ee3",
+  "name" : "AliBlobStoreIT_testListBlobVersions_happy-GET-5",
+  "request" : {
+    "urlPath" : "/",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "versions" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      },
+      "prefix" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/exact-three-versions-blob"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListVersionsResult>\n  <Name>chameleon-multicloudj-test-versioned</Name>\n  <Prefix>conformance-tests%2Flist-object-versions%2Fexact-three-versions-blob</Prefix>\n  <KeyMarker></KeyMarker>\n  <VersionIdMarker></VersionIdMarker>\n  <MaxKeys>100</MaxKeys>\n  <Delimiter></Delimiter>\n  <EncodingType>url</EncodingType>\n  <IsTruncated>false</IsTruncated>\n  <Version>\n    <Key>conformance-tests%2Flist-object-versions%2Fexact-three-versions-blob</Key>\n    <VersionId>CAEQ6wYYiZflyrmH1fMZIiA3OGU0ZTQyNDNhYmE0NTMyYWM2ZjA2MDZhMzAzODI0ZA--</VersionId>\n    <IsLatest>true</IsLatest>\n    <LastModified>2026-05-29T19:43:53.000Z</LastModified>\n    <ETag>\"E05F0ABEBC0C2132019426823E3B1923\"</ETag>\n    <Type>Normal</Type>\n    <Size>19</Size>\n    <StorageClass>Standard</StorageClass>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </Version>\n  <Version>\n    <Key>conformance-tests%2Flist-object-versions%2Fexact-three-versions-blob</Key>\n    <VersionId>CAEQ6wYYnJjqtbaH1fMZIiBjNDQxODFlZGU0OGQ0YjIwODEzZDU5NWNjMjI2MzI4OA--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-05-29T19:43:52.000Z</LastModified>\n    <ETag>\"AB9782DD75210385218989F982BE54EB\"</ETag>\n    <Type>Normal</Type>\n    <Size>19</Size>\n    <StorageClass>Standard</StorageClass>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </Version>\n  <Version>\n    <Key>conformance-tests%2Flist-object-versions%2Fexact-three-versions-blob</Key>\n    <VersionId>CAEQ6wYYo8S6kLOH1fMZIiA5NjcyNzg0Yjc5ODk0OTNjODQyNzRhNTE4OWZmY2Y0NA--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-05-29T19:43:51.000Z</LastModified>\n    <ETag>\"D62C85C9A3B1CAC2ED2DF2B9811D2891\"</ETag>\n    <Type>Normal</Type>\n    <Size>19</Size>\n    <StorageClass>Standard</StorageClass>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </Version>\n</ListVersionsResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A19EC7A9E5E0B313242546D",
+      "x-oss-server-time" : "44",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 29 May 2026 19:43:54 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "6edfc9cd-8f2a-4c93-8f5d-08c9937c6ee3",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1--2",
+  "insertionIndex" : 774
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-post-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-post-0.json
@@ -1,0 +1,43 @@
+{
+  "id" : "ac145611-1664-4378-863f-2ce36828c925",
+  "name" : "AliBlobStoreIT_testListBlobVersions_happy-POST-0",
+  "request" : {
+    "urlPath" : "/",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "delete" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Delete><Quiet>true</Quiet><Object><Key>conformance-tests/list-object-versions/exact-three-versions-blob</Key><VersionId>CAEQ6wYYiZflyrmH1fMZIiA3OGU0ZTQyNDNhYmE0NTMyYWM2ZjA2MDZhMzAzODI0ZA--</VersionId></Object><Object><Key>conformance-tests/list-object-versions/exact-three-versions-blob</Key><VersionId>CAEQ6wYYnJjqtbaH1fMZIiBjNDQxODFlZGU0OGQ0YjIwODEzZDU5NWNjMjI2MzI4OA--</VersionId></Object><Object><Key>conformance-tests/list-object-versions/exact-three-versions-blob</Key><VersionId>CAEQ6wYYo8S6kLOH1fMZIiA5NjcyNzg0Yjc5ODk0OTNjODQyNzRhNTE4OWZmY2Y0NA--</VersionId></Object></Delete>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A19EC7EDA12F9393995097E",
+      "x-oss-server-time" : "58",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 29 May 2026 19:43:58 GMT"
+    }
+  },
+  "uuid" : "ac145611-1664-4378-863f-2ce36828c925",
+  "persistent" : true,
+  "insertionIndex" : 769
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-put-6.json
@@ -1,0 +1,32 @@
+{
+  "id" : "550db9e7-c077-4fa5-8e13-a1f543762308",
+  "name" : "AliBlobStoreIT_testListBlobVersions_happy-PUT-6",
+  "request" : {
+    "url" : "/conformance-tests/list-object-versions/exact-three-versions-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "YXJjaGl2ZWQgY29udGVudCB2Mw=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQ6wYYiZflyrmH1fMZIiA3OGU0ZTQyNDNhYmE0NTMyYWM2ZjA2MDZhMzAzODI0ZA--",
+      "x-oss-request-id" : "6A19EC79EFD97E303745DF22",
+      "x-oss-server-time" : "24",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "6940689067564669586",
+      "ETag" : "\"E05F0ABEBC0C2132019426823E3B1923\"",
+      "Date" : "Fri, 29 May 2026 19:43:53 GMT",
+      "Content-MD5" : "4F8KvrwMITIBlCaCPjsZIw=="
+    }
+  },
+  "uuid" : "550db9e7-c077-4fa5-8e13-a1f543762308",
+  "persistent" : true,
+  "insertionIndex" : 775
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-put-7.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-put-7.json
@@ -1,0 +1,32 @@
+{
+  "id" : "c9be442c-c06e-463d-baec-3878aada4fb6",
+  "name" : "AliBlobStoreIT_testListBlobVersions_happy-PUT-7",
+  "request" : {
+    "url" : "/conformance-tests/list-object-versions/exact-three-versions-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "YXJjaGl2ZWQgY29udGVudCB2Mg=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQ6wYYnJjqtbaH1fMZIiBjNDQxODFlZGU0OGQ0YjIwODEzZDU5NWNjMjI2MzI4OA--",
+      "x-oss-request-id" : "6A19EC780710A83838E7032C",
+      "x-oss-server-time" : "35",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "15239067681685915133",
+      "ETag" : "\"AB9782DD75210385218989F982BE54EB\"",
+      "Date" : "Fri, 29 May 2026 19:43:52 GMT",
+      "Content-MD5" : "q5eC3XUhA4UhiYn5gr5U6w=="
+    }
+  },
+  "uuid" : "c9be442c-c06e-463d-baec-3878aada4fb6",
+  "persistent" : true,
+  "insertionIndex" : 776
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-put-8.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testlistblobversions_happy-put-8.json
@@ -1,0 +1,32 @@
+{
+  "id" : "63ce0285-a5a6-4605-abb3-a3673b12c493",
+  "name" : "AliBlobStoreIT_testListBlobVersions_happy-PUT-8",
+  "request" : {
+    "url" : "/conformance-tests/list-object-versions/exact-three-versions-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "YXJjaGl2ZWQgY29udGVudCB2MQ=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQ6wYYo8S6kLOH1fMZIiA5NjcyNzg0Yjc5ODk0OTNjODQyNzRhNTE4OWZmY2Y0NA--",
+      "x-oss-request-id" : "6A19EC77F5C7C43032AFBA69",
+      "x-oss-server-time" : "51",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "10724884600550701769",
+      "ETag" : "\"D62C85C9A3B1CAC2ED2DF2B9811D2891\"",
+      "Date" : "Fri, 29 May 2026 19:43:51 GMT",
+      "Content-MD5" : "1iyFyaOxysLtLfK5gR0okQ=="
+    }
+  },
+  "uuid" : "63ce0285-a5a6-4605-abb3-a3673b12c493",
+  "persistent" : true,
+  "insertionIndex" : 777
+}

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -5393,7 +5393,6 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testListBlobVersions_happy() throws IOException {
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
     BucketClient bucketClient = new BucketClient(blobStore);
     String key = "conformance-tests/list-object-versions/exact-three-versions-blob";
@@ -5461,7 +5460,6 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testListBlobVersions_nullKey() {
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
     BucketClient bucketClient = new BucketClient(blobStore);
 


### PR DESCRIPTION
## Summary

Implement the listBlobVersions API for Ali. Removed the Ali filter in the conformance test to enable the scenarios and included the replay files.

Original AWS/GCP PR: https://github.com/salesforce/multicloudj/pull/418

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
