### PR TITLE
blobstore: implement async tags and presign URL operation for Ali OSS

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -3,16 +3,20 @@ package com.salesforce.multicloudj.blob.ali.async;
 import com.aliyun.sdk.service.oss2.OSSAsyncClient;
 import com.aliyun.sdk.service.oss2.OSSClient;
 import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.PresignOptions;
 import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
 import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
 import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectResult;
+import com.aliyun.sdk.service.oss2.models.GetObjectTaggingRequest;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
 import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
 import com.aliyun.sdk.service.oss2.models.ListObjectsV2Request;
+import com.aliyun.sdk.service.oss2.models.PresignResult;
 import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
+import com.aliyun.sdk.service.oss2.models.PutObjectTaggingRequest;
 import com.aliyun.sdk.service.oss2.transfermanager.DownloadError;
 import com.aliyun.sdk.service.oss2.transfermanager.Downloader;
 import com.aliyun.sdk.service.oss2.transport.BinaryData;
@@ -48,6 +52,7 @@ import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.ali.AliConstants;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import java.io.ByteArrayOutputStream;
@@ -436,19 +441,52 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
 
   @Override
   protected CompletableFuture<Map<String, String>> doGetTags(String key) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    GetObjectTaggingRequest request =
+        GetObjectTaggingRequest.newBuilder()
+            .bucket(getBucket())
+            .key(key)
+            .build();
+    return asyncClient
+        .getObjectTaggingAsync(request, OperationOptions.defaults())
+        .thenApply(result -> transformer.toTagMap(result));
   }
 
   @Override
   protected CompletableFuture<Void> doSetTags(
       String key, Map<String, String> tags) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    PutObjectTaggingRequest request =
+        transformer.toPutObjectTaggingRequest(key, tags);
+    return asyncClient
+        .putObjectTaggingAsync(request, OperationOptions.defaults())
+        .thenAccept(result -> {});
   }
 
   @Override
   protected CompletableFuture<URL> doGeneratePresignedUrl(
       PresignedUrlRequest request) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return CompletableFuture.supplyAsync(() -> {
+      PresignOptions options = transformer.toPresignOptions(request);
+      PresignResult result;
+      switch (request.getType()) {
+        case UPLOAD:
+          result = syncClient.presign(
+              transformer.toPresignedPutObjectRequest(request), options);
+          break;
+        case DOWNLOAD:
+          result = syncClient.presign(
+              transformer.toPresignedGetObjectRequest(request), options);
+          break;
+        default:
+          throw new InvalidArgumentException(
+              "Unsupported PresignedOperation. type=" + request.getType());
+      }
+      try {
+        return new URL(result.url());
+      } catch (java.net.MalformedURLException e) {
+        throw new SubstrateSdkException(
+            "Invalid presigned URL: " + result.url(), e);
+      }
+    }, executorService);
   }
 
   @Override

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import com.aliyun.sdk.service.oss2.OSSAsyncClient;
 import com.aliyun.sdk.service.oss2.OSSClient;
 import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.PresignOptions;
 import com.aliyun.sdk.service.oss2.models.AbortMultipartUploadRequest;
 import com.aliyun.sdk.service.oss2.models.AbortMultipartUploadResult;
 import com.aliyun.sdk.service.oss2.models.CommonPrefix;
@@ -30,6 +31,8 @@ import com.aliyun.sdk.service.oss2.models.DeleteObjectResult;
 import com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectResult;
+import com.aliyun.sdk.service.oss2.models.GetObjectTaggingRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectTaggingResult;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
 import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload;
@@ -41,8 +44,14 @@ import com.aliyun.sdk.service.oss2.models.ListPartsRequest;
 import com.aliyun.sdk.service.oss2.models.ListPartsResult;
 import com.aliyun.sdk.service.oss2.models.ObjectSummary;
 import com.aliyun.sdk.service.oss2.models.Part;
+import com.aliyun.sdk.service.oss2.models.PresignResult;
 import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
 import com.aliyun.sdk.service.oss2.models.PutObjectResult;
+import com.aliyun.sdk.service.oss2.models.PutObjectTaggingRequest;
+import com.aliyun.sdk.service.oss2.models.PutObjectTaggingResult;
+import com.aliyun.sdk.service.oss2.models.Tag;
+import com.aliyun.sdk.service.oss2.models.TagSet;
+import com.aliyun.sdk.service.oss2.models.Tagging;
 import com.aliyun.sdk.service.oss2.models.UploadPartRequest;
 import com.aliyun.sdk.service.oss2.models.UploadPartResult;
 import com.aliyun.sdk.service.oss2.transfermanager.DownloadError;
@@ -65,14 +74,18 @@ import com.salesforce.multicloudj.blob.driver.MultipartPart;
 import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
+import com.salesforce.multicloudj.blob.driver.PresignedOperation;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -917,5 +930,87 @@ public class AliAsyncBlobStoreTest {
     ExecutionException ex = assertThrows(ExecutionException.class,
         () -> store.abortMultipartUpload(mpu).get());
     assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testGetTags() throws Exception {
+    Tag tag1 = mock(Tag.class);
+    when(tag1.key()).thenReturn("env");
+    when(tag1.value()).thenReturn("prod");
+    Tag tag2 = mock(Tag.class);
+    when(tag2.key()).thenReturn("team");
+    when(tag2.value()).thenReturn("platform");
+
+    TagSet tagSet = mock(TagSet.class);
+    when(tagSet.tags()).thenReturn(List.of(tag1, tag2));
+    Tagging tagging = mock(Tagging.class);
+    when(tagging.tagSet()).thenReturn(tagSet);
+
+    GetObjectTaggingResult mockResult =
+        mock(GetObjectTaggingResult.class);
+    when(mockResult.tagging()).thenReturn(tagging);
+    when(mockAsyncClient.getObjectTaggingAsync(
+        any(GetObjectTaggingRequest.class),
+        any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    Map<String, String> tags = store.getTags("tagged-key").get();
+
+    assertNotNull(tags);
+    assertEquals(2, tags.size());
+    assertEquals("prod", tags.get("env"));
+    assertEquals("platform", tags.get("team"));
+  }
+
+  @Test
+  void testSetTags() throws Exception {
+    PutObjectTaggingResult mockResult =
+        mock(PutObjectTaggingResult.class);
+    when(mockAsyncClient.putObjectTaggingAsync(
+        any(PutObjectTaggingRequest.class),
+        any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    Map<String, String> tags = Map.of("env", "staging", "version", "2");
+    store.setTags("tag-key", tags).get();
+  }
+
+  @Test
+  void testGeneratePresignedUrlDownload() throws Exception {
+    PresignResult mockResult = mock(PresignResult.class);
+    when(mockResult.url()).thenReturn("https://bucket.oss.aliyuncs.com/key?sig=abc");
+    when(mockSyncClient.presign(
+        any(GetObjectRequest.class), any(PresignOptions.class)))
+        .thenReturn(mockResult);
+
+    PresignedUrlRequest request = PresignedUrlRequest.builder()
+        .key("presign-key")
+        .type(PresignedOperation.DOWNLOAD)
+        .duration(Duration.ofMinutes(15))
+        .build();
+    URL url = store.generatePresignedUrl(request).get();
+
+    assertNotNull(url);
+    assertEquals("https", url.getProtocol());
+    assertEquals("bucket.oss.aliyuncs.com", url.getHost());
+  }
+
+  @Test
+  void testGeneratePresignedUrlUpload() throws Exception {
+    PresignResult mockResult = mock(PresignResult.class);
+    when(mockResult.url()).thenReturn("https://bucket.oss.aliyuncs.com/upload-key?sig=xyz");
+    when(mockSyncClient.presign(
+        any(PutObjectRequest.class), any(PresignOptions.class)))
+        .thenReturn(mockResult);
+
+    PresignedUrlRequest request = PresignedUrlRequest.builder()
+        .key("upload-key")
+        .type(PresignedOperation.UPLOAD)
+        .duration(Duration.ofMinutes(30))
+        .build();
+    URL url = store.generatePresignedUrl(request).get();
+
+    assertNotNull(url);
+    assertEquals("https", url.getProtocol());
   }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -1013,4 +1013,47 @@ public class AliAsyncBlobStoreTest {
     assertNotNull(url);
     assertEquals("https", url.getProtocol());
   }
+
+  @Test
+  void testGetTagsFailed() {
+    RuntimeException cause = new RuntimeException("object not found");
+    when(mockAsyncClient.getObjectTaggingAsync(
+        any(GetObjectTaggingRequest.class),
+        any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.getTags("missing-key").get());
+    assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testSetTagsFailed() {
+    RuntimeException cause = new RuntimeException("access denied");
+    when(mockAsyncClient.putObjectTaggingAsync(
+        any(PutObjectTaggingRequest.class),
+        any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.setTags("forbidden-key", Map.of("k", "v")).get());
+    assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testGeneratePresignedUrlFailed() {
+    when(mockSyncClient.presign(
+        any(GetObjectRequest.class), any(PresignOptions.class)))
+        .thenThrow(new RuntimeException("presign error"));
+
+    PresignedUrlRequest request = PresignedUrlRequest.builder()
+        .key("fail-key")
+        .type(PresignedOperation.DOWNLOAD)
+        .duration(Duration.ofMinutes(15))
+        .build();
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.generatePresignedUrl(request).get());
+    assertNotNull(ex.getCause());
+  }
 }


### PR DESCRIPTION
## Summary

Add async tags and presign URL operation support for Ali blobstore.

Includes unit tests with mocked SDK client. Performed manual integration testing against live Ali environment to verify functionality.

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
