### PR TITLE
blobstore: implement async directory operations for Ali OSS

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -66,6 +66,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -665,5 +666,22 @@ public class AliTransformer {
     }
 
     return builder.build();
+  }
+
+  public List<List<BlobInfo>> partitionList(List<BlobInfo> blobInfos, int partitionSize) {
+    List<List<BlobInfo>> partitionedList = new ArrayList<>();
+    int listSize = blobInfos.size();
+
+    for (int i = 0; i < listSize; i += partitionSize) {
+      int endIndex = Math.min(i + partitionSize, listSize);
+      partitionedList.add(new ArrayList<>(blobInfos.subList(i, endIndex)));
+    }
+    return partitionedList;
+  }
+
+  public List<BlobIdentifier> toBlobIdentifiers(List<BlobInfo> blobList) {
+    return blobList.stream()
+        .map(blob -> new BlobIdentifier(blob.getKey(), null))
+        .collect(Collectors.toList());
   }
 }

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -561,28 +561,39 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
                 blobInfos.add(blob);
               }
             }))
-        // Stage 3: fan out per-file downloads and compose; no blocking join.
-        .thenCompose(v -> {
+        // Stage 3: create all destination directories upfront, then fan out downloads.
+        // Uses thenComposeAsync to ensure directory I/O runs on our executor,
+        // not on the SDK's async-completion thread that resolved the listing.
+        .thenComposeAsync(v -> {
+          // Pre-create all unique parent directories before starting downloads.
+          for (BlobInfo blob : blobInfos) {
+            String key = blob.getKey();
+            String relative = (prefix != null && key.startsWith(prefix))
+                ? key.substring(prefix.length()) : key;
+            Path destination = targetDir.resolve(relative).normalize();
+            if (!destination.startsWith(targetDir)) {
+              throw new SubstrateSdkException(
+                  "Path traversal detected: key '" + key
+                      + "' resolves outside target directory");
+            }
+            Path parent = destination.getParent();
+            if (parent != null) {
+              try {
+                Files.createDirectories(parent);
+              } catch (IOException e) {
+                throw new SubstrateSdkException(
+                    "Failed to create directories: " + parent, e);
+              }
+            }
+          }
+
+          // Fan out per-file downloads.
           List<CompletableFuture<Void>> futures = blobInfos.stream()
               .map(blob -> {
                 String key = blob.getKey();
                 String relative = (prefix != null && key.startsWith(prefix))
                     ? key.substring(prefix.length()) : key;
                 Path destination = targetDir.resolve(relative).normalize();
-                if (!destination.startsWith(targetDir)) {
-                  throw new SubstrateSdkException(
-                      "Path traversal detected: key '" + key
-                          + "' resolves outside target directory");
-                }
-                Path parent = destination.getParent();
-                if (parent != null) {
-                  try {
-                    Files.createDirectories(parent);
-                  } catch (IOException e) {
-                    throw new SubstrateSdkException(
-                        "Failed to create directories: " + parent, e);
-                  }
-                }
 
                 DownloadRequest downloadRequest = DownloadRequest.builder()
                     .withKey(key)
@@ -605,7 +616,7 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
               .collect(Collectors.toList());
           return CompletableFuture.allOf(
               futures.toArray(new CompletableFuture[0]));
-        })
+        }, executorService)
         // Stage 4: build response after all downloads complete.
         .thenApply(v -> DirectoryDownloadResponse.builder()
             .failedTransfers(new ArrayList<>(failures))
@@ -644,21 +655,29 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
     List<FailedBlobUpload> failures =
         Collections.synchronizedList(new ArrayList<>());
 
-    // Stage 1: blocking directory walk on an executor thread; released after.
+    // Stage 1: blocking directory walk + file size stat on an executor thread.
     return CompletableFuture.supplyAsync(
-        () -> collectFilePaths(sourceDir, directoryUploadRequest),
+        () -> {
+          List<Path> paths = collectFilePaths(sourceDir, directoryUploadRequest);
+          // Compute file sizes upfront so Stage 2 avoids I/O on completion threads.
+          Map<Path, Long> fileSizes = paths.stream()
+              .collect(Collectors.toMap(p -> p, p -> p.toFile().length()));
+          return fileSizes;
+        },
         executorService)
         // Stage 2: fan out per-file uploads and compose; no blocking join.
-        .thenCompose(filePaths -> {
-          if (filePaths.isEmpty()) {
+        .thenCompose(fileSizes -> {
+          if (fileSizes.isEmpty()) {
             return CompletableFuture.completedFuture(null);
           }
-          List<CompletableFuture<Void>> futures = filePaths.stream()
-              .map(filePath -> {
+          List<CompletableFuture<Void>> futures = fileSizes.entrySet().stream()
+              .map(entry -> {
+                Path filePath = entry.getKey();
+                long fileSize = entry.getValue();
                 String key = toBlobKey(sourceDir, filePath, prefix);
                 UploadRequest.Builder uploadBuilder = UploadRequest.builder()
                     .withKey(key)
-                    .withContentLength(filePath.toFile().length());
+                    .withContentLength(fileSize);
                 if (tags != null && !tags.isEmpty()) {
                   uploadBuilder.withTags(tags);
                 }
@@ -670,7 +689,7 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
                     .thenAccept(response -> {
                       if (directoryUploadRequest
                           .isTransferStatusLoggingEnabled()) {
-                        totalBytes.addAndGet(filePath.toFile().length());
+                        totalBytes.addAndGet(fileSize);
                       }
                     })
                     .exceptionally(ex -> {

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -569,6 +569,11 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
                 String relative = (prefix != null && key.startsWith(prefix))
                     ? key.substring(prefix.length()) : key;
                 Path destination = targetDir.resolve(relative).normalize();
+                if (!destination.startsWith(targetDir)) {
+                  throw new SubstrateSdkException(
+                      "Path traversal detected: key '" + key
+                          + "' resolves outside target directory");
+                }
                 Path parent = destination.getParent();
                 if (parent != null) {
                   try {

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -523,100 +523,91 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
   @Override
   protected CompletableFuture<DirectoryDownloadResponse> doDownloadDirectory(
       DirectoryDownloadRequest directoryDownloadRequest) {
-    return CompletableFuture.supplyAsync(() -> {
-      Path targetDir = Paths.get(
-          directoryDownloadRequest.getLocalDestinationDirectory())
-          .toAbsolutePath().normalize();
+    Path targetDir = Paths.get(
+        directoryDownloadRequest.getLocalDestinationDirectory())
+        .toAbsolutePath().normalize();
+
+    String rawPrefix = directoryDownloadRequest.getPrefixToDownload();
+    String prefix = (rawPrefix != null && !rawPrefix.isEmpty()
+        && !rawPrefix.endsWith("/"))
+        ? rawPrefix + "/" : rawPrefix;
+
+    List<String> prefixesToExclude =
+        directoryDownloadRequest.getPrefixesToExclude();
+
+    List<BlobInfo> blobInfos = Collections.synchronizedList(new ArrayList<>());
+    AtomicLong totalBytes = new AtomicLong(0L);
+    List<FailedBlobDownload> failures =
+        Collections.synchronizedList(new ArrayList<>());
+
+    // Stage 1: short blocking filesystem prep on an executor thread; released after.
+    return CompletableFuture.runAsync(() -> {
       try {
         Files.createDirectories(targetDir);
       } catch (IOException e) {
         throw new SubstrateSdkException(
             "Failed to create destination directory: " + targetDir, e);
       }
-
-      String rawPrefix = directoryDownloadRequest.getPrefixToDownload();
-      String prefix = (rawPrefix != null && !rawPrefix.isEmpty()
-          && !rawPrefix.endsWith("/"))
-          ? rawPrefix + "/" : rawPrefix;
-
-      List<String> prefixesToExclude =
-          directoryDownloadRequest.getPrefixesToExclude();
-
-      List<BlobInfo> blobInfos = new ArrayList<>();
-      ListBlobsRequest listRequest = ListBlobsRequest.builder()
-          .withPrefix(prefix)
-          .build();
-      doList(listRequest, batch -> {
-        for (BlobInfo blob : batch.getBlobs()) {
-          if (isFolderMarker(blob)) {
-            continue;
-          }
-          if (isExcluded(blob.getKey(), prefixesToExclude)) {
-            continue;
-          }
-          synchronized (blobInfos) {
-            blobInfos.add(blob);
-          }
-        }
-      }).join();
-
-      if (blobInfos.isEmpty()) {
-        return DirectoryDownloadResponse.builder()
-            .failedTransfers(new ArrayList<>())
-            .build();
-      }
-
-      AtomicLong totalBytes = new AtomicLong(0L);
-      List<FailedBlobDownload> failures = new ArrayList<>();
-
-      List<CompletableFuture<Void>> futures = blobInfos.stream()
-          .map(blob -> {
-            String key = blob.getKey();
-            String relative = (prefix != null && key.startsWith(prefix))
-                ? key.substring(prefix.length()) : key;
-            Path destination = targetDir.resolve(relative).normalize();
-            Path parent = destination.getParent();
-            if (parent != null) {
-              try {
-                Files.createDirectories(parent);
-              } catch (IOException e) {
-                throw new SubstrateSdkException(
-                    "Failed to create directories: " + parent, e);
+    }, executorService)
+        // Stage 2: async paginated listing; consumer collects matching blobs.
+        .thenCompose(v -> doList(
+            ListBlobsRequest.builder().withPrefix(prefix).build(),
+            batch -> {
+              for (BlobInfo blob : batch.getBlobs()) {
+                if (isFolderMarker(blob)
+                    || isExcluded(blob.getKey(), prefixesToExclude)) {
+                  continue;
+                }
+                blobInfos.add(blob);
               }
-            }
-
-            DownloadRequest downloadRequest = DownloadRequest.builder()
-                .withKey(key)
-                .build();
-            return doDownload(downloadRequest, destination)
-                .thenAccept(response -> {
-                  if (directoryDownloadRequest
-                      .isTransferStatusLoggingEnabled()) {
-                    totalBytes.addAndGet(blob.getObjectSize());
+            }))
+        // Stage 3: fan out per-file downloads and compose; no blocking join.
+        .thenCompose(v -> {
+          List<CompletableFuture<Void>> futures = blobInfos.stream()
+              .map(blob -> {
+                String key = blob.getKey();
+                String relative = (prefix != null && key.startsWith(prefix))
+                    ? key.substring(prefix.length()) : key;
+                Path destination = targetDir.resolve(relative).normalize();
+                Path parent = destination.getParent();
+                if (parent != null) {
+                  try {
+                    Files.createDirectories(parent);
+                  } catch (IOException e) {
+                    throw new SubstrateSdkException(
+                        "Failed to create directories: " + parent, e);
                   }
-                })
-                .exceptionally(ex -> {
-                  synchronized (failures) {
-                    failures.add(FailedBlobDownload.builder()
-                        .destination(destination)
-                        .exception(ex)
-                        .build());
-                  }
-                  return null;
-                });
-          })
-          .collect(Collectors.toList());
+                }
 
-      CompletableFuture.allOf(
-          futures.toArray(new CompletableFuture[0])).join();
-
-      return DirectoryDownloadResponse.builder()
-          .failedTransfers(failures)
-          .totalBytesTransferred(
-              directoryDownloadRequest.isTransferStatusLoggingEnabled()
-                  ? totalBytes.get() : null)
-          .build();
-    }, executorService);
+                DownloadRequest downloadRequest = DownloadRequest.builder()
+                    .withKey(key)
+                    .build();
+                return doDownload(downloadRequest, destination)
+                    .thenAccept(response -> {
+                      if (directoryDownloadRequest
+                          .isTransferStatusLoggingEnabled()) {
+                        totalBytes.addAndGet(blob.getObjectSize());
+                      }
+                    })
+                    .exceptionally(ex -> {
+                      failures.add(FailedBlobDownload.builder()
+                          .destination(destination)
+                          .exception(ex)
+                          .build());
+                      return null;
+                    });
+              })
+              .collect(Collectors.toList());
+          return CompletableFuture.allOf(
+              futures.toArray(new CompletableFuture[0]));
+        })
+        // Stage 4: build response after all downloads complete.
+        .thenApply(v -> DirectoryDownloadResponse.builder()
+            .failedTransfers(new ArrayList<>(failures))
+            .totalBytesTransferred(
+                directoryDownloadRequest.isTransferStatusLoggingEnabled()
+                    ? totalBytes.get() : null)
+            .build());
   }
 
   private boolean isFolderMarker(BlobInfo blob) {
@@ -638,67 +629,64 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
   @Override
   protected CompletableFuture<DirectoryUploadResponse> doUploadDirectory(
       DirectoryUploadRequest directoryUploadRequest) {
-    return CompletableFuture.supplyAsync(() -> {
-      Path sourceDir = Paths.get(
-          directoryUploadRequest.getLocalSourceDirectory())
-          .toAbsolutePath().normalize();
-      List<Path> filePaths = collectFilePaths(
-          sourceDir, directoryUploadRequest);
-      if (filePaths.isEmpty()) {
-        return DirectoryUploadResponse.builder()
-            .failedTransfers(new ArrayList<>())
-            .build();
-      }
+    Path sourceDir = Paths.get(
+        directoryUploadRequest.getLocalSourceDirectory())
+        .toAbsolutePath().normalize();
+    String prefix = directoryUploadRequest.getPrefix();
+    Map<String, String> tags = directoryUploadRequest.getTags();
+    var objectLock = directoryUploadRequest.getObjectLock();
+    AtomicLong totalBytes = new AtomicLong(0L);
+    List<FailedBlobUpload> failures =
+        Collections.synchronizedList(new ArrayList<>());
 
-      String prefix = directoryUploadRequest.getPrefix();
-      AtomicLong totalBytes = new AtomicLong(0L);
-      List<FailedBlobUpload> failures = new ArrayList<>();
-
-      Map<String, String> tags = directoryUploadRequest.getTags();
-      var objectLock = directoryUploadRequest.getObjectLock();
-
-      List<CompletableFuture<Void>> futures = filePaths.stream()
-          .map(filePath -> {
-            String key = toBlobKey(sourceDir, filePath, prefix);
-            UploadRequest.Builder uploadBuilder = UploadRequest.builder()
-                .withKey(key)
-                .withContentLength(filePath.toFile().length());
-            if (tags != null && !tags.isEmpty()) {
-              uploadBuilder.withTags(tags);
-            }
-            if (objectLock != null) {
-              uploadBuilder.withObjectLock(objectLock);
-            }
-            UploadRequest uploadRequest = uploadBuilder.build();
-            return doUpload(uploadRequest, filePath)
-                .thenAccept(response -> {
-                  if (directoryUploadRequest
-                      .isTransferStatusLoggingEnabled()) {
-                    totalBytes.addAndGet(filePath.toFile().length());
-                  }
-                })
-                .exceptionally(ex -> {
-                  synchronized (failures) {
-                    failures.add(FailedBlobUpload.builder()
-                        .source(filePath)
-                        .exception(ex)
-                        .build());
-                  }
-                  return null;
-                });
-          })
-          .collect(Collectors.toList());
-
-      CompletableFuture.allOf(
-          futures.toArray(new CompletableFuture[0])).join();
-
-      return DirectoryUploadResponse.builder()
-          .failedTransfers(failures)
-          .totalBytesTransferred(
-              directoryUploadRequest.isTransferStatusLoggingEnabled()
-                  ? totalBytes.get() : null)
-          .build();
-    }, executorService);
+    // Stage 1: blocking directory walk on an executor thread; released after.
+    return CompletableFuture.supplyAsync(
+        () -> collectFilePaths(sourceDir, directoryUploadRequest),
+        executorService)
+        // Stage 2: fan out per-file uploads and compose; no blocking join.
+        .thenCompose(filePaths -> {
+          if (filePaths.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+          }
+          List<CompletableFuture<Void>> futures = filePaths.stream()
+              .map(filePath -> {
+                String key = toBlobKey(sourceDir, filePath, prefix);
+                UploadRequest.Builder uploadBuilder = UploadRequest.builder()
+                    .withKey(key)
+                    .withContentLength(filePath.toFile().length());
+                if (tags != null && !tags.isEmpty()) {
+                  uploadBuilder.withTags(tags);
+                }
+                if (objectLock != null) {
+                  uploadBuilder.withObjectLock(objectLock);
+                }
+                UploadRequest uploadRequest = uploadBuilder.build();
+                return doUpload(uploadRequest, filePath)
+                    .thenAccept(response -> {
+                      if (directoryUploadRequest
+                          .isTransferStatusLoggingEnabled()) {
+                        totalBytes.addAndGet(filePath.toFile().length());
+                      }
+                    })
+                    .exceptionally(ex -> {
+                      failures.add(FailedBlobUpload.builder()
+                          .source(filePath)
+                          .exception(ex)
+                          .build());
+                      return null;
+                    });
+              })
+              .collect(Collectors.toList());
+          return CompletableFuture.allOf(
+              futures.toArray(new CompletableFuture[0]));
+        })
+        // Stage 3: build response after all uploads complete.
+        .thenApply(v -> DirectoryUploadResponse.builder()
+            .failedTransfers(new ArrayList<>(failures))
+            .totalBytesTransferred(
+                directoryUploadRequest.isTransferStatusLoggingEnabled()
+                    ? totalBytes.get() : null)
+            .build());
   }
 
   private List<Path> collectFilePaths(

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -71,6 +71,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -735,7 +736,8 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
 
   @Override
   protected CompletableFuture<Void> doDeleteDirectory(String prefix) {
-    List<CompletableFuture<Void>> futures = new ArrayList<>();
+    List<CompletableFuture<Void>> futures =
+        Collections.synchronizedList(new ArrayList<>());
 
     Consumer<ListBlobsBatch> consumer =
         batch -> {

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -40,6 +40,7 @@ import com.salesforce.multicloudj.blob.driver.DirectoryUploadRequest;
 import com.salesforce.multicloudj.blob.driver.DirectoryUploadResponse;
 import com.salesforce.multicloudj.blob.driver.DownloadRequest;
 import com.salesforce.multicloudj.blob.driver.DownloadResponse;
+import com.salesforce.multicloudj.blob.driver.FailedBlobDownload;
 import com.salesforce.multicloudj.blob.driver.FailedBlobUpload;
 import com.salesforce.multicloudj.blob.driver.ListBlobsBatch;
 import com.salesforce.multicloudj.blob.driver.ListBlobsPageRequest;
@@ -518,7 +519,116 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
   @Override
   protected CompletableFuture<DirectoryDownloadResponse> doDownloadDirectory(
       DirectoryDownloadRequest directoryDownloadRequest) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return CompletableFuture.supplyAsync(() -> {
+      Path targetDir = Paths.get(
+          directoryDownloadRequest.getLocalDestinationDirectory())
+          .toAbsolutePath().normalize();
+      try {
+        Files.createDirectories(targetDir);
+      } catch (IOException e) {
+        throw new SubstrateSdkException(
+            "Failed to create destination directory: " + targetDir, e);
+      }
+
+      String rawPrefix = directoryDownloadRequest.getPrefixToDownload();
+      String prefix = (rawPrefix != null && !rawPrefix.isEmpty()
+          && !rawPrefix.endsWith("/"))
+          ? rawPrefix + "/" : rawPrefix;
+
+      List<String> prefixesToExclude =
+          directoryDownloadRequest.getPrefixesToExclude();
+
+      List<BlobInfo> blobInfos = new ArrayList<>();
+      ListBlobsRequest listRequest = ListBlobsRequest.builder()
+          .withPrefix(prefix)
+          .build();
+      doList(listRequest, batch -> {
+        for (BlobInfo blob : batch.getBlobs()) {
+          if (isFolderMarker(blob)) {
+            continue;
+          }
+          if (isExcluded(blob.getKey(), prefixesToExclude)) {
+            continue;
+          }
+          synchronized (blobInfos) {
+            blobInfos.add(blob);
+          }
+        }
+      }).join();
+
+      if (blobInfos.isEmpty()) {
+        return DirectoryDownloadResponse.builder()
+            .failedTransfers(new ArrayList<>())
+            .build();
+      }
+
+      AtomicLong totalBytes = new AtomicLong(0L);
+      List<FailedBlobDownload> failures = new ArrayList<>();
+
+      List<CompletableFuture<Void>> futures = blobInfos.stream()
+          .map(blob -> {
+            String key = blob.getKey();
+            String relative = (prefix != null && key.startsWith(prefix))
+                ? key.substring(prefix.length()) : key;
+            Path destination = targetDir.resolve(relative).normalize();
+            Path parent = destination.getParent();
+            if (parent != null) {
+              try {
+                Files.createDirectories(parent);
+              } catch (IOException e) {
+                throw new SubstrateSdkException(
+                    "Failed to create directories: " + parent, e);
+              }
+            }
+
+            DownloadRequest downloadRequest = DownloadRequest.builder()
+                .withKey(key)
+                .build();
+            return doDownload(downloadRequest, destination)
+                .thenAccept(response -> {
+                  if (directoryDownloadRequest
+                      .isTransferStatusLoggingEnabled()) {
+                    totalBytes.addAndGet(blob.getObjectSize());
+                  }
+                })
+                .exceptionally(ex -> {
+                  synchronized (failures) {
+                    failures.add(FailedBlobDownload.builder()
+                        .destination(destination)
+                        .exception(ex)
+                        .build());
+                  }
+                  return null;
+                });
+          })
+          .collect(Collectors.toList());
+
+      CompletableFuture.allOf(
+          futures.toArray(new CompletableFuture[0])).join();
+
+      return DirectoryDownloadResponse.builder()
+          .failedTransfers(failures)
+          .totalBytesTransferred(
+              directoryDownloadRequest.isTransferStatusLoggingEnabled()
+                  ? totalBytes.get() : null)
+          .build();
+    }, executorService);
+  }
+
+  private boolean isFolderMarker(BlobInfo blob) {
+    return blob.getKey().endsWith("/") && blob.getObjectSize() == 0;
+  }
+
+  private boolean isExcluded(String key, List<String> prefixesToExclude) {
+    if (prefixesToExclude == null || prefixesToExclude.isEmpty()) {
+      return false;
+    }
+    for (String excludePrefix : prefixesToExclude) {
+      if (key.startsWith(excludePrefix)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -29,6 +29,7 @@ import com.salesforce.multicloudj.blob.async.driver.AbstractAsyncBlobStore;
 import com.salesforce.multicloudj.blob.async.driver.AsyncBlobStore;
 import com.salesforce.multicloudj.blob.async.driver.AsyncBlobStoreProvider;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
+import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.BlobStoreValidator;
 import com.salesforce.multicloudj.blob.driver.ByteArray;
@@ -83,6 +84,8 @@ import lombok.Getter;
 
 /** Alibaba Cloud OSS native async implementation of AsyncBlobStore. */
 public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkService {
+
+  private static final int MAX_OBJECTS_PER_DELETE = 1000;
 
   private final OSSAsyncClient asyncClient;
   // syncClient is required for operations not available on OSSAsyncClient:
@@ -732,7 +735,21 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
 
   @Override
   protected CompletableFuture<Void> doDeleteDirectory(String prefix) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+    Consumer<ListBlobsBatch> consumer =
+        batch -> {
+          List<List<BlobInfo>> partitionedBlobLists =
+              transformer.partitionList(batch.getBlobs(), MAX_OBJECTS_PER_DELETE);
+          for (List<BlobInfo> blobList : partitionedBlobLists) {
+            futures.add(doDelete(transformer.toBlobIdentifiers(blobList)));
+          }
+        };
+    CompletableFuture<Void> listFuture =
+        doList(ListBlobsRequest.builder().withPrefix(prefix).build(), consumer);
+    futures.add(listFuture);
+    return listFuture.thenCompose(v ->
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])));
   }
 
   public static Builder builder() {

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -40,6 +40,7 @@ import com.salesforce.multicloudj.blob.driver.DirectoryUploadRequest;
 import com.salesforce.multicloudj.blob.driver.DirectoryUploadResponse;
 import com.salesforce.multicloudj.blob.driver.DownloadRequest;
 import com.salesforce.multicloudj.blob.driver.DownloadResponse;
+import com.salesforce.multicloudj.blob.driver.FailedBlobUpload;
 import com.salesforce.multicloudj.blob.driver.ListBlobsBatch;
 import com.salesforce.multicloudj.blob.driver.ListBlobsPageRequest;
 import com.salesforce.multicloudj.blob.driver.ListBlobsPageResponse;
@@ -62,15 +63,21 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.Getter;
 
 /** Alibaba Cloud OSS native async implementation of AsyncBlobStore. */
@@ -517,7 +524,100 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
   @Override
   protected CompletableFuture<DirectoryUploadResponse> doUploadDirectory(
       DirectoryUploadRequest directoryUploadRequest) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return CompletableFuture.supplyAsync(() -> {
+      Path sourceDir = Paths.get(
+          directoryUploadRequest.getLocalSourceDirectory())
+          .toAbsolutePath().normalize();
+      List<Path> filePaths = collectFilePaths(
+          sourceDir, directoryUploadRequest);
+      if (filePaths.isEmpty()) {
+        return DirectoryUploadResponse.builder()
+            .failedTransfers(new ArrayList<>())
+            .build();
+      }
+
+      String prefix = directoryUploadRequest.getPrefix();
+      AtomicLong totalBytes = new AtomicLong(0L);
+      List<FailedBlobUpload> failures = new ArrayList<>();
+
+      Map<String, String> tags = directoryUploadRequest.getTags();
+      var objectLock = directoryUploadRequest.getObjectLock();
+
+      List<CompletableFuture<Void>> futures = filePaths.stream()
+          .map(filePath -> {
+            String key = toBlobKey(sourceDir, filePath, prefix);
+            UploadRequest.Builder uploadBuilder = UploadRequest.builder()
+                .withKey(key)
+                .withContentLength(filePath.toFile().length());
+            if (tags != null && !tags.isEmpty()) {
+              uploadBuilder.withTags(tags);
+            }
+            if (objectLock != null) {
+              uploadBuilder.withObjectLock(objectLock);
+            }
+            UploadRequest uploadRequest = uploadBuilder.build();
+            return doUpload(uploadRequest, filePath)
+                .thenAccept(response -> {
+                  if (directoryUploadRequest
+                      .isTransferStatusLoggingEnabled()) {
+                    totalBytes.addAndGet(filePath.toFile().length());
+                  }
+                })
+                .exceptionally(ex -> {
+                  synchronized (failures) {
+                    failures.add(FailedBlobUpload.builder()
+                        .source(filePath)
+                        .exception(ex)
+                        .build());
+                  }
+                  return null;
+                });
+          })
+          .collect(Collectors.toList());
+
+      CompletableFuture.allOf(
+          futures.toArray(new CompletableFuture[0])).join();
+
+      return DirectoryUploadResponse.builder()
+          .failedTransfers(failures)
+          .totalBytesTransferred(
+              directoryUploadRequest.isTransferStatusLoggingEnabled()
+                  ? totalBytes.get() : null)
+          .build();
+    }, executorService);
+  }
+
+  private List<Path> collectFilePaths(
+      Path sourceDir, DirectoryUploadRequest request) {
+    try (Stream<Path> paths = request.isFollowSymbolicLinks()
+        ? Files.walk(sourceDir, Integer.MAX_VALUE,
+            FileVisitOption.FOLLOW_LINKS)
+        : Files.walk(sourceDir)) {
+      return paths
+          .filter(Files::isRegularFile)
+          .filter(path -> {
+            if (!request.isIncludeSubFolders()) {
+              Path relativePath = sourceDir.relativize(path);
+              return relativePath.getParent() == null;
+            }
+            return true;
+          })
+          .collect(Collectors.toList());
+    } catch (IOException e) {
+      throw new SubstrateSdkException(
+          "Failed to traverse directory: " + sourceDir, e);
+    }
+  }
+
+  private String toBlobKey(Path sourceDir, Path filePath, String prefix) {
+    Path relativePath = sourceDir.relativize(filePath);
+    String key = relativePath.toString().replace("\\", "/");
+    if (prefix != null && !prefix.isEmpty()) {
+      String normalizedPrefix =
+          prefix.endsWith("/") ? prefix : prefix + "/";
+      key = normalizedPrefix + key;
+    }
+    return key;
   }
 
   @Override

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -1401,4 +1401,93 @@ public class AliAsyncBlobStoreTest {
         any(DeleteMultipleObjectsRequest.class),
         any(OperationOptions.class));
   }
+
+  @Test
+  void testUploadDirectoryNonExistentPath() {
+    DirectoryUploadRequest request = DirectoryUploadRequest.builder()
+        .localSourceDirectory("/non/existent/path")
+        .prefix("pfx")
+        .includeSubFolders(true)
+        .build();
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.uploadDirectory(request).get());
+    assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testUploadDirectoryFileUploadFailed(@TempDir Path tempDir)
+      throws Exception {
+    Files.writeString(tempDir.resolve("fail.txt"), "will fail");
+
+    RuntimeException cause = new RuntimeException("upload error");
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    DirectoryUploadRequest request = DirectoryUploadRequest.builder()
+        .localSourceDirectory(tempDir.toString())
+        .prefix("pfx")
+        .includeSubFolders(true)
+        .build();
+    DirectoryUploadResponse response = store.uploadDirectory(request).get();
+
+    assertNotNull(response);
+    assertTrue(response.getFailedTransfers().size() > 0);
+  }
+
+  @Test
+  void testDownloadDirectoryListFailed() {
+    RuntimeException cause = new RuntimeException("list error");
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    DirectoryDownloadRequest request = DirectoryDownloadRequest.builder()
+        .prefixToDownload("dir/")
+        .localDestinationDirectory("/tmp/download-dir")
+        .build();
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.downloadDirectory(request).get());
+    assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testDeleteDirectoryListFailed() {
+    RuntimeException cause = new RuntimeException("access denied");
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.deleteDirectory("dir/").get());
+    assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testDeleteDirectoryBatchDeleteFailed() throws Exception {
+    ObjectSummary obj = mock(ObjectSummary.class);
+    when(obj.key()).thenReturn("dir/file.txt");
+    when(obj.size()).thenReturn(100L);
+
+    ListObjectsV2Result listResult = mock(ListObjectsV2Result.class);
+    when(listResult.contents()).thenReturn(List.of(obj));
+    when(listResult.commonPrefixes()).thenReturn(null);
+    when(listResult.isTruncated()).thenReturn(false);
+    when(listResult.nextContinuationToken()).thenReturn(null);
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(listResult));
+
+    RuntimeException cause = new RuntimeException("batch delete error");
+    when(mockAsyncClient.deleteMultipleObjectsAsync(
+        any(DeleteMultipleObjectsRequest.class),
+        any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.failedFuture(cause));
+
+    ExecutionException ex = assertThrows(ExecutionException.class,
+        () -> store.deleteDirectory("dir/").get());
+    assertNotNull(ex.getCause());
+  }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -64,6 +64,8 @@ import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.BlobStoreValidator;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
 import com.salesforce.multicloudj.blob.driver.CopyResponse;
+import com.salesforce.multicloudj.blob.driver.DirectoryUploadRequest;
+import com.salesforce.multicloudj.blob.driver.DirectoryUploadResponse;
 import com.salesforce.multicloudj.blob.driver.DownloadRequest;
 import com.salesforce.multicloudj.blob.driver.DownloadResponse;
 import com.salesforce.multicloudj.blob.driver.ListBlobsBatch;
@@ -1055,5 +1057,77 @@ public class AliAsyncBlobStoreTest {
     ExecutionException ex = assertThrows(ExecutionException.class,
         () -> store.generatePresignedUrl(request).get());
     assertNotNull(ex.getCause());
+  }
+
+  @Test
+  void testUploadDirectory(@TempDir Path tempDir) throws Exception {
+    Files.writeString(tempDir.resolve("file1.txt"), "content1");
+    Files.writeString(tempDir.resolve("file2.txt"), "content2");
+
+    PutObjectResult mockResult = mock(PutObjectResult.class);
+    when(mockResult.versionId()).thenReturn(null);
+    when(mockResult.eTag()).thenReturn("\"etag\"");
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    DirectoryUploadRequest request = DirectoryUploadRequest.builder()
+        .localSourceDirectory(tempDir.toString())
+        .prefix("upload-prefix")
+        .includeSubFolders(true)
+        .build();
+    DirectoryUploadResponse response =
+        store.uploadDirectory(request).get();
+
+    assertNotNull(response);
+    assertNotNull(response.getFailedTransfers());
+    assertEquals(0, response.getFailedTransfers().size());
+  }
+
+  @Test
+  void testUploadDirectoryWithSubFolders(@TempDir Path tempDir)
+      throws Exception {
+    Files.writeString(tempDir.resolve("root.txt"), "root");
+    Path subDir = Files.createDirectory(tempDir.resolve("sub"));
+    Files.writeString(subDir.resolve("nested.txt"), "nested");
+
+    PutObjectResult mockResult = mock(PutObjectResult.class);
+    when(mockResult.versionId()).thenReturn(null);
+    when(mockResult.eTag()).thenReturn("\"etag\"");
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    DirectoryUploadRequest requestWithSub = DirectoryUploadRequest.builder()
+        .localSourceDirectory(tempDir.toString())
+        .prefix("pfx")
+        .includeSubFolders(true)
+        .build();
+    DirectoryUploadResponse responseWithSub =
+        store.uploadDirectory(requestWithSub).get();
+    assertEquals(0, responseWithSub.getFailedTransfers().size());
+
+    DirectoryUploadRequest requestNoSub = DirectoryUploadRequest.builder()
+        .localSourceDirectory(tempDir.toString())
+        .prefix("pfx")
+        .includeSubFolders(false)
+        .build();
+    DirectoryUploadResponse responseNoSub =
+        store.uploadDirectory(requestNoSub).get();
+    assertEquals(0, responseNoSub.getFailedTransfers().size());
+  }
+
+  @Test
+  void testUploadDirectoryEmptyDir(@TempDir Path tempDir) throws Exception {
+    DirectoryUploadRequest request = DirectoryUploadRequest.builder()
+        .localSourceDirectory(tempDir.toString())
+        .prefix("empty")
+        .includeSubFolders(true)
+        .build();
+    DirectoryUploadResponse response =
+        store.uploadDirectory(request).get();
+
+    assertNotNull(response);
+    assertEquals(0, response.getFailedTransfers().size());
   }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -1312,5 +1313,92 @@ public class AliAsyncBlobStoreTest {
     assertNotNull(response);
     assertEquals(0, response.getFailedTransfers().size());
     assertEquals(1024L, response.getTotalBytesTransferred());
+  }
+
+  @Test
+  void testDeleteDirectory() throws Exception {
+    ObjectSummary obj1 = mock(ObjectSummary.class);
+    when(obj1.key()).thenReturn("dir/file1.txt");
+    when(obj1.size()).thenReturn(100L);
+    ObjectSummary obj2 = mock(ObjectSummary.class);
+    when(obj2.key()).thenReturn("dir/file2.txt");
+    when(obj2.size()).thenReturn(200L);
+
+    ListObjectsV2Result listResult = mock(ListObjectsV2Result.class);
+    when(listResult.contents()).thenReturn(List.of(obj1, obj2));
+    when(listResult.commonPrefixes()).thenReturn(null);
+    when(listResult.isTruncated()).thenReturn(false);
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(listResult));
+
+    DeleteMultipleObjectsResult deleteResult =
+        mock(DeleteMultipleObjectsResult.class);
+    when(mockAsyncClient.deleteMultipleObjectsAsync(
+        any(DeleteMultipleObjectsRequest.class),
+        any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(deleteResult));
+
+    store.deleteDirectory("dir/").get();
+
+    verify(mockAsyncClient, times(1)).deleteMultipleObjectsAsync(
+        any(DeleteMultipleObjectsRequest.class),
+        any(OperationOptions.class));
+  }
+
+  @Test
+  void testDeleteDirectoryEmpty() throws Exception {
+    ListObjectsV2Result listResult = mock(ListObjectsV2Result.class);
+    when(listResult.contents()).thenReturn(List.of());
+    when(listResult.commonPrefixes()).thenReturn(null);
+    when(listResult.isTruncated()).thenReturn(false);
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(listResult));
+
+    store.deleteDirectory("empty-dir/").get();
+
+    verify(mockAsyncClient, never()).deleteMultipleObjectsAsync(
+        any(DeleteMultipleObjectsRequest.class),
+        any(OperationOptions.class));
+  }
+
+  @Test
+  void testDeleteDirectoryWithPagination() throws Exception {
+    ObjectSummary obj1 = mock(ObjectSummary.class);
+    when(obj1.key()).thenReturn("dir/page1.txt");
+    when(obj1.size()).thenReturn(50L);
+    ObjectSummary obj2 = mock(ObjectSummary.class);
+    when(obj2.key()).thenReturn("dir/page2.txt");
+    when(obj2.size()).thenReturn(60L);
+
+    ListObjectsV2Result firstPage = mock(ListObjectsV2Result.class);
+    when(firstPage.contents()).thenReturn(List.of(obj1));
+    when(firstPage.commonPrefixes()).thenReturn(null);
+    when(firstPage.isTruncated()).thenReturn(true);
+    when(firstPage.nextContinuationToken()).thenReturn("token1");
+
+    ListObjectsV2Result secondPage = mock(ListObjectsV2Result.class);
+    when(secondPage.contents()).thenReturn(List.of(obj2));
+    when(secondPage.commonPrefixes()).thenReturn(null);
+    when(secondPage.isTruncated()).thenReturn(false);
+
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(firstPage))
+        .thenReturn(CompletableFuture.completedFuture(secondPage));
+
+    DeleteMultipleObjectsResult deleteResult =
+        mock(DeleteMultipleObjectsResult.class);
+    when(mockAsyncClient.deleteMultipleObjectsAsync(
+        any(DeleteMultipleObjectsRequest.class),
+        any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(deleteResult));
+
+    store.deleteDirectory("dir/").get();
+
+    verify(mockAsyncClient, times(2)).deleteMultipleObjectsAsync(
+        any(DeleteMultipleObjectsRequest.class),
+        any(OperationOptions.class));
   }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -64,6 +64,8 @@ import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.BlobStoreValidator;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
 import com.salesforce.multicloudj.blob.driver.CopyResponse;
+import com.salesforce.multicloudj.blob.driver.DirectoryDownloadRequest;
+import com.salesforce.multicloudj.blob.driver.DirectoryDownloadResponse;
 import com.salesforce.multicloudj.blob.driver.DirectoryUploadRequest;
 import com.salesforce.multicloudj.blob.driver.DirectoryUploadResponse;
 import com.salesforce.multicloudj.blob.driver.DownloadRequest;
@@ -1129,5 +1131,186 @@ public class AliAsyncBlobStoreTest {
 
     assertNotNull(response);
     assertEquals(0, response.getFailedTransfers().size());
+  }
+
+  @Test
+  void testDownloadDirectory(@TempDir Path tempDir) throws Exception {
+    ObjectSummary obj1 = mock(ObjectSummary.class);
+    when(obj1.key()).thenReturn("prefix/file1.txt");
+    when(obj1.size()).thenReturn(6L);
+    ObjectSummary obj2 = mock(ObjectSummary.class);
+    when(obj2.key()).thenReturn("prefix/sub/file2.txt");
+    when(obj2.size()).thenReturn(7L);
+
+    ListObjectsV2Result listResult = mock(ListObjectsV2Result.class);
+    when(listResult.contents()).thenReturn(List.of(obj1, obj2));
+    when(listResult.commonPrefixes()).thenReturn(null);
+    when(listResult.isTruncated()).thenReturn(false);
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(listResult));
+
+    byte[] content = "hello1".getBytes(StandardCharsets.UTF_8);
+    when(mockAsyncClient.getObjectAsync(
+        any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenAnswer(invocation -> {
+          GetObjectResult result = mock(GetObjectResult.class);
+          when(result.body()).thenReturn(
+              new ByteArrayInputStream(content));
+          when(result.contentLength()).thenReturn((long) content.length);
+          when(result.eTag()).thenReturn("\"e\"");
+          return CompletableFuture.completedFuture(result);
+        });
+
+    DirectoryDownloadRequest request = DirectoryDownloadRequest.builder()
+        .prefixToDownload("prefix")
+        .localDestinationDirectory(tempDir.toString())
+        .build();
+    DirectoryDownloadResponse response =
+        store.downloadDirectory(request).get();
+
+    assertNotNull(response);
+    assertEquals(0, response.getFailedTransfers().size());
+    assertTrue(Files.exists(tempDir.resolve("file1.txt")));
+    assertTrue(Files.exists(tempDir.resolve("sub/file2.txt")));
+  }
+
+  @Test
+  void testDownloadDirectorySkipsFolderMarkers(
+      @TempDir Path tempDir) throws Exception {
+    ObjectSummary realObj = mock(ObjectSummary.class);
+    when(realObj.key()).thenReturn("dir/file.txt");
+    when(realObj.size()).thenReturn(5L);
+    ObjectSummary folderMarker = mock(ObjectSummary.class);
+    when(folderMarker.key()).thenReturn("dir/subfolder/");
+    when(folderMarker.size()).thenReturn(0L);
+
+    ListObjectsV2Result listResult = mock(ListObjectsV2Result.class);
+    when(listResult.contents()).thenReturn(List.of(realObj, folderMarker));
+    when(listResult.commonPrefixes()).thenReturn(null);
+    when(listResult.isTruncated()).thenReturn(false);
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(listResult));
+
+    byte[] content = "hello".getBytes(StandardCharsets.UTF_8);
+    GetObjectResult getResult = mock(GetObjectResult.class);
+    when(getResult.body()).thenReturn(new ByteArrayInputStream(content));
+    when(getResult.contentLength()).thenReturn((long) content.length);
+    when(getResult.eTag()).thenReturn("\"e\"");
+    when(mockAsyncClient.getObjectAsync(
+        any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(getResult));
+
+    DirectoryDownloadRequest request = DirectoryDownloadRequest.builder()
+        .prefixToDownload("dir")
+        .localDestinationDirectory(tempDir.toString())
+        .build();
+    DirectoryDownloadResponse response =
+        store.downloadDirectory(request).get();
+
+    assertNotNull(response);
+    assertEquals(0, response.getFailedTransfers().size());
+    assertTrue(Files.exists(tempDir.resolve("file.txt")));
+    assertArrayEquals(content, Files.readAllBytes(tempDir.resolve("file.txt")));
+  }
+
+  @Test
+  void testDownloadDirectoryWithPrefixExclusions(
+      @TempDir Path tempDir) throws Exception {
+    ObjectSummary included = mock(ObjectSummary.class);
+    when(included.key()).thenReturn("data/keep.txt");
+    when(included.size()).thenReturn(4L);
+    ObjectSummary excluded = mock(ObjectSummary.class);
+    when(excluded.key()).thenReturn("data/logs/debug.log");
+    when(excluded.size()).thenReturn(10L);
+
+    ListObjectsV2Result listResult = mock(ListObjectsV2Result.class);
+    when(listResult.contents()).thenReturn(List.of(included, excluded));
+    when(listResult.commonPrefixes()).thenReturn(null);
+    when(listResult.isTruncated()).thenReturn(false);
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(listResult));
+
+    byte[] content = "keep".getBytes(StandardCharsets.UTF_8);
+    GetObjectResult getResult = mock(GetObjectResult.class);
+    when(getResult.body()).thenReturn(new ByteArrayInputStream(content));
+    when(getResult.contentLength()).thenReturn((long) content.length);
+    when(getResult.eTag()).thenReturn("\"e\"");
+    when(mockAsyncClient.getObjectAsync(
+        any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(getResult));
+
+    DirectoryDownloadRequest request = DirectoryDownloadRequest.builder()
+        .prefixToDownload("data")
+        .localDestinationDirectory(tempDir.toString())
+        .prefixesToExclude(List.of("data/logs/"))
+        .build();
+    DirectoryDownloadResponse response =
+        store.downloadDirectory(request).get();
+
+    assertNotNull(response);
+    assertEquals(0, response.getFailedTransfers().size());
+    assertTrue(Files.exists(tempDir.resolve("keep.txt")));
+    assertTrue(Files.notExists(tempDir.resolve("logs/debug.log")));
+  }
+
+  @Test
+  void testDownloadDirectoryEmpty(@TempDir Path tempDir) throws Exception {
+    ListObjectsV2Result listResult = mock(ListObjectsV2Result.class);
+    when(listResult.contents()).thenReturn(List.of());
+    when(listResult.commonPrefixes()).thenReturn(null);
+    when(listResult.isTruncated()).thenReturn(false);
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(listResult));
+
+    DirectoryDownloadRequest request = DirectoryDownloadRequest.builder()
+        .prefixToDownload("empty-prefix")
+        .localDestinationDirectory(tempDir.toString())
+        .build();
+    DirectoryDownloadResponse response =
+        store.downloadDirectory(request).get();
+
+    assertNotNull(response);
+    assertEquals(0, response.getFailedTransfers().size());
+  }
+
+  @Test
+  void testDownloadDirectoryWithTransferLogging(
+      @TempDir Path tempDir) throws Exception {
+    ObjectSummary obj = mock(ObjectSummary.class);
+    when(obj.key()).thenReturn("log/data.bin");
+    when(obj.size()).thenReturn(1024L);
+
+    ListObjectsV2Result listResult = mock(ListObjectsV2Result.class);
+    when(listResult.contents()).thenReturn(List.of(obj));
+    when(listResult.commonPrefixes()).thenReturn(null);
+    when(listResult.isTruncated()).thenReturn(false);
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(listResult));
+
+    byte[] content = new byte[1024];
+    GetObjectResult getResult = mock(GetObjectResult.class);
+    when(getResult.body()).thenReturn(new ByteArrayInputStream(content));
+    when(getResult.contentLength()).thenReturn(1024L);
+    when(getResult.eTag()).thenReturn("\"e\"");
+    when(mockAsyncClient.getObjectAsync(
+        any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(getResult));
+
+    DirectoryDownloadRequest request = DirectoryDownloadRequest.builder()
+        .prefixToDownload("log")
+        .localDestinationDirectory(tempDir.toString())
+        .transferStatusLoggingEnabled(true)
+        .build();
+    DirectoryDownloadResponse response =
+        store.downloadDirectory(request).get();
+
+    assertNotNull(response);
+    assertEquals(0, response.getFailedTransfers().size());
+    assertEquals(1024L, response.getTotalBytesTransferred());
   }
 }


### PR DESCRIPTION
## Summary

Add async directory related operations support for Ali blobstore.

Includes unit tests with mocked SDK client. Performed manual integration testing against live Ali environment to verify functionality.

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
