### PR TITLE
blobstore: implement async list/listPage operation for Ali OSS

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -6,7 +6,6 @@ import com.aliyun.sdk.service.oss2.PresignOptions;
 import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
 import com.aliyun.sdk.service.oss2.exceptions.OperationException;
 import com.aliyun.sdk.service.oss2.exceptions.ServiceException;
-import com.aliyun.sdk.service.oss2.models.CommonPrefix;
 import com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest;
 import com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult;
 import com.aliyun.sdk.service.oss2.models.CopyObjectRequest;
@@ -75,7 +74,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.Getter;
 
 /** Alibaba implementation of BlobStore */
@@ -465,27 +463,7 @@ public class AliBlobStore extends AbstractBlobStore {
     ListObjectsV2Result response =
         ossClient.listObjectsV2(listRequest,
             OperationOptions.defaults());
-
-    List<BlobInfo> blobs =
-        response.contents().stream()
-            .map(
-                objSum ->
-                    new BlobInfo.Builder()
-                        .withKey(objSum.key())
-                        .withObjectSize(objSum.size() != null ? objSum.size() : 0L)
-                        .build())
-            .collect(Collectors.toList());
-
-    List<String> commonPrefixes = response.commonPrefixes() != null
-        ? response.commonPrefixes().stream()
-            .map(CommonPrefix::prefix)
-            .collect(Collectors.toList())
-        : List.of();
-
-    return new ListBlobsPageResponse(
-        blobs, commonPrefixes,
-        Boolean.TRUE.equals(response.isTruncated()),
-        response.nextContinuationToken());
+    return transformer.toListBlobsPageResponse(response);
   }
 
   @Override

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -2,6 +2,7 @@ package com.salesforce.multicloudj.blob.ali;
 
 import com.aliyun.sdk.service.oss2.PresignOptions;
 import com.aliyun.sdk.service.oss2.models.AbortMultipartUploadRequest;
+import com.aliyun.sdk.service.oss2.models.CommonPrefix;
 import com.aliyun.sdk.service.oss2.models.CompleteMultipartUpload;
 import com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest;
 import com.aliyun.sdk.service.oss2.models.CopyObjectRequest;
@@ -18,6 +19,7 @@ import com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult;
 import com.aliyun.sdk.service.oss2.models.ListObjectsV2Request;
+import com.aliyun.sdk.service.oss2.models.ListObjectsV2Result;
 import com.aliyun.sdk.service.oss2.models.ListPartsRequest;
 import com.aliyun.sdk.service.oss2.models.ListPartsResult;
 import com.aliyun.sdk.service.oss2.models.ObjectIdentifier;
@@ -32,6 +34,7 @@ import com.aliyun.sdk.service.oss2.models.UploadPartRequest;
 import com.aliyun.sdk.service.oss2.models.UploadPartResult;
 import com.aliyun.sdk.service.oss2.transport.BinaryData;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
+import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.ChecksumMethod;
 import com.salesforce.multicloudj.blob.driver.CopyFromRequest;
@@ -39,7 +42,9 @@ import com.salesforce.multicloudj.blob.driver.CopyRequest;
 import com.salesforce.multicloudj.blob.driver.CopyResponse;
 import com.salesforce.multicloudj.blob.driver.DownloadRequest;
 import com.salesforce.multicloudj.blob.driver.DownloadResponse;
+import com.salesforce.multicloudj.blob.driver.ListBlobsBatch;
 import com.salesforce.multicloudj.blob.driver.ListBlobsPageRequest;
+import com.salesforce.multicloudj.blob.driver.ListBlobsPageResponse;
 import com.salesforce.multicloudj.blob.driver.ListBlobsRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartPart;
 import com.salesforce.multicloudj.blob.driver.MultipartUpload;
@@ -565,5 +570,30 @@ public class AliTransformer {
     }
 
     return builder.build();
+  }
+
+  public ListBlobsPageResponse toListBlobsPageResponse(ListObjectsV2Result result) {
+    ListBlobsBatch batch = toListBlobsBatch(result);
+    return new ListBlobsPageResponse(
+        batch.getBlobs(), batch.getCommonPrefixes(),
+        Boolean.TRUE.equals(result.isTruncated()),
+        result.nextContinuationToken());
+  }
+
+  public ListBlobsBatch toListBlobsBatch(ListObjectsV2Result result) {
+    List<BlobInfo> blobs = result.contents().stream()
+        .map(obj -> new BlobInfo.Builder()
+            .withKey(obj.key())
+            .withObjectSize(obj.size() != null ? obj.size() : 0L)
+            .build())
+        .collect(Collectors.toList());
+
+    List<String> commonPrefixes = result.commonPrefixes() != null
+        ? result.commonPrefixes().stream()
+            .map(CommonPrefix::prefix)
+            .collect(Collectors.toList())
+        : List.of();
+
+    return new ListBlobsBatch(blobs, commonPrefixes);
   }
 }

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -4,6 +4,7 @@ import com.aliyun.sdk.service.oss2.OSSAsyncClient;
 import com.aliyun.sdk.service.oss2.OSSClient;
 import com.aliyun.sdk.service.oss2.OperationOptions;
 import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
+import com.aliyun.sdk.service.oss2.models.CommonPrefix;
 import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
 import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest;
@@ -11,6 +12,8 @@ import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectResult;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
 import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
+import com.aliyun.sdk.service.oss2.models.ListObjectsV2Request;
+import com.aliyun.sdk.service.oss2.models.ListObjectsV2Result;
 import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
 import com.aliyun.sdk.service.oss2.transfermanager.DownloadError;
 import com.aliyun.sdk.service.oss2.transfermanager.Downloader;
@@ -23,6 +26,7 @@ import com.salesforce.multicloudj.blob.async.driver.AbstractAsyncBlobStore;
 import com.salesforce.multicloudj.blob.async.driver.AsyncBlobStore;
 import com.salesforce.multicloudj.blob.async.driver.AsyncBlobStoreProvider;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
+import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.BlobStoreValidator;
 import com.salesforce.multicloudj.blob.driver.ByteArray;
@@ -64,6 +68,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import lombok.Getter;
 
 /** Alibaba Cloud OSS native async implementation of AsyncBlobStore. */
@@ -333,13 +338,69 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
   @Override
   protected CompletableFuture<Void> doList(
       ListBlobsRequest request, Consumer<ListBlobsBatch> consumer) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return doListRecursive(request, null, consumer);
+  }
+
+  private CompletableFuture<Void> doListRecursive(
+      ListBlobsRequest request, String continuationToken,
+      Consumer<ListBlobsBatch> consumer) {
+    ListObjectsV2Request listRequest =
+        transformer.toListObjectsRequest(request, continuationToken);
+    return asyncClient
+        .listObjectsV2Async(listRequest, OperationOptions.defaults())
+        .thenCompose(result -> {
+          consumer.accept(toBatch(result));
+          if (Boolean.TRUE.equals(result.isTruncated())) {
+            return doListRecursive(
+                request, result.nextContinuationToken(), consumer);
+          }
+          return CompletableFuture.completedFuture(null);
+        });
   }
 
   @Override
   protected CompletableFuture<ListBlobsPageResponse> doListPage(
       ListBlobsPageRequest request) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    ListObjectsV2Request listRequest =
+        transformer.toListObjectsRequest(request);
+    return asyncClient
+        .listObjectsV2Async(listRequest, OperationOptions.defaults())
+        .thenApply(result -> {
+          List<BlobInfo> blobs = result.contents().stream()
+              .map(obj -> new BlobInfo.Builder()
+                  .withKey(obj.key())
+                  .withObjectSize(obj.size() != null ? obj.size() : 0L)
+                  .build())
+              .collect(Collectors.toList());
+
+          List<String> commonPrefixes = result.commonPrefixes() != null
+              ? result.commonPrefixes().stream()
+                  .map(CommonPrefix::prefix)
+                  .collect(Collectors.toList())
+              : List.of();
+
+          return new ListBlobsPageResponse(
+              blobs, commonPrefixes,
+              Boolean.TRUE.equals(result.isTruncated()),
+              result.nextContinuationToken());
+        });
+  }
+
+  private ListBlobsBatch toBatch(ListObjectsV2Result result) {
+    List<BlobInfo> blobs = result.contents().stream()
+        .map(obj -> new BlobInfo.Builder()
+            .withKey(obj.key())
+            .withObjectSize(obj.size() != null ? obj.size() : 0L)
+            .build())
+        .collect(Collectors.toList());
+
+    List<String> commonPrefixes = result.commonPrefixes() != null
+        ? result.commonPrefixes().stream()
+            .map(CommonPrefix::prefix)
+            .collect(Collectors.toList())
+        : List.of();
+
+    return new ListBlobsBatch(blobs, commonPrefixes);
   }
 
   @Override

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -4,7 +4,6 @@ import com.aliyun.sdk.service.oss2.OSSAsyncClient;
 import com.aliyun.sdk.service.oss2.OSSClient;
 import com.aliyun.sdk.service.oss2.OperationOptions;
 import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
-import com.aliyun.sdk.service.oss2.models.CommonPrefix;
 import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
 import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest;
@@ -13,7 +12,6 @@ import com.aliyun.sdk.service.oss2.models.GetObjectResult;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
 import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
 import com.aliyun.sdk.service.oss2.models.ListObjectsV2Request;
-import com.aliyun.sdk.service.oss2.models.ListObjectsV2Result;
 import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
 import com.aliyun.sdk.service.oss2.transfermanager.DownloadError;
 import com.aliyun.sdk.service.oss2.transfermanager.Downloader;
@@ -26,7 +24,6 @@ import com.salesforce.multicloudj.blob.async.driver.AbstractAsyncBlobStore;
 import com.salesforce.multicloudj.blob.async.driver.AsyncBlobStore;
 import com.salesforce.multicloudj.blob.async.driver.AsyncBlobStoreProvider;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
-import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.BlobStoreValidator;
 import com.salesforce.multicloudj.blob.driver.ByteArray;
@@ -68,7 +65,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import lombok.Getter;
 
 /** Alibaba Cloud OSS native async implementation of AsyncBlobStore. */
@@ -341,6 +337,13 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
     return doListRecursive(request, null, consumer);
   }
 
+  /**
+   * Recursively fetches all pages of object listings by manually chaining continuation tokens.
+   * Unlike the sync OSSClient which provides a built-in {@code listObjectsV2Paginator()}, the
+   * async OSSAsyncClient only offers single-page {@code listObjectsV2Async()} with no async
+   * paginator or Publisher-style API. This method fills that gap by composing futures recursively
+   * until all pages are consumed.
+   */
   private CompletableFuture<Void> doListRecursive(
       ListBlobsRequest request, String continuationToken,
       Consumer<ListBlobsBatch> consumer) {
@@ -349,8 +352,9 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
     return asyncClient
         .listObjectsV2Async(listRequest, OperationOptions.defaults())
         .thenCompose(result -> {
-          consumer.accept(toBatch(result));
-          if (Boolean.TRUE.equals(result.isTruncated())) {
+          consumer.accept(transformer.toListBlobsBatch(result));
+          if (Boolean.TRUE.equals(result.isTruncated())
+              && result.nextContinuationToken() != null) {
             return doListRecursive(
                 request, result.nextContinuationToken(), consumer);
           }
@@ -365,43 +369,9 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
         transformer.toListObjectsRequest(request);
     return asyncClient
         .listObjectsV2Async(listRequest, OperationOptions.defaults())
-        .thenApply(result -> {
-          List<BlobInfo> blobs = result.contents().stream()
-              .map(obj -> new BlobInfo.Builder()
-                  .withKey(obj.key())
-                  .withObjectSize(obj.size() != null ? obj.size() : 0L)
-                  .build())
-              .collect(Collectors.toList());
-
-          List<String> commonPrefixes = result.commonPrefixes() != null
-              ? result.commonPrefixes().stream()
-                  .map(CommonPrefix::prefix)
-                  .collect(Collectors.toList())
-              : List.of();
-
-          return new ListBlobsPageResponse(
-              blobs, commonPrefixes,
-              Boolean.TRUE.equals(result.isTruncated()),
-              result.nextContinuationToken());
-        });
+        .thenApply(transformer::toListBlobsPageResponse);
   }
 
-  private ListBlobsBatch toBatch(ListObjectsV2Result result) {
-    List<BlobInfo> blobs = result.contents().stream()
-        .map(obj -> new BlobInfo.Builder()
-            .withKey(obj.key())
-            .withObjectSize(obj.size() != null ? obj.size() : 0L)
-            .build())
-        .collect(Collectors.toList());
-
-    List<String> commonPrefixes = result.commonPrefixes() != null
-        ? result.commonPrefixes().stream()
-            .map(CommonPrefix::prefix)
-            .collect(Collectors.toList())
-        : List.of();
-
-    return new ListBlobsBatch(blobs, commonPrefixes);
-  }
 
   @Override
   protected CompletableFuture<MultipartUpload> doInitiateMultipartUpload(

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -63,6 +63,7 @@ import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 
 public class AliAsyncBlobStoreTest {
 
@@ -595,6 +596,14 @@ public class AliAsyncBlobStoreTest {
     assertEquals(true, response.isTruncated());
     assertEquals("token-abc", response.getNextPageToken());
     assertEquals(1, response.getBlobs().size());
+
+    ArgumentCaptor<ListObjectsV2Request> captor =
+        ArgumentCaptor.forClass(ListObjectsV2Request.class);
+    verify(mockAsyncClient).listObjectsV2Async(
+        captor.capture(), any(OperationOptions.class));
+    ListObjectsV2Request captured = captor.getValue();
+    assertEquals("prefix/", captured.prefix());
+    assertEquals(1L, captured.maxKeys());
   }
 
   @Test

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -633,4 +633,37 @@ public class AliAsyncBlobStoreTest {
     assertEquals("a/1.txt", batches.get(0).getBlobs().get(0).getKey());
     assertEquals("a/2.txt", batches.get(1).getBlobs().get(0).getKey());
   }
+
+  @Test
+  void testListPageFailed() {
+    RuntimeException cause = new RuntimeException("access denied");
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    ListBlobsPageRequest request = ListBlobsPageRequest.builder()
+        .withPrefix("prefix/")
+        .build();
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.listPage(request).get());
+    assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testListFailed() {
+    RuntimeException cause = new RuntimeException("service unavailable");
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    List<ListBlobsBatch> batches = new ArrayList<>();
+    ListBlobsRequest request = ListBlobsRequest.builder()
+        .withPrefix("a/")
+        .build();
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.list(request, batches::add).get());
+    assertNotNull(ex.getCause());
+  }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import com.aliyun.sdk.service.oss2.OSSAsyncClient;
 import com.aliyun.sdk.service.oss2.OSSClient;
 import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.models.CommonPrefix;
 import com.aliyun.sdk.service.oss2.models.CopyObjectRequest;
 import com.aliyun.sdk.service.oss2.models.CopyObjectResult;
 import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
@@ -26,6 +27,9 @@ import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectResult;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
 import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
+import com.aliyun.sdk.service.oss2.models.ListObjectsV2Request;
+import com.aliyun.sdk.service.oss2.models.ListObjectsV2Result;
+import com.aliyun.sdk.service.oss2.models.ObjectSummary;
 import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
 import com.aliyun.sdk.service.oss2.models.PutObjectResult;
 import com.aliyun.sdk.service.oss2.transfermanager.DownloadError;
@@ -33,12 +37,17 @@ import com.aliyun.sdk.service.oss2.transfermanager.DownloadResult;
 import com.aliyun.sdk.service.oss2.transfermanager.Downloader;
 import com.salesforce.multicloudj.blob.ali.AliTransformerSupplier;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
+import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.BlobStoreValidator;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
 import com.salesforce.multicloudj.blob.driver.CopyResponse;
 import com.salesforce.multicloudj.blob.driver.DownloadRequest;
 import com.salesforce.multicloudj.blob.driver.DownloadResponse;
+import com.salesforce.multicloudj.blob.driver.ListBlobsBatch;
+import com.salesforce.multicloudj.blob.driver.ListBlobsPageRequest;
+import com.salesforce.multicloudj.blob.driver.ListBlobsPageResponse;
+import com.salesforce.multicloudj.blob.driver.ListBlobsRequest;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import java.io.ByteArrayInputStream;
@@ -46,6 +55,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -523,5 +533,104 @@ public class AliAsyncBlobStoreTest {
     ExecutionException ex = assertThrows(ExecutionException.class,
         () -> store.doesBucketExist().get());
     assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testListPage() throws Exception {
+    ObjectSummary obj1 = mock(ObjectSummary.class);
+    when(obj1.key()).thenReturn("prefix/file1.txt");
+    when(obj1.size()).thenReturn(100L);
+    ObjectSummary obj2 = mock(ObjectSummary.class);
+    when(obj2.key()).thenReturn("prefix/file2.txt");
+    when(obj2.size()).thenReturn(200L);
+
+    CommonPrefix cp = mock(CommonPrefix.class);
+    when(cp.prefix()).thenReturn("prefix/subdir/");
+
+    ListObjectsV2Result mockResult = mock(ListObjectsV2Result.class);
+    when(mockResult.contents()).thenReturn(List.of(obj1, obj2));
+    when(mockResult.commonPrefixes()).thenReturn(List.of(cp));
+    when(mockResult.isTruncated()).thenReturn(false);
+    when(mockResult.nextContinuationToken()).thenReturn(null);
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    ListBlobsPageRequest request = ListBlobsPageRequest.builder()
+        .withPrefix("prefix/")
+        .build();
+    ListBlobsPageResponse response = store.listPage(request).get();
+
+    assertNotNull(response);
+    assertEquals(2, response.getBlobs().size());
+    assertEquals("prefix/file1.txt", response.getBlobs().get(0).getKey());
+    assertEquals(100L, response.getBlobs().get(0).getObjectSize());
+    assertEquals("prefix/file2.txt", response.getBlobs().get(1).getKey());
+    assertEquals(1, response.getCommonPrefixes().size());
+    assertEquals("prefix/subdir/", response.getCommonPrefixes().get(0));
+    assertEquals(false, response.isTruncated());
+  }
+
+  @Test
+  void testListPageTruncated() throws Exception {
+    ObjectSummary obj = mock(ObjectSummary.class);
+    when(obj.key()).thenReturn("key1");
+    when(obj.size()).thenReturn(50L);
+
+    ListObjectsV2Result mockResult = mock(ListObjectsV2Result.class);
+    when(mockResult.contents()).thenReturn(List.of(obj));
+    when(mockResult.commonPrefixes()).thenReturn(null);
+    when(mockResult.isTruncated()).thenReturn(true);
+    when(mockResult.nextContinuationToken()).thenReturn("token-abc");
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    ListBlobsPageRequest request = ListBlobsPageRequest.builder()
+        .withPrefix("prefix/")
+        .withMaxResults(1)
+        .build();
+    ListBlobsPageResponse response = store.listPage(request).get();
+
+    assertEquals(true, response.isTruncated());
+    assertEquals("token-abc", response.getNextPageToken());
+    assertEquals(1, response.getBlobs().size());
+  }
+
+  @Test
+  void testList() throws Exception {
+    ObjectSummary obj1 = mock(ObjectSummary.class);
+    when(obj1.key()).thenReturn("a/1.txt");
+    when(obj1.size()).thenReturn(10L);
+    ObjectSummary obj2 = mock(ObjectSummary.class);
+    when(obj2.key()).thenReturn("a/2.txt");
+    when(obj2.size()).thenReturn(20L);
+
+    ListObjectsV2Result page1 = mock(ListObjectsV2Result.class);
+    when(page1.contents()).thenReturn(List.of(obj1));
+    when(page1.commonPrefixes()).thenReturn(null);
+    when(page1.isTruncated()).thenReturn(true);
+    when(page1.nextContinuationToken()).thenReturn("token-2");
+
+    ListObjectsV2Result page2 = mock(ListObjectsV2Result.class);
+    when(page2.contents()).thenReturn(List.of(obj2));
+    when(page2.commonPrefixes()).thenReturn(null);
+    when(page2.isTruncated()).thenReturn(false);
+    when(page2.nextContinuationToken()).thenReturn(null);
+
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(page1))
+        .thenReturn(CompletableFuture.completedFuture(page2));
+
+    List<ListBlobsBatch> batches = new ArrayList<>();
+    ListBlobsRequest request = ListBlobsRequest.builder()
+        .withPrefix("a/")
+        .build();
+    store.list(request, batches::add).get();
+
+    assertEquals(2, batches.size());
+    assertEquals("a/1.txt", batches.get(0).getBlobs().get(0).getKey());
+    assertEquals("a/2.txt", batches.get(1).getBlobs().get(0).getKey());
   }
 }


### PR DESCRIPTION
## Summary

Add async list and listPage operation support for Ali.

Includes unit tests with mocked SDK client. Performed manual integration testing against live Ali environment to verify functionality.

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
