### PR TITLE
blobstore: implement retry configuration for Ali OSS sync and async clients

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -31,6 +31,7 @@ import com.aliyun.sdk.service.oss2.models.PutObjectResult;
 import com.aliyun.sdk.service.oss2.models.PutObjectTaggingRequest;
 import com.aliyun.sdk.service.oss2.models.UploadPartRequest;
 import com.aliyun.sdk.service.oss2.models.UploadPartResult;
+import com.aliyun.sdk.service.oss2.retry.Retryer;
 import com.aliyun.sdk.service.oss2.transport.BinaryData;
 import com.google.auto.service.AutoService;
 import com.salesforce.multicloudj.blob.driver.AbstractBlobStore;
@@ -70,6 +71,7 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -717,6 +719,16 @@ public class AliBlobStore extends AbstractBlobStore {
         clientBuilder.proxyHost(
             builder.getProxyEndpoint().getHost()
                 + ":" + builder.getProxyEndpoint().getPort());
+      }
+      if (builder.getRetryConfig() != null) {
+        Retryer retryer = AliTransformer.toAliRetryer(builder.getRetryConfig());
+        if (retryer != null) {
+          clientBuilder.retryer(retryer);
+        }
+        if (builder.getRetryConfig().getAttemptTimeout() != null) {
+          clientBuilder.readWriteTimeout(
+              Duration.ofMillis(builder.getRetryConfig().getAttemptTimeout()));
+        }
       }
 
       return clientBuilder.build();

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -58,6 +58,7 @@ import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.retries.RetryConfig;
 import com.salesforce.multicloudj.common.util.HexUtil;
 import java.io.InputStream;
@@ -621,14 +622,14 @@ public class AliTransformer {
    */
   public static Retryer toAliRetryer(RetryConfig config) {
     if (config == null) {
-      return null;
+      throw new InvalidArgumentException("RetryConfig cannot be null");
     }
 
     StandardRetryer.Builder builder = StandardRetryer.newBuilder();
 
     if (config.getMaxAttempts() != null) {
       if (config.getMaxAttempts() <= 0) {
-        throw new IllegalArgumentException(
+        throw new InvalidArgumentException(
             "RetryConfig.maxAttempts must be greater than 0, got: "
                 + config.getMaxAttempts());
       }
@@ -639,12 +640,12 @@ public class AliTransformer {
       BackoffDelayer backoff;
       if (config.getMode() == RetryConfig.Mode.EXPONENTIAL) {
         if (config.getInitialDelayMillis() <= 0) {
-          throw new IllegalArgumentException(
+          throw new InvalidArgumentException(
               "RetryConfig.initialDelayMillis must be greater than 0 for EXPONENTIAL mode, got: "
                   + config.getInitialDelayMillis());
         }
         if (config.getMaxDelayMillis() <= 0) {
-          throw new IllegalArgumentException(
+          throw new InvalidArgumentException(
               "RetryConfig.maxDelayMillis must be greater than 0 for EXPONENTIAL mode, got: "
                   + config.getMaxDelayMillis());
         }
@@ -653,7 +654,7 @@ public class AliTransformer {
             Duration.ofMillis(config.getMaxDelayMillis()));
       } else {
         if (config.getFixedDelayMillis() <= 0) {
-          throw new IllegalArgumentException(
+          throw new InvalidArgumentException(
               "RetryConfig.fixedDelayMillis must be greater than 0 for FIXED mode, got: "
                   + config.getFixedDelayMillis());
         }

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -32,6 +32,11 @@ import com.aliyun.sdk.service.oss2.models.TagSet;
 import com.aliyun.sdk.service.oss2.models.Tagging;
 import com.aliyun.sdk.service.oss2.models.UploadPartRequest;
 import com.aliyun.sdk.service.oss2.models.UploadPartResult;
+import com.aliyun.sdk.service.oss2.retry.BackoffDelayer;
+import com.aliyun.sdk.service.oss2.retry.EqualJitterBackoff;
+import com.aliyun.sdk.service.oss2.retry.FixedDelayBackoff;
+import com.aliyun.sdk.service.oss2.retry.Retryer;
+import com.aliyun.sdk.service.oss2.retry.StandardRetryer;
 import com.aliyun.sdk.service.oss2.transport.BinaryData;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobInfo;
@@ -53,8 +58,10 @@ import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
+import com.salesforce.multicloudj.common.retries.RetryConfig;
 import com.salesforce.multicloudj.common.util.HexUtil;
 import java.io.InputStream;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -595,5 +602,67 @@ public class AliTransformer {
         : List.of();
 
     return new ListBlobsBatch(blobs, commonPrefixes);
+  }
+
+  /**
+   * Converts a cloud-agnostic {@link RetryConfig} to an Ali OSS v2 SDK {@link Retryer}.
+   *
+   * <p>Mapping:
+   * <ul>
+   *   <li>EXPONENTIAL mode → {@link EqualJitterBackoff} with baseDelay and maxBackoff</li>
+   *   <li>FIXED mode → {@link FixedDelayBackoff} with constant delay</li>
+   *   <li>maxAttempts → {@link StandardRetryer.Builder#maxAttempts(Integer)}</li>
+   * </ul>
+   *
+   * <p>Note: The Ali OSS v2 SDK does not support a totalTimeout equivalent (a hard deadline
+   * across all retry attempts combined). This field from RetryConfig is not applied. The
+   * attemptTimeout is handled separately via readWriteTimeout on the client builder.
+   * The multiplier field is not directly configurable — EqualJitterBackoff uses 2x internally.
+   */
+  public static Retryer toAliRetryer(RetryConfig config) {
+    if (config == null) {
+      return null;
+    }
+
+    StandardRetryer.Builder builder = StandardRetryer.newBuilder();
+
+    if (config.getMaxAttempts() != null) {
+      if (config.getMaxAttempts() <= 0) {
+        throw new IllegalArgumentException(
+            "RetryConfig.maxAttempts must be greater than 0, got: "
+                + config.getMaxAttempts());
+      }
+      builder.maxAttempts(config.getMaxAttempts());
+    }
+
+    if (config.getMode() != null) {
+      BackoffDelayer backoff;
+      if (config.getMode() == RetryConfig.Mode.EXPONENTIAL) {
+        if (config.getInitialDelayMillis() <= 0) {
+          throw new IllegalArgumentException(
+              "RetryConfig.initialDelayMillis must be greater than 0 for EXPONENTIAL mode, got: "
+                  + config.getInitialDelayMillis());
+        }
+        if (config.getMaxDelayMillis() <= 0) {
+          throw new IllegalArgumentException(
+              "RetryConfig.maxDelayMillis must be greater than 0 for EXPONENTIAL mode, got: "
+                  + config.getMaxDelayMillis());
+        }
+        backoff = new EqualJitterBackoff(
+            Duration.ofMillis(config.getInitialDelayMillis()),
+            Duration.ofMillis(config.getMaxDelayMillis()));
+      } else {
+        if (config.getFixedDelayMillis() <= 0) {
+          throw new IllegalArgumentException(
+              "RetryConfig.fixedDelayMillis must be greater than 0 for FIXED mode, got: "
+                  + config.getFixedDelayMillis());
+        }
+        backoff = new FixedDelayBackoff(
+            Duration.ofMillis(config.getFixedDelayMillis()));
+      }
+      builder.backoffDelayer(backoff);
+    }
+
+    return builder.build();
   }
 }

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -17,6 +17,7 @@ import com.aliyun.sdk.service.oss2.models.ListObjectsV2Request;
 import com.aliyun.sdk.service.oss2.models.PresignResult;
 import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
 import com.aliyun.sdk.service.oss2.models.PutObjectTaggingRequest;
+import com.aliyun.sdk.service.oss2.retry.Retryer;
 import com.aliyun.sdk.service.oss2.transfermanager.DownloadError;
 import com.aliyun.sdk.service.oss2.transfermanager.Downloader;
 import com.aliyun.sdk.service.oss2.transport.BinaryData;
@@ -560,6 +561,8 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
           OSSCredentialsProvider.getCredentialsProvider(
               getCredentialsOverrider(), getRegion());
 
+      Retryer retryer = AliTransformer.toAliRetryer(getRetryConfig());
+
       OSSAsyncClient async = this.asyncClient;
       if (async == null && creds != null) {
         var asyncBuilder = OSSAsyncClient.newBuilder()
@@ -575,6 +578,14 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
         }
         if (getSocketTimeout() != null) {
           asyncBuilder.readWriteTimeout(getSocketTimeout());
+        }
+        if (retryer != null) {
+          asyncBuilder.retryer(retryer);
+        }
+        if (getRetryConfig() != null
+            && getRetryConfig().getAttemptTimeout() != null) {
+          asyncBuilder.readWriteTimeout(
+              java.time.Duration.ofMillis(getRetryConfig().getAttemptTimeout()));
         }
         async = asyncBuilder.build();
       }
@@ -594,6 +605,14 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
         }
         if (getSocketTimeout() != null) {
           syncBuilder.readWriteTimeout(getSocketTimeout());
+        }
+        if (retryer != null) {
+          syncBuilder.retryer(retryer);
+        }
+        if (getRetryConfig() != null
+            && getRetryConfig().getAttemptTimeout() != null) {
+          syncBuilder.readWriteTimeout(
+              java.time.Duration.ofMillis(getRetryConfig().getAttemptTimeout()));
         }
         sync = syncBuilder.build();
       }

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -576,16 +576,19 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
               getProxyEndpoint().getHost()
                   + ":" + getProxyEndpoint().getPort());
         }
-        if (getSocketTimeout() != null) {
-          asyncBuilder.readWriteTimeout(getSocketTimeout());
-        }
         if (retryer != null) {
           asyncBuilder.retryer(retryer);
         }
+        // socketTimeout and RetryConfig.attemptTimeout both map to the Ali SDK's
+        // single readWriteTimeout setting. When both are set, attemptTimeout (the
+        // more specific per-attempt deadline) takes precedence over the
+        // transport-level socketTimeout.
         if (getRetryConfig() != null
             && getRetryConfig().getAttemptTimeout() != null) {
           asyncBuilder.readWriteTimeout(
               java.time.Duration.ofMillis(getRetryConfig().getAttemptTimeout()));
+        } else if (getSocketTimeout() != null) {
+          asyncBuilder.readWriteTimeout(getSocketTimeout());
         }
         async = asyncBuilder.build();
       }
@@ -603,16 +606,19 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
               getProxyEndpoint().getHost()
                   + ":" + getProxyEndpoint().getPort());
         }
-        if (getSocketTimeout() != null) {
-          syncBuilder.readWriteTimeout(getSocketTimeout());
-        }
         if (retryer != null) {
           syncBuilder.retryer(retryer);
         }
+        // socketTimeout and RetryConfig.attemptTimeout both map to the Ali SDK's
+        // single readWriteTimeout setting. When both are set, attemptTimeout (the
+        // more specific per-attempt deadline) takes precedence over the
+        // transport-level socketTimeout.
         if (getRetryConfig() != null
             && getRetryConfig().getAttemptTimeout() != null) {
           syncBuilder.readWriteTimeout(
               java.time.Duration.ofMillis(getRetryConfig().getAttemptTimeout()));
+        } else if (getSocketTimeout() != null) {
+          syncBuilder.readWriteTimeout(getSocketTimeout());
         }
         sync = syncBuilder.build();
       }

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -561,7 +561,8 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
           OSSCredentialsProvider.getCredentialsProvider(
               getCredentialsOverrider(), getRegion());
 
-      Retryer retryer = AliTransformer.toAliRetryer(getRetryConfig());
+      Retryer retryer =
+          getRetryConfig() != null ? AliTransformer.toAliRetryer(getRetryConfig()) : null;
 
       OSSAsyncClient async = this.asyncClient;
       if (async == null && creds != null) {

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -618,7 +618,7 @@ public class AliTransformerTest {
     // Verify delay is within expected range (EqualJitterBackoff adds jitter)
     Duration delay = retryer.retryDelay(1, new RuntimeException("test"));
     assertNotNull(delay);
-    assertTrue(delay.toMillis() >= 0);
+    assertTrue(delay.toMillis() >= 100);
     assertTrue(delay.toMillis() <= 10000);
   }
 
@@ -653,6 +653,11 @@ public class AliTransformerTest {
 
     assertNotNull(retryer);
     assertEquals(4, retryer.maxAttempts());
+    // Verify SDK default backoff produces a sane delay (not zero or negative)
+    Duration delay = retryer.retryDelay(1, new RuntimeException("test"));
+    assertNotNull(delay);
+    assertTrue(delay.toMillis() > 0,
+        "Default backoff should produce a positive delay, got: " + delay.toMillis());
   }
 
   @Test

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -22,6 +22,7 @@ import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.retries.RetryConfig;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -639,8 +640,10 @@ public class AliTransformerTest {
   }
 
   @Test
-  void testToAliRetryerNullConfigReturnsNull() {
-    assertNull(AliTransformer.toAliRetryer(null));
+  void testToAliRetryerNullConfigThrows() {
+    InvalidArgumentException ex = assertThrows(InvalidArgumentException.class,
+        () -> AliTransformer.toAliRetryer(null));
+    assertEquals("RetryConfig cannot be null", ex.getMessage());
   }
 
   @Test
@@ -669,7 +672,7 @@ public class AliTransformerTest {
         .maxDelayMillis(5000L)
         .build();
 
-    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+    InvalidArgumentException ex = assertThrows(InvalidArgumentException.class,
         () -> AliTransformer.toAliRetryer(config));
     assertEquals("RetryConfig.maxAttempts must be greater than 0, got: 0", ex.getMessage());
   }
@@ -683,7 +686,7 @@ public class AliTransformerTest {
         .maxDelayMillis(5000L)
         .build();
 
-    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+    InvalidArgumentException ex = assertThrows(InvalidArgumentException.class,
         () -> AliTransformer.toAliRetryer(config));
     assertEquals("RetryConfig.maxAttempts must be greater than 0, got: -1", ex.getMessage());
   }
@@ -697,7 +700,7 @@ public class AliTransformerTest {
         .maxDelayMillis(5000L)
         .build();
 
-    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+    InvalidArgumentException ex = assertThrows(InvalidArgumentException.class,
         () -> AliTransformer.toAliRetryer(config));
     assertEquals(
         "RetryConfig.initialDelayMillis must be greater than 0 for EXPONENTIAL mode, got: 0",
@@ -713,7 +716,7 @@ public class AliTransformerTest {
         .maxDelayMillis(0L)
         .build();
 
-    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+    InvalidArgumentException ex = assertThrows(InvalidArgumentException.class,
         () -> AliTransformer.toAliRetryer(config));
     assertEquals(
         "RetryConfig.maxDelayMillis must be greater than 0 for EXPONENTIAL mode, got: 0",
@@ -728,7 +731,7 @@ public class AliTransformerTest {
         .fixedDelayMillis(0L)
         .build();
 
-    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+    InvalidArgumentException ex = assertThrows(InvalidArgumentException.class,
         () -> AliTransformer.toAliRetryer(config));
     assertEquals(
         "RetryConfig.fixedDelayMillis must be greater than 0 for FIXED mode, got: 0",

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -3,6 +3,7 @@ package com.salesforce.multicloudj.blob.ali;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -21,6 +22,7 @@ import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
+import com.salesforce.multicloudj.common.retries.RetryConfig;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.Duration;
@@ -598,5 +600,133 @@ public class AliTransformerTest {
     assertEquals(BUCKET, result.bucket());
     assertEquals("test-key", result.key());
     assertEquals("text/plain", result.contentType());
+  }
+
+  @Test
+  void testToAliRetryerExponentialMode() {
+    RetryConfig config = RetryConfig.builder()
+        .mode(RetryConfig.Mode.EXPONENTIAL)
+        .maxAttempts(5)
+        .initialDelayMillis(200L)
+        .maxDelayMillis(10000L)
+        .build();
+
+    var retryer = AliTransformer.toAliRetryer(config);
+
+    assertNotNull(retryer);
+    assertEquals(5, retryer.maxAttempts());
+    // Verify delay is within expected range (EqualJitterBackoff adds jitter)
+    Duration delay = retryer.retryDelay(1, new RuntimeException("test"));
+    assertNotNull(delay);
+    assertTrue(delay.toMillis() >= 0);
+    assertTrue(delay.toMillis() <= 10000);
+  }
+
+  @Test
+  void testToAliRetryerFixedMode() {
+    RetryConfig config = RetryConfig.builder()
+        .mode(RetryConfig.Mode.FIXED)
+        .maxAttempts(3)
+        .fixedDelayMillis(500L)
+        .build();
+
+    var retryer = AliTransformer.toAliRetryer(config);
+
+    assertNotNull(retryer);
+    assertEquals(3, retryer.maxAttempts());
+    Duration delay = retryer.retryDelay(1, new RuntimeException("test"));
+    assertEquals(500L, delay.toMillis());
+  }
+
+  @Test
+  void testToAliRetryerNullConfigReturnsNull() {
+    assertNull(AliTransformer.toAliRetryer(null));
+  }
+
+  @Test
+  void testToAliRetryerNoModeUsesDefaults() {
+    RetryConfig config = RetryConfig.builder()
+        .maxAttempts(4)
+        .build();
+
+    var retryer = AliTransformer.toAliRetryer(config);
+
+    assertNotNull(retryer);
+    assertEquals(4, retryer.maxAttempts());
+  }
+
+  @Test
+  void testToAliRetryerInvalidMaxAttempts() {
+    RetryConfig config = RetryConfig.builder()
+        .mode(RetryConfig.Mode.EXPONENTIAL)
+        .maxAttempts(0)
+        .initialDelayMillis(100L)
+        .maxDelayMillis(5000L)
+        .build();
+
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AliTransformer.toAliRetryer(config));
+    assertEquals("RetryConfig.maxAttempts must be greater than 0, got: 0", ex.getMessage());
+  }
+
+  @Test
+  void testToAliRetryerNegativeMaxAttempts() {
+    RetryConfig config = RetryConfig.builder()
+        .mode(RetryConfig.Mode.EXPONENTIAL)
+        .maxAttempts(-1)
+        .initialDelayMillis(100L)
+        .maxDelayMillis(5000L)
+        .build();
+
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AliTransformer.toAliRetryer(config));
+    assertEquals("RetryConfig.maxAttempts must be greater than 0, got: -1", ex.getMessage());
+  }
+
+  @Test
+  void testToAliRetryerExponentialInvalidInitialDelay() {
+    RetryConfig config = RetryConfig.builder()
+        .mode(RetryConfig.Mode.EXPONENTIAL)
+        .maxAttempts(3)
+        .initialDelayMillis(0L)
+        .maxDelayMillis(5000L)
+        .build();
+
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AliTransformer.toAliRetryer(config));
+    assertEquals(
+        "RetryConfig.initialDelayMillis must be greater than 0 for EXPONENTIAL mode, got: 0",
+        ex.getMessage());
+  }
+
+  @Test
+  void testToAliRetryerExponentialInvalidMaxDelay() {
+    RetryConfig config = RetryConfig.builder()
+        .mode(RetryConfig.Mode.EXPONENTIAL)
+        .maxAttempts(3)
+        .initialDelayMillis(100L)
+        .maxDelayMillis(0L)
+        .build();
+
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AliTransformer.toAliRetryer(config));
+    assertEquals(
+        "RetryConfig.maxDelayMillis must be greater than 0 for EXPONENTIAL mode, got: 0",
+        ex.getMessage());
+  }
+
+  @Test
+  void testToAliRetryerFixedInvalidDelay() {
+    RetryConfig config = RetryConfig.builder()
+        .mode(RetryConfig.Mode.FIXED)
+        .maxAttempts(3)
+        .fixedDelayMillis(0L)
+        .build();
+
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+        () -> AliTransformer.toAliRetryer(config));
+    assertEquals(
+        "RetryConfig.fixedDelayMillis must be greater than 0 for FIXED mode, got: 0",
+        ex.getMessage());
   }
 }


### PR DESCRIPTION
## Summary

Implement retry mechanism in Ali sync and async client.

Maps the cloud-agnostic RetryConfig to the Ali OSS v2 SDK's native retry framework (StandardRetryer + BackoffDelayer). Supports EXPONENTIAL mode via EqualJitterBackoff and FIXED mode via FixedDelayBackoff. The attemptTimeout maps to readWriteTimeout on the client builder.

Note: totalTimeout has no SDK equivalent and is not applied (same limitation as the AWS CRT client).


## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
