### PR TITLE
test: align sync blob benchmarks with existing patterns

### DIFF
--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobBenchmarkTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobBenchmarkTest.java
@@ -2,18 +2,10 @@ package com.salesforce.multicloudj.blob.aws;
 
 import com.salesforce.multicloudj.blob.client.AbstractBlobBenchmarkTest;
 import com.salesforce.multicloudj.blob.driver.AbstractBlobStore;
-import java.net.URI;
 import org.junit.jupiter.api.TestInstance;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3Configuration;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AwsBlobBenchmarkTest extends AbstractBlobBenchmarkTest {
-
-  private static final Logger logger = LoggerFactory.getLogger(AwsBlobBenchmarkTest.class);
 
   @Override
   protected String getProviderId() {
@@ -26,60 +18,14 @@ public class AwsBlobBenchmarkTest extends AbstractBlobBenchmarkTest {
   }
 
   public static class HarnessImpl implements Harness {
-    S3Client client;
+    AwsBlobStore blobStore;
 
     @Override
     public AbstractBlobStore createBlobStore() {
       String region = requireEnv("BLOB_BENCHMARK_AWS_REGION");
       String bucket = requireEnv("BLOB_BENCHMARK_AWS_BUCKET");
-      String endpoint = "https://s3." + region + ".amazonaws.com";
-
-      logger.info(
-          "Creating AWS blob store with endpoint: {}, bucket: {}, region: {}",
-          endpoint, bucket, region);
-
-      try {
-        URI endpointUri = URI.create(endpoint);
-
-        client =
-            S3Client.builder()
-                .region(Region.of(region))
-                .endpointOverride(endpointUri)
-                .serviceConfiguration(
-                    S3Configuration.builder().pathStyleAccessEnabled(true).build())
-                .build();
-
-        logger.info("Successfully created S3 client");
-
-        AwsBlobStore.Builder builder = new AwsBlobStore.Builder();
-        builder
-            .withS3Client(client)
-            .withEndpoint(endpointUri)
-            .withBucket(bucket)
-            .withRegion(region);
-
-        AbstractBlobStore blobStore = builder.build();
-        logger.info("Successfully created AWS blob store");
-        return blobStore;
-
-      } catch (Exception e) {
-        logger.error("Failed to create AWS blob store", e);
-
-        if (client != null) {
-          try {
-            client.close();
-          } catch (Exception cleanupException) {
-            logger.warn("Failed to cleanup S3 client after failure", cleanupException);
-          }
-          client = null;
-        }
-
-        if (e instanceof RuntimeException) {
-          throw (RuntimeException) e;
-        } else {
-          throw new RuntimeException("Failed to create AWS blob store", e);
-        }
-      }
+      blobStore = new AwsBlobStore.Builder().withBucket(bucket).withRegion(region).build();
+      return blobStore;
     }
 
     @Override
@@ -88,9 +34,9 @@ public class AwsBlobBenchmarkTest extends AbstractBlobBenchmarkTest {
     }
 
     @Override
-    public void close() throws Exception {
-      if (client != null) {
-        client.close();
+    public void close() {
+      if (blobStore != null) {
+        blobStore.close();
       }
     }
   }

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobBenchmarkTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobBenchmarkTest.java
@@ -3,7 +3,6 @@ package com.salesforce.multicloudj.blob.aws;
 import com.salesforce.multicloudj.blob.client.AbstractBlobBenchmarkTest;
 import com.salesforce.multicloudj.blob.driver.AbstractBlobStore;
 import java.net.URI;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,17 +10,15 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 
-@Disabled
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AwsBlobBenchmarkTest extends AbstractBlobBenchmarkTest {
 
   private static final Logger logger = LoggerFactory.getLogger(AwsBlobBenchmarkTest.class);
-  private static final String region =
-      System.getProperty("aws.benchmark.region", "us-west-2");
-  private static final String endpoint =
-      System.getProperty("aws.benchmark.endpoint", "https://s3." + region + ".amazonaws.com");
-  private static final String bucketName =
-      System.getProperty("aws.benchmark.bucket", "multicloudj-sync-client-benchmark");
+
+  @Override
+  protected String getProviderId() {
+    return "aws";
+  }
 
   @Override
   protected Harness createHarness() {
@@ -33,15 +30,16 @@ public class AwsBlobBenchmarkTest extends AbstractBlobBenchmarkTest {
 
     @Override
     public AbstractBlobStore createBlobStore() {
+      String region = requireEnv("BLOB_BENCHMARK_AWS_REGION");
+      String bucket = requireEnv("BLOB_BENCHMARK_AWS_BUCKET");
+      String endpoint = "https://s3." + region + ".amazonaws.com";
+
       logger.info(
           "Creating AWS blob store with endpoint: {}, bucket: {}, region: {}",
-          endpoint,
-          bucketName,
-          region);
+          endpoint, bucket, region);
 
       try {
         URI endpointUri = URI.create(endpoint);
-        logger.debug("Building S3 client with region: {}", region);
 
         client =
             S3Client.builder()
@@ -53,17 +51,15 @@ public class AwsBlobBenchmarkTest extends AbstractBlobBenchmarkTest {
 
         logger.info("Successfully created S3 client");
 
-        logger.debug("Building AwsBlobStore with bucket: {}", bucketName);
         AwsBlobStore.Builder builder = new AwsBlobStore.Builder();
         builder
             .withS3Client(client)
             .withEndpoint(endpointUri)
-            .withBucket(bucketName)
+            .withBucket(bucket)
             .withRegion(region);
 
         AbstractBlobStore blobStore = builder.build();
         logger.info("Successfully created AWS blob store");
-
         return blobStore;
 
       } catch (Exception e) {
@@ -72,10 +68,8 @@ public class AwsBlobBenchmarkTest extends AbstractBlobBenchmarkTest {
         if (client != null) {
           try {
             client.close();
-            logger.debug("Cleaned up S3 client after failure");
           } catch (Exception cleanupException) {
-            logger.warn(
-                "Failed to cleanup S3 client after blob store creation failure", cleanupException);
+            logger.warn("Failed to cleanup S3 client after failure", cleanupException);
           }
           client = null;
         }
@@ -90,7 +84,7 @@ public class AwsBlobBenchmarkTest extends AbstractBlobBenchmarkTest {
 
     @Override
     public String getBucketName() {
-      return bucketName;
+      return requireEnv("BLOB_BENCHMARK_AWS_BUCKET");
     }
 
     @Override

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobBenchmarkTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobBenchmarkTest.java
@@ -63,6 +63,10 @@ import org.slf4j.LoggerFactory;
  * <p>Each benchmark method performs exactly one logical operation per invocation so that JMH
  * reports true per-op latency and throughput. Pre-seeded data is used for read-path benchmarks
  * to avoid conflating write cost into read measurements.
+ *
+ * <p>{@link #cleanupBenchmarkData()} runs at both {@code @Setup} and {@code @TearDown} on
+ * purpose, to clear residue from interrupted prior runs. Blob content uses a fixed seed
+ * ({@code new Random(42)}) for reproducibility, which may flatter dedup/compression vs. real data.
  */
 @BenchmarkMode({Mode.Throughput, Mode.SampleTime})
 @OutputTimeUnit(TimeUnit.SECONDS)

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobBenchmarkTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobBenchmarkTest.java
@@ -6,7 +6,6 @@ import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
 import com.salesforce.multicloudj.blob.driver.CopyResponse;
 import com.salesforce.multicloudj.blob.driver.DownloadRequest;
-import com.salesforce.multicloudj.blob.driver.DownloadResponse;
 import com.salesforce.multicloudj.blob.driver.ListBlobsPageRequest;
 import com.salesforce.multicloudj.blob.driver.ListBlobsPageResponse;
 import com.salesforce.multicloudj.blob.driver.ListBlobsRequest;
@@ -24,15 +23,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.UUID;
+import java.util.Random;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.Disabled;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -52,10 +51,20 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/** Abstract JMH benchmark class for Blob operations */
-@Disabled
-@BenchmarkMode({Mode.Throughput, Mode.AverageTime})
+/**
+ * JMH benchmarks for sync blob operations via {@link BucketClient}.
+ *
+ * <p>Covers single-object upload/download (small/medium/large), write-read-delete lifecycle,
+ * multipart upload, metadata, list, listPage, and copy.
+ *
+ * <p>Each benchmark method performs exactly one logical operation per invocation so that JMH
+ * reports true per-op latency and throughput. Pre-seeded data is used for read-path benchmarks
+ * to avoid conflating write cost into read measurements.
+ */
+@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
@@ -64,29 +73,66 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractBlobBenchmarkTest {
 
-  // Blob size constants
+  private static final Logger logger = LoggerFactory.getLogger(AbstractBlobBenchmarkTest.class);
+
   protected static final int SMALL_BLOB = 1024; // 1KB
   protected static final int MEDIUM_BLOB = 1024 * 1024; // 1MB
   protected static final int LARGE_BLOB = 10 * 1024 * 1024; // 10MB
-  protected static final int PART_SIZE = 5 * 1024 * 1024;
+  protected static final int PART_SIZE = 5 * 1024 * 1024; // 5MB per MPU part
+  protected static final int LIST_PAGE_MAX_RESULTS = 20;
 
-  // Test data
+  protected static final String DOWNLOAD_BLOBS_PREFIX = "bench-download/";
+  protected static final String SMALL_BLOBS_PREFIX = DOWNLOAD_BLOBS_PREFIX + "small/";
+  protected static final String MEDIUM_BLOBS_PREFIX = DOWNLOAD_BLOBS_PREFIX + "medium/";
+  protected static final String LARGE_BLOBS_PREFIX = DOWNLOAD_BLOBS_PREFIX + "large/";
+
+  protected static final String UPLOAD_SMALL_PREFIX = "bench-upload-small/";
+  protected static final String UPLOAD_MEDIUM_PREFIX = "bench-upload-medium/";
+  protected static final String UPLOAD_LARGE_PREFIX = "bench-upload-large/";
+  protected static final String WRITE_READ_DELETE_PREFIX = "bench-write-read-delete/";
+  protected static final String MULTIPART_PREFIX = "bench-multipart/";
+  protected static final String COPY_DEST_PREFIX = "bench-copy-dest/";
+
+  private static final int SMALL_COUNT = 100;
+  private static final int MEDIUM_COUNT = 20;
+  private static final int LARGE_COUNT = 5;
+
   protected String bucketName;
-  protected List<String> blobKeys;
-  protected List<byte[]> testBlobs;
   protected BucketClient bucketClient;
 
-  private final AtomicInteger nextPutId = new AtomicInteger(0);
-  private final AtomicInteger nextGetId = new AtomicInteger(0);
-  private final AtomicInteger nextBatchPutId = new AtomicInteger(0);
-  private final AtomicInteger nextBatchGetId = new AtomicInteger(0);
+  private byte[] smallBlob;
+  private byte[] mediumBlob;
+  private byte[] largeBlob;
+  private List<String> smallKeys;
+  private List<String> mediumKeys;
+  private List<String> largeKeys;
+  private String copySourceKey;
+
+  private final AtomicInteger nextUploadSmallId = new AtomicInteger(0);
+  private final AtomicInteger nextUploadMediumId = new AtomicInteger(0);
+  private final AtomicInteger nextUploadLargeId = new AtomicInteger(0);
   private final AtomicInteger nextWriteReadDeleteId = new AtomicInteger(0);
   private final AtomicInteger nextMultipartUploadId = new AtomicInteger(0);
-  // Grows by one entry per copy invocation; pruned only at trial end. The memory overhead
-  // is negligible (a few KB) relative to the seconds-scale network IO being measured.
+  private final AtomicInteger nextCopyId = new AtomicInteger(0);
+
   private final ConcurrentLinkedQueue<String> copyDestKeys = new ConcurrentLinkedQueue<>();
 
-  // Harness interface
+  /**
+   * Reads a required config value from OS environment first, then from -D system properties.
+   * Fails fast with a clear error if neither is set — avoids silent misconfiguration producing
+   * garbage benchmark results.
+   */
+  protected static String requireEnv(String name) {
+    String value = System.getenv(name);
+    if (StringUtils.isBlank(value)) {
+      value = System.getProperty(name);
+    }
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalStateException("Required environment variable not set: " + name);
+    }
+    return value;
+  }
+
   public interface Harness extends AutoCloseable {
     AbstractBlobStore createBlobStore();
 
@@ -95,21 +141,21 @@ public abstract class AbstractBlobBenchmarkTest {
 
   protected abstract Harness createHarness();
 
+  protected abstract String getProviderId();
+
   private Harness harness;
 
   @Setup(Level.Trial)
   public void setupBenchmark() {
+    logger.info("Creating {} sync blob store", getProviderId());
     try {
       harness = createHarness();
-
       bucketName = harness.getBucketName();
-      blobKeys = new ArrayList<>();
-      testBlobs = new ArrayList<>();
 
       AbstractBlobStore blobStore = harness.createBlobStore();
       bucketClient = new BucketClient(blobStore);
-      cleanupTestData();
-      generateTestBlobs();
+
+      cleanupBenchmarkData();
       setupTestData();
     } catch (Exception e) {
       throw new RuntimeException("Failed to setup benchmark", e);
@@ -119,8 +165,7 @@ public abstract class AbstractBlobBenchmarkTest {
   @TearDown(Level.Trial)
   public void teardownBenchmark() {
     try {
-      cleanupTestData();
-
+      cleanupBenchmarkData();
       if (harness != null) {
         harness.close();
       }
@@ -129,65 +174,74 @@ public abstract class AbstractBlobBenchmarkTest {
     }
   }
 
-  /** Generate test blobs of various sizes */
-  private void generateTestBlobs() {
-    // Generate small blobs
-    for (int i = 0; i < 100; i++) {
-      byte[] blob = createBlob(SMALL_BLOB);
-      blobKeys.add("small/blob_" + i + ".dat");
-      testBlobs.add(blob);
-    }
-
-    // Generate medium blobs
-    for (int i = 0; i < 20; i++) {
-      byte[] blob = createBlob(MEDIUM_BLOB);
-      blobKeys.add("medium/blob_" + i + ".dat");
-      testBlobs.add(blob);
-    }
-
-    // Generate large blobs
-    for (int i = 0; i < 5; i++) {
-      byte[] blob = createBlob(LARGE_BLOB);
-      blobKeys.add("large/blob_" + i + ".dat");
-      testBlobs.add(blob);
-    }
-  }
-
-  /** Setup pre-populated test data */
   private void setupTestData() {
-    try {
-      for (int i = 0; i < blobKeys.size(); i++) {
-        String key = blobKeys.get(i);
-        byte[] blob = testBlobs.get(i);
+    Random rnd = new Random(42);
+    smallBlob = new byte[SMALL_BLOB];
+    rnd.nextBytes(smallBlob);
+    mediumBlob = new byte[MEDIUM_BLOB];
+    rnd.nextBytes(mediumBlob);
+    largeBlob = new byte[LARGE_BLOB];
+    rnd.nextBytes(largeBlob);
 
-        try (InputStream inputStream = new ByteArrayInputStream(blob)) {
-          UploadRequest request =
-              new UploadRequest.Builder().withKey(key).withContentLength(blob.length).build();
-          bucketClient.upload(request, inputStream);
-        }
-      }
+    smallKeys = new ArrayList<>(SMALL_COUNT);
+    for (int i = 0; i < SMALL_COUNT; i++) {
+      String key = SMALL_BLOBS_PREFIX + "blob_" + i + ".dat";
+      uploadBlob(key, smallBlob);
+      smallKeys.add(key);
+    }
+
+    mediumKeys = new ArrayList<>(MEDIUM_COUNT);
+    for (int i = 0; i < MEDIUM_COUNT; i++) {
+      String key = MEDIUM_BLOBS_PREFIX + "blob_" + i + ".dat";
+      uploadBlob(key, mediumBlob);
+      mediumKeys.add(key);
+    }
+
+    largeKeys = new ArrayList<>(LARGE_COUNT);
+    for (int i = 0; i < LARGE_COUNT; i++) {
+      String key = LARGE_BLOBS_PREFIX + "blob_" + i + ".dat";
+      uploadBlob(key, largeBlob);
+      largeKeys.add(key);
+    }
+
+    copySourceKey = smallKeys.get(0);
+  }
+
+  private void uploadBlob(String key, byte[] data) {
+    try (InputStream inputStream = new ByteArrayInputStream(data)) {
+      UploadRequest request =
+          new UploadRequest.Builder().withKey(key).withContentLength(data.length).build();
+      bucketClient.upload(request, inputStream);
     } catch (Exception e) {
-      throw new RuntimeException("Failed to setup test data", e);
+      throw new RuntimeException("Failed to upload test blob: " + key, e);
     }
   }
 
-  /** Cleanup test data */
-  private void cleanupTestData() {
+  private void cleanupBenchmarkData() {
     if (bucketClient == null) {
       return;
     }
-    if (blobKeys != null) {
-      for (String key : blobKeys) {
-        try {
-          bucketClient.delete(key, null);
-        } catch (Exception expected) {
+    String[] prefixes = {
+        DOWNLOAD_BLOBS_PREFIX, UPLOAD_SMALL_PREFIX, UPLOAD_MEDIUM_PREFIX,
+        UPLOAD_LARGE_PREFIX, WRITE_READ_DELETE_PREFIX, MULTIPART_PREFIX,
+        COPY_DEST_PREFIX
+    };
+    for (String prefix : prefixes) {
+      try {
+        ListBlobsRequest listRequest = ListBlobsRequest.builder().withPrefix(prefix).build();
+        Iterator<BlobInfo> iter = bucketClient.list(listRequest);
+        while (iter.hasNext()) {
+          bucketClient.delete(iter.next().getKey(), null);
         }
+      } catch (Exception e) {
+        logger.warn("Failed to cleanup prefix {}", prefix, e);
       }
     }
     for (String key : copyDestKeys) {
       try {
         bucketClient.delete(key, null);
-      } catch (Exception expected) {
+      } catch (Exception e) {
+        // best-effort
       }
     }
     copyDestKeys.clear();
@@ -195,237 +249,146 @@ public abstract class AbstractBlobBenchmarkTest {
 
   @Benchmark
   @Threads(4)
-  public void benchmarkSingleActionPut(Blackhole bh) {
-    benchmarkSingleActionPut(bh, 10);
-  }
-
-  private void benchmarkSingleActionPut(Blackhole bh, int n) {
-    final String baseKey = "benchmarksingleaction-put-";
-
-    try {
-      for (int i = 0; i < n; i++) {
-        String key = baseKey + nextPutId.incrementAndGet();
-        byte[] blobData = createBlob(SMALL_BLOB);
-
-        try (InputStream inputStream = new ByteArrayInputStream(blobData)) {
-          UploadRequest request =
-              new UploadRequest.Builder().withKey(key).withContentLength(blobData.length).build();
-          UploadResponse response = bucketClient.upload(request, inputStream);
-          bh.consume(response.getETag());
-        }
-      }
+  public void benchmarkUploadSmall(Blackhole bh) {
+    String key = UPLOAD_SMALL_PREFIX + nextUploadSmallId.incrementAndGet() + ".dat";
+    try (InputStream is = new ByteArrayInputStream(smallBlob)) {
+      UploadRequest request =
+          new UploadRequest.Builder().withKey(key).withContentLength(smallBlob.length).build();
+      UploadResponse response = bucketClient.upload(request, is);
+      bh.consume(response.getETag());
     } catch (Exception e) {
-      throw new RuntimeException("Benchmark single action put failed", e);
+      throw new RuntimeException("Benchmark upload small failed", e);
     }
   }
 
-  /** Single Action Get */
-  @Benchmark
-  @Threads(4)
-  public void benchmarkSingleActionGet(Blackhole bh) {
-    benchmarkSingleActionGet(bh, 10);
-  }
-
-  private void benchmarkSingleActionGet(Blackhole bh, int n) {
-    final String baseKey = "benchmarksingleaction-get-";
-
-    try {
-      // Pre-populate data
-      List<String> keys = new ArrayList<>();
-      for (int i = 0; i < n; i++) {
-        String key = baseKey + nextGetId.incrementAndGet();
-        keys.add(key);
-        byte[] blobData = createBlob(SMALL_BLOB);
-
-        try (InputStream inputStream = new ByteArrayInputStream(blobData)) {
-          UploadRequest request =
-              new UploadRequest.Builder().withKey(key).withContentLength(blobData.length).build();
-          bucketClient.upload(request, inputStream);
-        }
-      }
-      for (String key : keys) {
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-          DownloadRequest request = new DownloadRequest.Builder().withKey(key).build();
-          DownloadResponse response = bucketClient.download(request, outputStream);
-          bh.consume(outputStream.toByteArray());
-        }
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Benchmark single action get failed", e);
-    }
-  }
-
-  /** Batch Action Put */
-  @Benchmark
-  @Threads(4)
-  public void benchmarkActionListPut(Blackhole bh) {
-    benchmarkActionListPut(bh, 50);
-  }
-
-  private void benchmarkActionListPut(Blackhole bh, int n) {
-    final String baseKey = "benchmarkactionlist-put-";
-
-    try {
-      List<String> etags = new ArrayList<>();
-      for (int i = 0; i < n; i++) {
-        String key = baseKey + nextBatchPutId.incrementAndGet();
-        byte[] blobData = createBlob(SMALL_BLOB);
-
-        try (InputStream inputStream = new ByteArrayInputStream(blobData)) {
-          UploadRequest request =
-              new UploadRequest.Builder().withKey(key).withContentLength(blobData.length).build();
-          UploadResponse response = bucketClient.upload(request, inputStream);
-          etags.add(response.getETag());
-        }
-      }
-      bh.consume(etags.size());
-    } catch (Exception e) {
-      throw new RuntimeException("Benchmark action list put failed", e);
-    }
-  }
-
-  /** Batch Action Get */
-  @Benchmark
-  @Threads(4)
-  public void benchmarkActionListGet(Blackhole bh) {
-    benchmarkActionListGet(bh, 100);
-  }
-
-  private void benchmarkActionListGet(Blackhole bh, int n) {
-    final String baseKey = "benchmarkactionlist-get-";
-
-    try {
-      // Pre-populate data
-      List<String> keys = new ArrayList<>();
-      for (int i = 0; i < n; i++) {
-        String key = baseKey + nextBatchGetId.incrementAndGet();
-        keys.add(key);
-        byte[] blobData = createBlob(SMALL_BLOB);
-
-        try (InputStream inputStream = new ByteArrayInputStream(blobData)) {
-          UploadRequest request =
-              new UploadRequest.Builder().withKey(key).withContentLength(blobData.length).build();
-          bucketClient.upload(request, inputStream);
-        }
-      }
-
-      // Benchmark batched Get operations
-      List<Integer> results = new ArrayList<>();
-      for (String key : keys) {
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-          DownloadRequest request = new DownloadRequest.Builder().withKey(key).build();
-          bucketClient.download(request, outputStream);
-          results.add(outputStream.size());
-        }
-      }
-      bh.consume(results.size());
-    } catch (Exception e) {
-      throw new RuntimeException("Benchmark action list get failed", e);
-    }
-  }
-
-  /** Multipart Upload */
   @Benchmark
   @Threads(2)
-  public void benchmarkMultipartUpload(Blackhole bh) {
-    benchmarkMultipartUpload(bh, 10);
-  }
-
-  private void benchmarkMultipartUpload(Blackhole bh, int n) {
-    final String baseKey = "benchmarkmultipartupload-";
-    final byte[] content = createBlob(LARGE_BLOB);
-    try {
-      for (int i = 0; i < n; i++) {
-        String key = baseKey + nextMultipartUploadId.incrementAndGet();
-
-        MultipartUploadRequest request = new MultipartUploadRequest.Builder().withKey(key).build();
-        MultipartUpload mpu = bucketClient.initiateMultipartUpload(request);
-        bh.consume(mpu.getId());
-
-        List<UploadPartResponse> partResponses = new ArrayList<>();
-
-        int numParts = (int) Math.ceil((double) content.length / PART_SIZE);
-        for (int partNum = 1; partNum <= numParts; partNum++) {
-          int startIndex = (partNum - 1) * PART_SIZE;
-          int endIndex = Math.min(startIndex + PART_SIZE, content.length);
-          byte[] partData = Arrays.copyOfRange(content, startIndex, endIndex);
-
-          MultipartPart part = new MultipartPart(partNum, partData);
-          UploadPartResponse partResponse = bucketClient.uploadMultipartPart(mpu, part);
-          partResponses.add(partResponse);
-          bh.consume(partResponse.getEtag());
-        }
-
-        MultipartUploadResponse completeResponse =
-            bucketClient.completeMultipartUpload(mpu, partResponses);
-        bh.consume(completeResponse.getEtag());
-      }
+  public void benchmarkUploadMedium(Blackhole bh) {
+    String key = UPLOAD_MEDIUM_PREFIX + nextUploadMediumId.incrementAndGet() + ".dat";
+    try (InputStream is = new ByteArrayInputStream(mediumBlob)) {
+      UploadRequest request =
+          new UploadRequest.Builder().withKey(key).withContentLength(mediumBlob.length).build();
+      UploadResponse response = bucketClient.upload(request, is);
+      bh.consume(response.getETag());
     } catch (Exception e) {
-      throw new RuntimeException("Benchmark multipart upload failed", e);
+      throw new RuntimeException("Benchmark upload medium failed", e);
     }
   }
 
-  /** Write-Read-Delete Benchmark */
+  @Benchmark
+  @Threads(1)
+  @Measurement(iterations = 5, time = 30, timeUnit = TimeUnit.SECONDS)
+  public void benchmarkUploadLarge(Blackhole bh) {
+    String key = UPLOAD_LARGE_PREFIX + nextUploadLargeId.incrementAndGet() + ".dat";
+    try (InputStream is = new ByteArrayInputStream(largeBlob)) {
+      UploadRequest request =
+          new UploadRequest.Builder().withKey(key).withContentLength(largeBlob.length).build();
+      UploadResponse response = bucketClient.upload(request, is);
+      bh.consume(response.getETag());
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark upload large failed", e);
+    }
+  }
+
+  @Benchmark
+  @Threads(4)
+  public void benchmarkDownloadSmall(Blackhole bh) {
+    String key = pickRandom(smallKeys);
+    try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+      DownloadRequest request = new DownloadRequest.Builder().withKey(key).build();
+      bucketClient.download(request, os);
+      bh.consume(os.toByteArray());
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark download small failed", e);
+    }
+  }
+
+  @Benchmark
+  @Threads(2)
+  public void benchmarkDownloadMedium(Blackhole bh) {
+    String key = pickRandom(mediumKeys);
+    try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+      DownloadRequest request = new DownloadRequest.Builder().withKey(key).build();
+      bucketClient.download(request, os);
+      bh.consume(os.toByteArray());
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark download medium failed", e);
+    }
+  }
+
+  @Benchmark
+  @Threads(1)
+  @Measurement(iterations = 5, time = 30, timeUnit = TimeUnit.SECONDS)
+  public void benchmarkDownloadLarge(Blackhole bh) {
+    String key = pickRandom(largeKeys);
+    try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+      DownloadRequest request = new DownloadRequest.Builder().withKey(key).build();
+      bucketClient.download(request, os);
+      bh.consume(os.toByteArray());
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark download large failed", e);
+    }
+  }
+
   @Benchmark
   @Threads(4)
   public void benchmarkWriteReadDelete(Blackhole bh) {
-    final String baseKey = "writereaddeletebenchmark-blob-";
-    final byte[] content = createBlob(SMALL_BLOB);
+    String key = WRITE_READ_DELETE_PREFIX + nextWriteReadDeleteId.incrementAndGet() + ".dat";
 
     try {
-      String key = baseKey + nextWriteReadDeleteId.incrementAndGet();
-
-      // Write operation
-      try (InputStream inputStream = new ByteArrayInputStream(content)) {
+      try (InputStream is = new ByteArrayInputStream(smallBlob)) {
         UploadRequest uploadRequest =
-            new UploadRequest.Builder().withKey(key).withContentLength(content.length).build();
-        UploadResponse uploadResponse = bucketClient.upload(uploadRequest, inputStream);
+            new UploadRequest.Builder().withKey(key).withContentLength(smallBlob.length).build();
+        UploadResponse uploadResponse = bucketClient.upload(uploadRequest, is);
         bh.consume(uploadResponse.getETag());
       }
 
-      // Read operation
-      byte[] readData;
-      try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+      try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
         DownloadRequest downloadRequest = new DownloadRequest.Builder().withKey(key).build();
-        DownloadResponse downloadResponse = bucketClient.download(downloadRequest, outputStream);
-        readData = outputStream.toByteArray();
-        bh.consume(downloadResponse);
+        bucketClient.download(downloadRequest, os);
+        bh.consume(os.toByteArray());
       }
 
-      // Verify content match
-      if (!Arrays.equals(readData, content)) {
-        throw new RuntimeException("Read data didn't match written data");
-      }
-
-      // Delete operation
       bucketClient.delete(key, null);
-
     } catch (Exception e) {
       throw new RuntimeException("Benchmark write-read-delete failed", e);
     }
   }
 
-  /** Benchmark downloads using pre-populated test data */
   @Benchmark
-  public void benchmarkDownloadFromTestData(Blackhole bh) {
-    try {
-      String key = getRandomBlobKey();
+  @Threads(2)
+  public void benchmarkMultipartUpload(Blackhole bh) {
+    String key = MULTIPART_PREFIX + nextMultipartUploadId.incrementAndGet() + ".dat";
 
-      try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-        DownloadRequest request = new DownloadRequest.Builder().withKey(key).build();
-        DownloadResponse response = bucketClient.download(request, outputStream);
-        bh.consume(outputStream.toByteArray());
+    try {
+      MultipartUploadRequest request = new MultipartUploadRequest.Builder().withKey(key).build();
+      MultipartUpload mpu = bucketClient.initiateMultipartUpload(request);
+
+      List<UploadPartResponse> partResponses = new ArrayList<>();
+      int numParts = (int) Math.ceil((double) largeBlob.length / PART_SIZE);
+      for (int partNum = 1; partNum <= numParts; partNum++) {
+        int startIndex = (partNum - 1) * PART_SIZE;
+        int endIndex = Math.min(startIndex + PART_SIZE, largeBlob.length);
+        byte[] partData = Arrays.copyOfRange(largeBlob, startIndex, endIndex);
+
+        MultipartPart part = new MultipartPart(partNum, partData);
+        UploadPartResponse partResponse = bucketClient.uploadMultipartPart(mpu, part);
+        partResponses.add(partResponse);
       }
+
+      MultipartUploadResponse completeResponse =
+          bucketClient.completeMultipartUpload(mpu, partResponses);
+      bh.consume(completeResponse.getEtag());
     } catch (Exception e) {
-      throw new RuntimeException("Benchmark download from test data failed", e);
+      throw new RuntimeException("Benchmark multipart upload failed", e);
     }
   }
 
-  /** Benchmark metadata operations on pre-populated data */
   @Benchmark
-  public void benchmarkGetMetadataFromTestData(Blackhole bh) {
+  @Threads(4)
+  public void benchmarkGetMetadata(Blackhole bh) {
+    String key = pickRandom(smallKeys);
     try {
-      String key = getRandomBlobKey();
       BlobMetadata metadata = bucketClient.getMetadata(key, null);
       bh.consume(metadata);
     } catch (Exception e) {
@@ -433,35 +396,11 @@ public abstract class AbstractBlobBenchmarkTest {
     }
   }
 
-  /** Benchmark server-side copy within the same bucket */
-  @Benchmark
-  @Threads(4)
-  public void benchmarkCopy(Blackhole bh) {
-    try {
-      String srcKey = getRandomBlobKey();
-      String destKey = "copy-dest/" + UUID.randomUUID() + ".dat";
-
-      CopyRequest request =
-          CopyRequest.builder()
-              .srcKey(srcKey)
-              .destBucket(bucketName)
-              .destKey(destKey)
-              .build();
-      CopyResponse response = bucketClient.copy(request);
-      bh.consume(response);
-
-      copyDestKeys.add(destKey);
-    } catch (Exception e) {
-      throw new RuntimeException("Benchmark copy failed", e);
-    }
-  }
-
-  /** Benchmark listing blobs using iterator */
   @Benchmark
   @Threads(4)
   public void benchmarkList(Blackhole bh) {
     try {
-      ListBlobsRequest request = ListBlobsRequest.builder().withPrefix("small/").build();
+      ListBlobsRequest request = ListBlobsRequest.builder().withPrefix(SMALL_BLOBS_PREFIX).build();
       Iterator<BlobInfo> iter = bucketClient.list(request);
       int count = 0;
       while (iter.hasNext()) {
@@ -474,13 +413,15 @@ public abstract class AbstractBlobBenchmarkTest {
     }
   }
 
-  /** Benchmark paginated listing */
   @Benchmark
   @Threads(4)
   public void benchmarkListPage(Blackhole bh) {
     try {
       ListBlobsPageRequest request =
-          ListBlobsPageRequest.builder().withPrefix("small/").withMaxResults(20).build();
+          ListBlobsPageRequest.builder()
+              .withPrefix(SMALL_BLOBS_PREFIX)
+              .withMaxResults(LIST_PAGE_MAX_RESULTS)
+              .build();
       ListBlobsPageResponse response = bucketClient.listPage(request);
       bh.consume(response.getBlobs().size());
     } catch (Exception e) {
@@ -488,93 +429,46 @@ public abstract class AbstractBlobBenchmarkTest {
     }
   }
 
-  /** Benchmark small blob downloads using helper method */
   @Benchmark
   @Threads(4)
-  public void benchmarkDownloadSmallBlobs(Blackhole bh) {
-    benchmarkDownloadByPrefix(bh, "small/");
-  }
-
-  /** Benchmark medium blob downloads using helper method */
-  @Benchmark
-  @Threads(4)
-  public void benchmarkDownloadMediumBlobs(Blackhole bh) {
-    benchmarkDownloadByPrefix(bh, "medium/");
-  }
-
-  /** Benchmark large blob downloads using helper method */
-  @Benchmark
-  @Threads(4)
-  public void benchmarkDownloadLargeBlobs(Blackhole bh) {
-    benchmarkDownloadByPrefix(bh, "large/");
-  }
-
-  /** Generic helper method for downloading blobs by prefix */
-  private void benchmarkDownloadByPrefix(Blackhole bh, String prefix) {
+  public void benchmarkCopy(Blackhole bh) {
+    String destKey = COPY_DEST_PREFIX + nextCopyId.incrementAndGet() + ".dat";
     try {
-      String key = getRandomBlobKeyWithPrefix(prefix);
-
-      try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-        DownloadRequest request = new DownloadRequest.Builder().withKey(key).build();
-        DownloadResponse response = bucketClient.download(request, outputStream);
-        bh.consume(outputStream.toByteArray());
-      }
+      CopyRequest request =
+          CopyRequest.builder()
+              .srcKey(copySourceKey)
+              .destBucket(bucketName)
+              .destKey(destKey)
+              .build();
+      CopyResponse response = bucketClient.copy(request);
+      bh.consume(response);
+      copyDestKeys.add(destKey);
     } catch (Exception e) {
-      throw new RuntimeException("Benchmark download " + prefix + " blobs failed", e);
+      throw new RuntimeException("Benchmark copy failed", e);
     }
   }
 
-  /** Create a blob of specified size with random data */
-  protected byte[] createBlob(int size) {
-    byte[] blob = new byte[size];
-    ThreadLocalRandom.current().nextBytes(blob);
-    return blob;
+  private static String pickRandom(List<String> keys) {
+    return keys.get(ThreadLocalRandom.current().nextInt(keys.size()));
   }
 
-  /** Generate a unique blob key */
-  protected String generateUniqueBlobKey(String prefix) {
-    return prefix + "/blob_" + UUID.randomUUID().toString() + ".dat";
-  }
-
-  /** Get a random blob key from pre-populated test data */
-  protected String getRandomBlobKey() {
-    if (blobKeys.isEmpty()) {
-      return generateUniqueBlobKey("fallback");
-    }
-    return blobKeys.get(ThreadLocalRandom.current().nextInt(blobKeys.size()));
-  }
-
-  /** Get a random blob key with specific prefix */
-  protected String getRandomBlobKeyWithPrefix(String prefix) {
-    List<String> filteredKeys =
-        blobKeys.stream().filter(key -> key.startsWith(prefix)).collect(Collectors.toList());
-
-    if (filteredKeys.isEmpty()) {
-      return generateUniqueBlobKey(prefix);
-    }
-
-    return filteredKeys.get(ThreadLocalRandom.current().nextInt(filteredKeys.size()));
-  }
-
-  /** Get random blob data from test blobs */
-  protected byte[] getRandomBlob() {
-    if (testBlobs.isEmpty()) {
-      return createBlob(SMALL_BLOB);
-    }
-    return testBlobs.get(ThreadLocalRandom.current().nextInt(testBlobs.size()));
-  }
-
-  /** JUnit test method to run JMH benchmarks */
   @Test
+  @EnabledIfSystemProperty(named = "runBenchmarks", matches = "true")
   public void runBenchmarks() throws RunnerException {
+    List<String> forwardedArgs = new ArrayList<>();
+    for (String key : System.getProperties().stringPropertyNames()) {
+      if (key.startsWith("BLOB_BENCHMARK_")) {
+        forwardedArgs.add("-D" + key + "=" + System.getProperty(key));
+      }
+    }
+
     Options opt =
         new OptionsBuilder()
             .include(".*" + this.getClass().getName() + ".*")
             .forks(1)
-            .warmupIterations(3)
-            .measurementIterations(5)
             .resultFormat(ResultFormatType.JSON)
-            .result("target/jmh-results.json")
+            .result("target/jmh-sync-results-" + getProviderId() + ".json")
+            .jvmArgsAppend(forwardedArgs.toArray(new String[0]))
             .build();
 
     new Runner(opt).run();

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobBenchmarkTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobBenchmarkTest.java
@@ -4,22 +4,19 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.salesforce.multicloudj.blob.client.AbstractBlobBenchmarkTest;
 import com.salesforce.multicloudj.blob.driver.AbstractBlobStore;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Disabled
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class GcpCloudBlobBenchmarkTest extends AbstractBlobBenchmarkTest {
+public class GcpBlobBenchmarkTest extends AbstractBlobBenchmarkTest {
 
-  private static final Logger logger = LoggerFactory.getLogger(GcpCloudBlobBenchmarkTest.class);
-  private static final String projectId =
-      System.getProperty(
-          "gcp.project.id",
-          System.getenv().getOrDefault("GOOGLE_CLOUD_PROJECT", "substrate-sdk-gcp-poc1"));
-  private static final String bucketName =
-      System.getProperty("gcp.bucket.name", "multicloudj-sync-client-benchmark-uswest1");
+  private static final Logger logger = LoggerFactory.getLogger(GcpBlobBenchmarkTest.class);
+
+  @Override
+  protected String getProviderId() {
+    return "gcp";
+  }
 
   @Override
   protected Harness createHarness() {
@@ -31,50 +28,42 @@ public class GcpCloudBlobBenchmarkTest extends AbstractBlobBenchmarkTest {
 
     @Override
     public AbstractBlobStore createBlobStore() {
+      String projectId = requireEnv("BLOB_BENCHMARK_GCP_PROJECT_ID");
+      String bucket = requireEnv("BLOB_BENCHMARK_GCP_BUCKET");
+
       logger.info(
           "Creating GCP Cloud Storage blob store with project: {}, bucket: {}",
-          projectId,
-          bucketName);
+          projectId, bucket);
 
       try {
-        Storage client = StorageOptions.getDefaultInstance().getService();
-        if (storage == null) {
-          storage = client;
-        }
+        storage = StorageOptions.newBuilder()
+            .setProjectId(projectId)
+            .build()
+            .getService();
 
         logger.info("Successfully created Storage client");
 
         AbstractBlobStore blobStore =
-            new GcpBlobStore.Builder().withStorage(client).withBucket(bucketName).build();
+            new GcpBlobStore.Builder().withStorage(storage).withBucket(bucket).build();
 
         logger.info("Successfully created GCP Cloud Storage blob store");
         return blobStore;
 
       } catch (Exception e) {
         logger.error("Failed to create GCP Cloud Storage blob store", e);
-
-        if (storage != null) {
-          try {
-            logger.debug("Storage client will be garbage collected");
-          } catch (Exception cleanupException) {
-            logger.warn("Cleanup warning", cleanupException);
-          }
-          storage = null;
-        }
-
+        storage = null;
         throw new RuntimeException("Failed to create GCP Cloud Storage blob store", e);
       }
     }
 
     @Override
     public String getBucketName() {
-      return bucketName;
+      return requireEnv("BLOB_BENCHMARK_GCP_BUCKET");
     }
 
     @Override
     public void close() throws Exception {
       if (storage != null) {
-        logger.debug("Storage client resources released");
         storage = null;
       }
     }


### PR DESCRIPTION
## Summary

Refactor sync blob benchmarks (`AbstractBlobBenchmarkTest`) to align with the patterns established in async blob, docstore, and pubsub benchmarks (PR #443, #426, #432) for consistency across all service benchmarks.

## What changed

**`AbstractBlobBenchmarkTest`** — full rewrite (574 lines → ~440):
- **One operation per `@Benchmark` invocation** — removed loop-based `benchmarkSingleActionPut/Get` and fake-batch `benchmarkActionListPut/Get` so JMH reports true per-op latency/throughput.
- **Pre-seeded read-path data** — small (100 × 1KB), medium (20 × 1MB), large (5 × 10MB) blobs uploaded once in `@Setup(Trial)`. Read benchmarks pick keys via `pickRandom()` instead of inlining writes.
- **Per-method `@Threads`** — 4 threads for light ops (small upload/download, getMetadata, list, listPage, copy, writeReadDelete), 2 for medium, 1 for large/MPU. Removed class-level `@Threads`.
- **`requireEnv` fail-fast** — replaces silent defaults that could let benchmarks hit the wrong bucket. Reads from OS env first, then `-D` system properties; throws `IllegalStateException` if neither is set.
- **`runBenchmarks()` forwards `-D` props** — JMH `@Fork(1)` spawns a new JVM that doesn't inherit `-D` flags from Maven, so `BLOB_BENCHMARK_*` props are forwarded explicitly via `jvmArgsAppend`. Cloud credentials still flow via OS env automatically.
- **Final 12 benchmarks**: `uploadSmall/Medium/Large`, `downloadSmall/Medium/Large`, `writeReadDelete`, `multipartUpload`, `getMetadata`, `list`, `listPage`, `copy`.

**`AwsBlobBenchmarkTest`** — removed `@Disabled` and hardcoded bucket/region defaults; now uses `requireEnv("BLOB_BENCHMARK_AWS_REGION")` and `requireEnv("BLOB_BENCHMARK_AWS_BUCKET")`.

**`GcpCloudBlobBenchmarkTest` → `GcpBlobBenchmarkTest`** — renamed for naming consistency with `AwsBlobBenchmarkTest`. Removed `@Disabled` and hardcoded defaults; uses `requireEnv("BLOB_BENCHMARK_GCP_PROJECT_ID")` and `requireEnv("BLOB_BENCHMARK_GCP_BUCKET")`.

## Why

The old benchmarks had the same "embedded put" anti-pattern that PR #432 fixed for docstore — read benchmarks were doing writes inline, so reported latency conflated write+read costs. Loop-based "batch" benchmarks weren't really measuring batch APIs. Aligning with the docstore/pubsub harness gives consistent reporting and makes results comparable across services.

## Results 

Run environment: developer laptop on residential broadband, AWS bucket `multicloudj-sync-benchmark-uswest2` in `us-west-2`, GCP bucket `multicloudj-sync-benchmark-uswest1` in `us-west1`. JMH 1.37, JDK 21, `@Fork(1)`. All 12 benchmarks complete on both providers.

How to read the numbers:
- **Throughput (ops/s)** — higher is better ↑ (operations completed per second).
- **P50 / P99 latency (ms)** — lower is better ↓ (50th / 99th percentile time per operation).

| Benchmark | Threads | AWS Thrpt (ops/s) | GCP Thrpt (ops/s) | AWS P50 (ms) | GCP P50 (ms) | AWS P99 (ms) | GCP P99 (ms) |
|---|---|---|---|---|---|---|---|
| benchmarkUploadSmall | 4 | 14.7 | 7.4 | 273 | 484 | 1,176 | 654 |
| benchmarkUploadMedium | 2 | 2.9 | 2.0 | 812 | 856 | 6,552 | 1,101 |
| benchmarkUploadLarge | 1 | 0.34 | 0.35 | 3,028 | 2,831 | 4,006 | 4,513 |
| benchmarkDownloadSmall | 4 | 24.8 | 11.8 | 137 | 339 | 596 | 528 |
| benchmarkDownloadMedium | 2 | 1.9 | 1.6 | 1,061 | 1,091 | 1,611 | 2,064 |
| benchmarkDownloadLarge | 1 | 0.18 | 0.20 | 5,411 | 4,614 | 6,409 | 10,905 |
| benchmarkWriteReadDelete | 4 | 7.2 | 3.4 | 581 | 1,074 | 954 | 1,325 |
| benchmarkMultipartUpload | 2 | 0.34 | 0.32 | 6,279 | 4,962 | 6,854 | 5,746 |
| benchmarkGetMetadata | 4 | 28.7 | 22.6 | 125 | 140 | 474 | 331 |
| benchmarkList | 4 | 22.4 | 12.7 | 173 | 251 | 400 | 506 |
| benchmarkListPage | 4 | 26.1 | 21.0 | 141 | 183 | 373 | 719 |
| benchmarkCopy | 4 | 23.4 | 21.6 | 169 | 173 | 379 | 669 |

## Test plan

- [x] `mvn clean install -DskipTests` succeeds
- [x] `mvn test -pl blob/blob-aws -Dtest=AwsBlobBenchmarkTest -DrunBenchmarks=true -DBLOB_BENCHMARK_AWS_REGION=... -DBLOB_BENCHMARK_AWS_BUCKET=...` — all 12 benchmarks run on AWS
- [x] Same against GCP with `BLOB_BENCHMARK_GCP_PROJECT_ID` / `BLOB_BENCHMARK_GCP_BUCKET`
- [x] JMH JSON results land in `target/jmh-sync-results-{aws,gcp}.json`