### PR TITLE
blobstore: presigned URL v2 — upload constraint binding + signed headers

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -780,7 +780,7 @@ public class AliBlobStore extends AbstractBlobStore {
     try {
       return PresignedUrlResponse.builder()
           .url(new URL(result.url()))
-          .signedHeaders(result.signedHeaders().orElse(java.util.Map.of()))
+          .signedHeaders(result.signedHeaders().orElse(Map.of()))
           .expiration(result.expiration().orElse(null))
           .build();
     } catch (java.net.MalformedURLException e) {

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -59,6 +59,7 @@ import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionRules;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
@@ -761,14 +762,8 @@ public class AliBlobStore extends AbstractBlobStore {
         OperationOptions.defaults());
   }
 
-  /**
-   * Generates a presigned URL for uploading/downloading blobs
-   *
-   * @param request The PresignedUrlRequest
-   * @return Returns the presigned URL
-   */
   @Override
-  protected URL doGeneratePresignedUrl(PresignedUrlRequest request) {
+  protected PresignedUrlResponse doPresign(PresignedUrlRequest request) {
     PresignOptions options = transformer.toPresignOptions(request);
     PresignResult result;
     switch (request.getType()) {
@@ -783,7 +778,11 @@ public class AliBlobStore extends AbstractBlobStore {
             "Unsupported PresignedOperation. type=" + request.getType());
     }
     try {
-      return new URL(result.url());
+      return PresignedUrlResponse.builder()
+          .url(new URL(result.url()))
+          .signedHeaders(result.signedHeaders().orElse(java.util.Map.of()))
+          .expiration(result.expiration().orElse(null))
+          .build();
     } catch (java.net.MalformedURLException e) {
       throw new RuntimeException("Invalid presigned URL: " + result.url(), e);
     }

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -593,6 +593,11 @@ public class AliTransformer {
     }
 
     if (request.getContentLength() > 0) {
+      if (request.getContentLength() > Integer.MAX_VALUE) {
+        throw new InvalidArgumentException(
+            "contentLength exceeds maximum supported by Ali OSS ("
+                + Integer.MAX_VALUE + " bytes)");
+      }
       builder.contentLength((int) request.getContentLength());
     }
 

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -592,6 +592,14 @@ public class AliTransformer {
       builder.serverSideEncryptionKeyId(request.getKmsKeyId());
     }
 
+    if (request.getContentLength() > 0) {
+      builder.contentLength((int) request.getContentLength());
+    }
+
+    if (StringUtils.isNotEmpty(request.getContentType())) {
+      builder.contentType(request.getContentType());
+    }
+
     return builder.build();
   }
 

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -605,6 +605,16 @@ public class AliTransformer {
       builder.contentType(request.getContentType());
     }
 
+    if (StringUtils.isNotEmpty(request.getChecksumValue())) {
+      ChecksumMethod algo = request.getChecksumAlgorithm() != null
+          ? request.getChecksumAlgorithm() : ChecksumMethod.CRC32C;
+      if (algo == ChecksumMethod.SHA256) {
+        builder.header("x-oss-content-sha256", request.getChecksumValue());
+      } else {
+        builder.header("x-oss-hash-crc64ecma", request.getChecksumValue());
+      }
+    }
+
     return builder.build();
   }
 

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -580,7 +580,7 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
       try {
         return PresignedUrlResponse.builder()
             .url(new URL(result.url()))
-            .signedHeaders(result.signedHeaders().orElse(java.util.Map.of()))
+            .signedHeaders(result.signedHeaders().orElse(Map.of()))
             .expiration(result.expiration().orElse(null))
             .build();
       } catch (java.net.MalformedURLException e) {

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -52,6 +52,7 @@ import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -558,7 +559,7 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
   }
 
   @Override
-  protected CompletableFuture<URL> doGeneratePresignedUrl(
+  protected CompletableFuture<PresignedUrlResponse> doPresign(
       PresignedUrlRequest request) {
     return CompletableFuture.supplyAsync(() -> {
       PresignOptions options = transformer.toPresignOptions(request);
@@ -577,7 +578,11 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
               "Unsupported PresignedOperation. type=" + request.getType());
       }
       try {
-        return new URL(result.url());
+        return PresignedUrlResponse.builder()
+            .url(new URL(result.url()))
+            .signedHeaders(result.signedHeaders().orElse(java.util.Map.of()))
+            .expiration(result.expiration().orElse(null))
+            .build();
       } catch (java.net.MalformedURLException e) {
         throw new SubstrateSdkException(
             "Invalid presigned URL: " + result.url(), e);

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -41,6 +41,7 @@ import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.ali.AliConstants;
@@ -987,7 +988,7 @@ public class AliBlobStoreTest {
             .duration(duration)
             .build();
 
-    URL result = ali.doGeneratePresignedUrl(presignedUploadRequest);
+    PresignedUrlResponse result = ali.doPresign(presignedUploadRequest);
 
     assertNotNull(result);
     ArgumentCaptor<com.aliyun.sdk.service.oss2.models.PutObjectRequest> requestCaptor =
@@ -1019,7 +1020,7 @@ public class AliBlobStoreTest {
             .duration(duration)
             .build();
 
-    URL result = ali.doGeneratePresignedUrl(presignedDownloadRequest);
+    PresignedUrlResponse result = ali.doPresign(presignedDownloadRequest);
 
     assertNotNull(result);
     ArgumentCaptor<com.aliyun.sdk.service.oss2.models.GetObjectRequest> requestCaptor =

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -432,6 +432,74 @@ public class AliTransformerTest {
   }
 
   @Test
+  void testToPresignedPutObjectRequest_withConstraints() {
+    PresignedUrlRequest request =
+        PresignedUrlRequest.builder()
+            .type(PresignedOperation.UPLOAD)
+            .key("object-1")
+            .duration(Duration.ofHours(1))
+            .contentLength(1024)
+            .contentType("application/json")
+            .build();
+
+    var actual = transformer.toPresignedPutObjectRequest(request);
+
+    assertEquals(BUCKET, actual.bucket());
+    assertEquals("object-1", actual.key());
+    assertEquals(Integer.valueOf(1024), actual.contentLength());
+    assertEquals("application/json", actual.contentType());
+  }
+
+  @Test
+  void testToPresignedPutObjectRequest_contentLengthOverflow() {
+    PresignedUrlRequest request =
+        PresignedUrlRequest.builder()
+            .type(PresignedOperation.UPLOAD)
+            .key("object-1")
+            .duration(Duration.ofHours(1))
+            .contentLength((long) Integer.MAX_VALUE + 1)
+            .build();
+
+    assertThrows(
+        InvalidArgumentException.class,
+        () -> transformer.toPresignedPutObjectRequest(request));
+  }
+
+  @Test
+  void testToPresignedPutObjectRequest_withChecksumCrc32c() {
+    PresignedUrlRequest request =
+        PresignedUrlRequest.builder()
+            .type(PresignedOperation.UPLOAD)
+            .key("object-1")
+            .duration(Duration.ofHours(1))
+            .checksumValue("abc123==")
+            .checksumAlgorithm(ChecksumMethod.CRC32C)
+            .build();
+
+    var actual = transformer.toPresignedPutObjectRequest(request);
+
+    assertEquals(BUCKET, actual.bucket());
+    assertEquals("object-1", actual.key());
+    assertEquals("abc123==", actual.headers().get("x-oss-hash-crc64ecma"));
+  }
+
+  @Test
+  void testToPresignedPutObjectRequest_withChecksumSha256() {
+    PresignedUrlRequest request =
+        PresignedUrlRequest.builder()
+            .type(PresignedOperation.UPLOAD)
+            .key("object-1")
+            .duration(Duration.ofHours(1))
+            .checksumValue("sha256val==")
+            .checksumAlgorithm(ChecksumMethod.SHA256)
+            .build();
+
+    var actual = transformer.toPresignedPutObjectRequest(request);
+
+    assertEquals("sha256val==", actual.headers().get("x-oss-content-sha256"));
+  }
+
+  @Test
   void testToPresignedDownloadRequest() {
     Duration duration = Duration.ofHours(12);
     PresignedUrlRequest presignedDownloadRequest =

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
@@ -23,6 +23,7 @@ import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionRules;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
@@ -533,24 +534,29 @@ public class AwsBlobStore extends AbstractBlobStore {
     s3Client.putObjectTagging(transformer.toPutObjectTaggingRequest(key, tags));
   }
 
-  /**
-   * Generates a presigned URL for uploading/downloading blobs
-   *
-   * @param request The PresignedUrlRequest
-   * @return Returns the presigned URL
-   */
   @Override
-  protected URL doGeneratePresignedUrl(PresignedUrlRequest request) {
+  protected PresignedUrlResponse doPresign(PresignedUrlRequest request) {
     try (S3Presigner presigner = getPresigner()) {
+      software.amazon.awssdk.awscore.presigner.PresignedRequest presigned;
       switch (request.getType()) {
         case UPLOAD:
-          return presigner.presignPutObject(transformer.toPutObjectPresignRequest(request)).url();
+          presigned = presigner.presignPutObject(transformer.toPutObjectPresignRequest(request));
+          break;
         case DOWNLOAD:
-          return presigner.presignGetObject(transformer.toGetObjectPresignRequest(request)).url();
+          presigned = presigner.presignGetObject(transformer.toGetObjectPresignRequest(request));
+          break;
         default:
           throw new InvalidArgumentException(
               "Unsupported PresignedOperation. type=" + request.getType());
       }
+      Map<String, String> flatHeaders = new java.util.LinkedHashMap<>();
+      presigned.signedHeaders().forEach((k, values) ->
+          flatHeaders.put(k, String.join(", ", values)));
+      return PresignedUrlResponse.builder()
+          .url(presigned.url())
+          .signedHeaders(flatHeaders)
+          .expiration(presigned.expiration())
+          .build();
     }
   }
 

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
@@ -549,14 +549,7 @@ public class AwsBlobStore extends AbstractBlobStore {
           throw new InvalidArgumentException(
               "Unsupported PresignedOperation. type=" + request.getType());
       }
-      Map<String, String> flatHeaders = new java.util.LinkedHashMap<>();
-      presigned.signedHeaders().forEach((k, values) ->
-          flatHeaders.put(k, String.join(", ", values)));
-      return PresignedUrlResponse.builder()
-          .url(presigned.url())
-          .signedHeaders(flatHeaders)
-          .expiration(presigned.expiration())
-          .build();
+      return transformer.toPresignedUrlResponse(presigned);
     }
   }
 

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -617,6 +617,19 @@ public class AwsTransformer {
     if (request.getKmsKeyId() != null) {
       builder.withKmsKeyId(request.getKmsKeyId());
     }
+    if (request.getContentLength() > 0) {
+      builder.withContentLength(request.getContentLength());
+    }
+    if (request.getContentType() != null) {
+      builder.withContentType(request.getContentType());
+    }
+    if (request.getChecksumValue() != null) {
+      builder.withChecksumValue(request.getChecksumValue());
+      builder.withChecksumAlgorithm(
+          request.getChecksumAlgorithm() != null
+              ? request.getChecksumAlgorithm()
+              : ChecksumMethod.CRC32C);
+    }
     UploadRequest uploadRequest = builder.build();
 
     return PutObjectPresignRequest.builder()

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -661,7 +661,7 @@ public class AwsTransformer {
       software.amazon.awssdk.awscore.presigner.PresignedRequest presigned) {
     Map<String, String> flatHeaders = new LinkedHashMap<>();
     presigned.signedHeaders().forEach((k, values) ->
-        flatHeaders.put(k, String.join(", ", values)));
+        flatHeaders.put(k, String.join(",", values)));
     return PresignedUrlResponse.builder()
         .url(presigned.url())
         .signedHeaders(flatHeaders)

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -26,6 +26,7 @@ import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration;
 import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
@@ -43,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -647,6 +649,18 @@ public class AwsTransformer {
     return GetObjectPresignRequest.builder()
         .signatureDuration(request.getDuration())
         .getObjectRequest(getObjectBuilder.build())
+        .build();
+  }
+
+  public PresignedUrlResponse toPresignedUrlResponse(
+      software.amazon.awssdk.awscore.presigner.PresignedRequest presigned) {
+    Map<String, String> flatHeaders = new LinkedHashMap<>();
+    presigned.signedHeaders().forEach((k, values) ->
+        flatHeaders.put(k, String.join(", ", values)));
+    return PresignedUrlResponse.builder()
+        .url(presigned.url())
+        .signedHeaders(flatHeaders)
+        .expiration(presigned.expiration())
         .build();
   }
 

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -229,6 +229,11 @@ public class AwsTransformer {
       }
     }
 
+    // Set content length if provided (required for presigned URL constraint enforcement)
+    if (request.getContentLength() > 0) {
+      builder.contentLength(request.getContentLength());
+    }
+
     // Set object lock if provided
     if (request.getObjectLock() != null) {
       applyObjectLockToPutObjectBuilder(builder, request.getObjectLock());

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStore.java
@@ -28,6 +28,7 @@ import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -410,23 +411,32 @@ public class AwsAsyncBlobStore extends AbstractAsyncBlobStore implements AwsSdkS
   }
 
   @Override
-  protected CompletableFuture<URL> doGeneratePresignedUrl(PresignedUrlRequest request) {
+  protected CompletableFuture<PresignedUrlResponse> doPresign(PresignedUrlRequest request) {
     return CompletableFuture.supplyAsync(
         () -> {
           try (S3Presigner presigner = getPresigner()) {
+            software.amazon.awssdk.awscore.presigner.PresignedRequest presigned;
             switch (request.getType()) {
               case UPLOAD:
-                return presigner
-                    .presignPutObject(transformer.toPutObjectPresignRequest(request))
-                    .url();
+                presigned =
+                    presigner.presignPutObject(transformer.toPutObjectPresignRequest(request));
+                break;
               case DOWNLOAD:
-                return presigner
-                    .presignGetObject(transformer.toGetObjectPresignRequest(request))
-                    .url();
+                presigned =
+                    presigner.presignGetObject(transformer.toGetObjectPresignRequest(request));
+                break;
               default:
                 throw new InvalidArgumentException(
                     "Unsupported PresignedOperation. type=" + request.getType());
             }
+            java.util.Map<String, String> flatHeaders = new java.util.LinkedHashMap<>();
+            presigned.signedHeaders().forEach((k, values) ->
+                flatHeaders.put(k, String.join(", ", values)));
+            return PresignedUrlResponse.builder()
+                .url(presigned.url())
+                .signedHeaders(flatHeaders)
+                .expiration(presigned.expiration())
+                .build();
           }
         });
   }

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStore.java
@@ -429,14 +429,7 @@ public class AwsAsyncBlobStore extends AbstractAsyncBlobStore implements AwsSdkS
                 throw new InvalidArgumentException(
                     "Unsupported PresignedOperation. type=" + request.getType());
             }
-            java.util.Map<String, String> flatHeaders = new java.util.LinkedHashMap<>();
-            presigned.signedHeaders().forEach((k, values) ->
-                flatHeaders.put(k, String.join(", ", values)));
-            return PresignedUrlResponse.builder()
-                .url(presigned.url())
-                .signedHeaders(flatHeaders)
-                .expiration(presigned.expiration())
-                .build();
+            return transformer.toPresignedUrlResponse(presigned);
           }
         });
   }

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreTest.java
@@ -39,6 +39,7 @@ import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
 import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -1368,8 +1369,8 @@ public class AwsBlobStoreTest {
             .duration(Duration.ofHours(4))
             .build();
 
-    URL actualUrl = spyAws.doGeneratePresignedUrl(presignedUrlRequest);
-    assertEquals(url, actualUrl);
+    PresignedUrlResponse presignedResponse = spyAws.doPresign(presignedUrlRequest);
+    assertEquals(url, presignedResponse.getUrl());
   }
 
   @Test
@@ -1392,8 +1393,8 @@ public class AwsBlobStoreTest {
             .duration(Duration.ofHours(4))
             .build();
 
-    URL actualUrl = spyAws.doGeneratePresignedUrl(presignedUrlRequest);
-    assertEquals(url, actualUrl);
+    PresignedUrlResponse presignedResponse = spyAws.doPresign(presignedUrlRequest);
+    assertEquals(url, presignedResponse.getUrl());
   }
 
   @Test

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
@@ -733,6 +733,37 @@ public class AwsTransformerTest {
   }
 
   @Test
+  void testToPutObjectPresignRequest_checksumDefaultsCrc32c() {
+    PresignedUrlRequest request =
+        PresignedUrlRequest.builder()
+            .type(PresignedOperation.UPLOAD)
+            .key("object-1")
+            .duration(Duration.ofHours(1))
+            .checksumValue("abc123==")
+            .build();
+    PutObjectPresignRequest actual = transformer.toPutObjectPresignRequest(request);
+    assertEquals("abc123==", actual.putObjectRequest().checksumCRC32C());
+    assertEquals(
+        software.amazon.awssdk.services.s3.model.ChecksumAlgorithm.CRC32_C,
+        actual.putObjectRequest().checksumAlgorithm());
+  }
+
+  @Test
+  void testToPutObjectPresignRequest_withContentLengthAndType() {
+    PresignedUrlRequest request =
+        PresignedUrlRequest.builder()
+            .type(PresignedOperation.UPLOAD)
+            .key("object-1")
+            .duration(Duration.ofHours(1))
+            .contentLength(2048)
+            .contentType("text/plain")
+            .build();
+    PutObjectPresignRequest actual = transformer.toPutObjectPresignRequest(request);
+    assertEquals(Long.valueOf(2048), actual.putObjectRequest().contentLength());
+    assertEquals("text/plain", actual.putObjectRequest().contentType());
+  }
+
+  @Test
   void testGetPrefixExclusionsFilter() {
     List<String> prefixesToExclude = List.of("files/images", "files/personal");
     DownloadFilter downloadFilter = transformer.getPrefixExclusionsFilter(prefixesToExclude);

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStoreTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStoreTest.java
@@ -41,6 +41,7 @@ import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration;
 import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -1220,8 +1221,8 @@ public class AwsAsyncBlobStoreTest {
             .duration(Duration.ofHours(4))
             .build();
 
-    URL actualUrl = spyAws.doGeneratePresignedUrl(presignedUrlRequest).get();
-    assertEquals(url, actualUrl);
+    PresignedUrlResponse presignedResponse = spyAws.doPresign(presignedUrlRequest).get();
+    assertEquals(url, presignedResponse.getUrl());
   }
 
   @Test
@@ -1245,8 +1246,8 @@ public class AwsAsyncBlobStoreTest {
             .duration(Duration.ofHours(4))
             .build();
 
-    URL actualUrl = spyAws.doGeneratePresignedUrl(presignedUrlRequest).get();
-    assertEquals(url, actualUrl);
+    PresignedUrlResponse presignedResponse = spyAws.doPresign(presignedUrlRequest).get();
+    assertEquals(url, presignedResponse.getUrl());
   }
 
   @Test

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_allconstraintscombined-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_allconstraintscombined-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "da54b9d2-e82e-46b7-a16f-05ee51c34e37",
+  "id" : "a0800dee-f052-4d32-a3f2-3ad5712d5515",
   "name" : "AwsBlobStoreIT_testPresignV2_allConstraintsCombined-DELETE-0",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/presign-v2/all-constraints-combined",
@@ -9,12 +9,12 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "RG8S83CGN2XYD3W9",
-      "x-amz-id-2" : "KPnvk+Ye4kDgbE6dXl3+qi48xGV+4sH4vwkxo/sxdDQ10yNJnOU9nG0qIOl38bb2MJG6atCj+ZM=",
-      "Date" : "Thu, 04 Jun 2026 10:50:59 GMT"
+      "x-amz-request-id" : "DPPGRXRY52VJ8QJZ",
+      "x-amz-id-2" : "/WRpP6uErneM9Z/BtkgKwlgki6WAuRbNVQlpx1+zz/IMostC4MfqObioYBNKTw8i9NVerN8r7Ow=",
+      "Date" : "Fri, 05 Jun 2026 04:48:10 GMT"
     }
   },
-  "uuid" : "da54b9d2-e82e-46b7-a16f-05ee51c34e37",
+  "uuid" : "a0800dee-f052-4d32-a3f2-3ad5712d5515",
   "persistent" : true,
-  "insertionIndex" : 765
+  "insertionIndex" : 759
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_allconstraintscombined-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_allconstraintscombined-delete-0.json
@@ -1,0 +1,20 @@
+{
+  "id" : "da54b9d2-e82e-46b7-a16f-05ee51c34e37",
+  "name" : "AwsBlobStoreIT_testPresignV2_allConstraintsCombined-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud/conformance-tests/presign-v2/all-constraints-combined",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "RG8S83CGN2XYD3W9",
+      "x-amz-id-2" : "KPnvk+Ye4kDgbE6dXl3+qi48xGV+4sH4vwkxo/sxdDQ10yNJnOU9nG0qIOl38bb2MJG6atCj+ZM=",
+      "Date" : "Thu, 04 Jun 2026 10:50:59 GMT"
+    }
+  },
+  "uuid" : "da54b9d2-e82e-46b7-a16f-05ee51c34e37",
+  "persistent" : true,
+  "insertionIndex" : 765
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_backwardcompatibility-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_backwardcompatibility-delete-0.json
@@ -1,0 +1,20 @@
+{
+  "id" : "d8ed0719-80b9-4b6b-9259-0e6b1457bb40",
+  "name" : "AwsBlobStoreIT_testPresignV2_backwardCompatibility-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud/conformance-tests/presign-v2/backward-compat",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "5C2G3Q450STT0VWD",
+      "x-amz-id-2" : "ovnA3ETfW4IW9cTBmfJFTBaODQF11QAsEHquRg2KBPujIA5Jbv6jVk87DTv2N7hAam8IelJ3lD4=",
+      "Date" : "Thu, 04 Jun 2026 10:50:54 GMT"
+    }
+  },
+  "uuid" : "d8ed0719-80b9-4b6b-9259-0e6b1457bb40",
+  "persistent" : true,
+  "insertionIndex" : 759
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_backwardcompatibility-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_backwardcompatibility-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "d8ed0719-80b9-4b6b-9259-0e6b1457bb40",
+  "id" : "2a5bce5e-6af3-414c-88b3-ad9ba6f9a98f",
   "name" : "AwsBlobStoreIT_testPresignV2_backwardCompatibility-DELETE-0",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/presign-v2/backward-compat",
@@ -9,12 +9,12 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "5C2G3Q450STT0VWD",
-      "x-amz-id-2" : "ovnA3ETfW4IW9cTBmfJFTBaODQF11QAsEHquRg2KBPujIA5Jbv6jVk87DTv2N7hAam8IelJ3lD4=",
-      "Date" : "Thu, 04 Jun 2026 10:50:54 GMT"
+      "x-amz-request-id" : "J3ZRV0YRZSZ3Y837",
+      "x-amz-id-2" : "Bo+kUlFCkmbT17kQ6+6Hfj69zbVbZcJd8CDJELCzcxqcZnS14CFcUqxYgcBhAHhgpfYEjyYCSXI=",
+      "Date" : "Fri, 05 Jun 2026 04:48:05 GMT"
     }
   },
-  "uuid" : "d8ed0719-80b9-4b6b-9259-0e6b1457bb40",
+  "uuid" : "2a5bce5e-6af3-414c-88b3-ad9ba6f9a98f",
   "persistent" : true,
-  "insertionIndex" : 759
+  "insertionIndex" : 753
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_checksumcrc32cbinding-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_checksumcrc32cbinding-delete-0.json
@@ -1,0 +1,20 @@
+{
+  "id" : "a52b0f16-135f-43f9-a59d-f07e3b0f41b4",
+  "name" : "AwsBlobStoreIT_testPresignV2_checksumCrc32cBinding-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud/conformance-tests/presign-v2/checksum-crc32c-binding",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "44NX3QGM62EHWY37",
+      "x-amz-id-2" : "BnjoLRByYy2RdVqM4vAsguDWS9r4mPkbFoZceZlB6LgV7xHbaCYALLozKkJglshNvG0r/48dhR0=",
+      "Date" : "Thu, 04 Jun 2026 10:51:00 GMT"
+    }
+  },
+  "uuid" : "a52b0f16-135f-43f9-a59d-f07e3b0f41b4",
+  "persistent" : true,
+  "insertionIndex" : 767
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_checksumcrc32cbinding-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_checksumcrc32cbinding-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "a52b0f16-135f-43f9-a59d-f07e3b0f41b4",
+  "id" : "46fe9e02-8063-4e01-a026-3cbb54356fa1",
   "name" : "AwsBlobStoreIT_testPresignV2_checksumCrc32cBinding-DELETE-0",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/presign-v2/checksum-crc32c-binding",
@@ -9,12 +9,12 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "44NX3QGM62EHWY37",
-      "x-amz-id-2" : "BnjoLRByYy2RdVqM4vAsguDWS9r4mPkbFoZceZlB6LgV7xHbaCYALLozKkJglshNvG0r/48dhR0=",
-      "Date" : "Thu, 04 Jun 2026 10:51:00 GMT"
+      "x-amz-request-id" : "0QMQCZMTZN4CHH6H",
+      "x-amz-id-2" : "gBFZaq1RA5fzeU1XpL3684Br7ZPklTrKpO7cGttHg9hMQnxNhXjJy+uSo/7HqRtCiKc/KdG88z8=",
+      "Date" : "Fri, 05 Jun 2026 04:48:11 GMT"
     }
   },
-  "uuid" : "a52b0f16-135f-43f9-a59d-f07e3b0f41b4",
+  "uuid" : "46fe9e02-8063-4e01-a026-3cbb54356fa1",
   "persistent" : true,
-  "insertionIndex" : 767
+  "insertionIndex" : 761
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_checksumcrc32cbinding_rejectswrongchecksum-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_checksumcrc32cbinding_rejectswrongchecksum-delete-0.json
@@ -1,0 +1,20 @@
+{
+  "id" : "e9a6438a-60a4-4d29-904b-1c569942856d",
+  "name" : "AwsBlobStoreIT_testPresignV2_checksumCrc32cBinding_rejectsWrongChecksum-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud/conformance-tests/presign-v2/negative/wrong-checksum",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "8RAVHYQ5DGCHVT5F",
+      "x-amz-id-2" : "Tn55V9f5Vpfh10xWZfQwuf4B10Q5+vg6gX/463d/NCMbz4RHUxT3FZzVSLlaOTy5UVTXkNGieaLaeWTk4uzWZSjj0uQDQtYh",
+      "Date" : "Fri, 05 Jun 2026 09:03:16 GMT"
+    }
+  },
+  "uuid" : "e9a6438a-60a4-4d29-904b-1c569942856d",
+  "persistent" : true,
+  "insertionIndex" : 763
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_contentlengthbinding-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_contentlengthbinding-delete-0.json
@@ -1,0 +1,20 @@
+{
+  "id" : "94a424cf-ad03-43cd-9df8-e0160e6ee55a",
+  "name" : "AwsBlobStoreIT_testPresignV2_contentLengthBinding-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud/conformance-tests/presign-v2/content-length-binding",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "XA7J1NP9MMZYBQYR",
+      "x-amz-id-2" : "B5/bZg2n0oYtqnoV6u6/SivaRuCcKsAq56MWBGxSwA7iE60aWg6o5R6eGlvuz+bNbH/uEXAL4fM=",
+      "Date" : "Thu, 04 Jun 2026 10:50:57 GMT"
+    }
+  },
+  "uuid" : "94a424cf-ad03-43cd-9df8-e0160e6ee55a",
+  "persistent" : true,
+  "insertionIndex" : 763
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_contentlengthbinding-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_contentlengthbinding-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "94a424cf-ad03-43cd-9df8-e0160e6ee55a",
+  "id" : "15e1ca99-7d42-46e4-b1e0-ee40a55ebbdc",
   "name" : "AwsBlobStoreIT_testPresignV2_contentLengthBinding-DELETE-0",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/presign-v2/content-length-binding",
@@ -9,12 +9,12 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "XA7J1NP9MMZYBQYR",
-      "x-amz-id-2" : "B5/bZg2n0oYtqnoV6u6/SivaRuCcKsAq56MWBGxSwA7iE60aWg6o5R6eGlvuz+bNbH/uEXAL4fM=",
-      "Date" : "Thu, 04 Jun 2026 10:50:57 GMT"
+      "x-amz-request-id" : "DV6FZE76N0WYM672",
+      "x-amz-id-2" : "9B5B+18aE21vbGhXIMhFS7R4+7m0XRjNQn2LIsql50Mgu3CF8Ld/Yad7d7WdjwkRfxALj9akOPk=",
+      "Date" : "Fri, 05 Jun 2026 04:48:09 GMT"
     }
   },
-  "uuid" : "94a424cf-ad03-43cd-9df8-e0160e6ee55a",
+  "uuid" : "15e1ca99-7d42-46e4-b1e0-ee40a55ebbdc",
   "persistent" : true,
-  "insertionIndex" : 763
+  "insertionIndex" : 757
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_contentlengthbinding_rejectswrongsize-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_contentlengthbinding_rejectswrongsize-delete-0.json
@@ -1,0 +1,20 @@
+{
+  "id" : "c7081d9d-1fbd-4051-81a4-3e91daeb9df0",
+  "name" : "AwsBlobStoreIT_testPresignV2_contentLengthBinding_rejectsWrongSize-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud/conformance-tests/presign-v2/negative/wrong-size",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "TZ8ZH0T2PKRZF40S",
+      "x-amz-id-2" : "ptab1dvbCLqoobImHS+lZP44PYBTIXhDjqkDHMvNnRqNzD0VnYrjD9ZupL+KcMTS/9igSrAqd1yQRxU4meg1PztmKzu7WFk+",
+      "Date" : "Fri, 05 Jun 2026 09:03:13 GMT"
+    }
+  },
+  "uuid" : "c7081d9d-1fbd-4051-81a4-3e91daeb9df0",
+  "persistent" : true,
+  "insertionIndex" : 759
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_contenttypebinding-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_contenttypebinding-delete-0.json
@@ -1,0 +1,20 @@
+{
+  "id" : "c0fd6589-9e91-4448-bd86-c856bb4e44f3",
+  "name" : "AwsBlobStoreIT_testPresignV2_contentTypeBinding-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud/conformance-tests/presign-v2/content-type-binding",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "P1BS9470A60558DP",
+      "x-amz-id-2" : "vZSTQoeVgrBNLXaE8r+95IktSa0oHV7JKPyNpPI6xhzo6c1GDYM8WPUEatDXFQLMgHUhm4hKhH0=",
+      "Date" : "Thu, 04 Jun 2026 10:50:55 GMT"
+    }
+  },
+  "uuid" : "c0fd6589-9e91-4448-bd86-c856bb4e44f3",
+  "persistent" : true,
+  "insertionIndex" : 761
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_contenttypebinding-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_contenttypebinding-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "c0fd6589-9e91-4448-bd86-c856bb4e44f3",
+  "id" : "8a110e17-c07b-4652-b0b7-2d4786255c52",
   "name" : "AwsBlobStoreIT_testPresignV2_contentTypeBinding-DELETE-0",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/presign-v2/content-type-binding",
@@ -9,12 +9,12 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "P1BS9470A60558DP",
-      "x-amz-id-2" : "vZSTQoeVgrBNLXaE8r+95IktSa0oHV7JKPyNpPI6xhzo6c1GDYM8WPUEatDXFQLMgHUhm4hKhH0=",
-      "Date" : "Thu, 04 Jun 2026 10:50:55 GMT"
+      "x-amz-request-id" : "JXPB2KY05AX75GVZ",
+      "x-amz-id-2" : "Hw3YwMHEUtB8kxH/ZS+kHshzDbY6i23y9jDxegQEmPgo2W4LxHisAFuAxiR7pn6Pl0haCJCVVyA=",
+      "Date" : "Fri, 05 Jun 2026 04:48:08 GMT"
     }
   },
-  "uuid" : "c0fd6589-9e91-4448-bd86-c856bb4e44f3",
+  "uuid" : "8a110e17-c07b-4652-b0b7-2d4786255c52",
   "persistent" : true,
-  "insertionIndex" : 761
+  "insertionIndex" : 755
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_contenttypebinding_rejectswrongtype-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_contenttypebinding_rejectswrongtype-delete-0.json
@@ -1,0 +1,20 @@
+{
+  "id" : "66dcf0b8-782f-4430-bda3-abf976cfc6a9",
+  "name" : "AwsBlobStoreIT_testPresignV2_contentTypeBinding_rejectsWrongType-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud/conformance-tests/presign-v2/negative/wrong-type",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "P3JY964YM1RXK0KT",
+      "x-amz-id-2" : "Wr/n5Gk57TNjeVPTFMQ6YgkhJ9uZOxlomRI/DfcV9oy9Nt/wvh2zyNXX2rxbyiiORZvv6rvAJ/eccJlCC1VAJf9HGg+KoZJX",
+      "Date" : "Fri, 05 Jun 2026 09:03:14 GMT"
+    }
+  },
+  "uuid" : "66dcf0b8-782f-4430-bda3-abf976cfc6a9",
+  "persistent" : true,
+  "insertionIndex" : 761
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_signedheadersnonempty-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_signedheadersnonempty-delete-0.json
@@ -1,0 +1,20 @@
+{
+  "id" : "2f29848a-748f-4069-be3e-f4817a50246d",
+  "name" : "AwsBlobStoreIT_testPresignV2_signedHeadersNonEmpty-DELETE-0",
+  "request" : {
+    "url" : "/chameleon-jcloud/conformance-tests/presign-v2/signed-headers-present",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "6H625K4JS3BBJ0K2",
+      "x-amz-id-2" : "LX9KAWWBM+acW3zKmzg5R96N7drXH9HX9umK87d4ShK+EAnoId1ZRtSc1l6Q94i5DpvqKt5SH4U=",
+      "Date" : "Thu, 04 Jun 2026 10:51:01 GMT"
+    }
+  },
+  "uuid" : "2f29848a-748f-4069-be3e-f4817a50246d",
+  "persistent" : true,
+  "insertionIndex" : 769
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_signedheadersnonempty-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testpresignv2_signedheadersnonempty-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "2f29848a-748f-4069-be3e-f4817a50246d",
+  "id" : "889ababe-b110-42c0-aff1-4bde516513ff",
   "name" : "AwsBlobStoreIT_testPresignV2_signedHeadersNonEmpty-DELETE-0",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/presign-v2/signed-headers-present",
@@ -9,12 +9,12 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "6H625K4JS3BBJ0K2",
-      "x-amz-id-2" : "LX9KAWWBM+acW3zKmzg5R96N7drXH9HX9umK87d4ShK+EAnoId1ZRtSc1l6Q94i5DpvqKt5SH4U=",
-      "Date" : "Thu, 04 Jun 2026 10:51:01 GMT"
+      "x-amz-request-id" : "QH1SQZNK5E9K458Q",
+      "x-amz-id-2" : "Z4d3ppi3+Cwgy2STq7KwLj5PShGNsoX5uQRrQK2e+2wERCqyU6lyY3cLghGfQzO0NzC6rQdrzA0=",
+      "Date" : "Fri, 05 Jun 2026 04:48:12 GMT"
     }
   },
-  "uuid" : "2f29848a-748f-4069-be3e-f4817a50246d",
+  "uuid" : "889ababe-b110-42c0-aff1-4bde516513ff",
   "persistent" : true,
-  "insertionIndex" : 769
+  "insertionIndex" : 763
 }

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/client/AsyncBucketClient.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/client/AsyncBucketClient.java
@@ -326,7 +326,7 @@ public class AsyncBucketClient implements AutoCloseable {
   /** Generates a presigned URL with full response including signed headers and expiration. */
   public CompletableFuture<PresignedUrlResponse> presign(PresignedUrlRequest request) {
     return multiCloudJLogger.traceAsyncOperation(
-        BlobSpanNames.PRESIGN,
+        BlobSpanNames.GENERATE_PRESIGNED_URL,
         bucketAttrs(),
         request.getOperationContext(),
         ctx -> blobStore.presign(request).exceptionally(this::handleException));

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/client/AsyncBucketClient.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/client/AsyncBucketClient.java
@@ -24,6 +24,7 @@ import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -320,6 +321,15 @@ public class AsyncBucketClient implements AutoCloseable {
         bucketAttrs(),
         request.getOperationContext(),
         ctx -> blobStore.generatePresignedUrl(request).exceptionally(this::handleException));
+  }
+
+  /** Generates a presigned URL with full response including signed headers and expiration. */
+  public CompletableFuture<PresignedUrlResponse> presign(PresignedUrlRequest request) {
+    return multiCloudJLogger.traceAsyncOperation(
+        BlobSpanNames.PRESIGN,
+        bucketAttrs(),
+        request.getOperationContext(),
+        ctx -> blobStore.presign(request).exceptionally(this::handleException));
   }
 
   /** Determines if an object exists for a given key/versionId */

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/driver/AbstractAsyncBlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/driver/AbstractAsyncBlobStore.java
@@ -21,6 +21,7 @@ import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -224,7 +225,14 @@ public abstract class AbstractAsyncBlobStore implements AsyncBlobStore {
   @Override
   public CompletableFuture<URL> generatePresignedUrl(PresignedUrlRequest request) {
     validator.validate(request);
-    return doGeneratePresignedUrl(request);
+    return doPresign(request).thenApply(PresignedUrlResponse::getUrl);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public CompletableFuture<PresignedUrlResponse> presign(PresignedUrlRequest request) {
+    validator.validate(request);
+    return doPresign(request);
   }
 
   /** {@inheritDoc} */
@@ -318,7 +326,7 @@ public abstract class AbstractAsyncBlobStore implements AsyncBlobStore {
 
   protected abstract CompletableFuture<Void> doSetTags(String key, Map<String, String> tags);
 
-  protected abstract CompletableFuture<URL> doGeneratePresignedUrl(PresignedUrlRequest request);
+  protected abstract CompletableFuture<PresignedUrlResponse> doPresign(PresignedUrlRequest request);
 
   protected abstract CompletableFuture<Boolean> doDoesObjectExist(String key, String versionId);
 

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/driver/AsyncBlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/driver/AsyncBlobStore.java
@@ -20,6 +20,7 @@ import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -245,6 +246,20 @@ public interface AsyncBlobStore extends SdkService, AutoCloseable {
    * @return Returns the presigned URL
    */
   CompletableFuture<URL> generatePresignedUrl(PresignedUrlRequest request);
+
+  /**
+   * Generates a presigned URL with full response including signed headers and expiration.
+   *
+   * @param request The presigned request
+   * @return Response containing the URL, signed headers map, and expiration
+   */
+  default CompletableFuture<PresignedUrlResponse> presign(PresignedUrlRequest request) {
+    return generatePresignedUrl(request)
+        .thenApply(url -> PresignedUrlResponse.builder()
+            .url(url)
+            .signedHeaders(java.util.Map.of())
+            .build());
+  }
 
   /**
    * Determines if an object exists for a given key/versionId

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/driver/AsyncBlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/driver/AsyncBlobStore.java
@@ -253,13 +253,7 @@ public interface AsyncBlobStore extends SdkService, AutoCloseable {
    * @param request The presigned request
    * @return Response containing the URL, signed headers map, and expiration
    */
-  default CompletableFuture<PresignedUrlResponse> presign(PresignedUrlRequest request) {
-    return generatePresignedUrl(request)
-        .thenApply(url -> PresignedUrlResponse.builder()
-            .url(url)
-            .signedHeaders(Map.of())
-            .build());
-  }
+  CompletableFuture<PresignedUrlResponse> presign(PresignedUrlRequest request);
 
   /**
    * Determines if an object exists for a given key/versionId

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/driver/AsyncBlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/driver/AsyncBlobStore.java
@@ -257,7 +257,7 @@ public interface AsyncBlobStore extends SdkService, AutoCloseable {
     return generatePresignedUrl(request)
         .thenApply(url -> PresignedUrlResponse.builder()
             .url(url)
-            .signedHeaders(java.util.Map.of())
+            .signedHeaders(Map.of())
             .build());
   }
 

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/driver/BlobStoreAsyncBridge.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/driver/BlobStoreAsyncBridge.java
@@ -22,6 +22,7 @@ import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -232,6 +233,12 @@ public class BlobStoreAsyncBridge implements AsyncBlobStore {
   public CompletableFuture<URL> generatePresignedUrl(PresignedUrlRequest request) {
     return CompletableFuture.supplyAsync(
         () -> blobStore.generatePresignedUrl(request), executorService);
+  }
+
+  @Override
+  public CompletableFuture<PresignedUrlResponse> presign(PresignedUrlRequest request) {
+    return CompletableFuture.supplyAsync(
+        () -> blobStore.presign(request), executorService);
   }
 
   @Override

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
@@ -22,6 +22,7 @@ import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -636,6 +637,28 @@ public class BucketClient implements AutoCloseable {
         ctx -> {
           try {
             return blobStore.generatePresignedUrl(request);
+          } catch (Throwable t) {
+            propagate(t);
+            return null;
+          }
+        });
+  }
+
+  /**
+   * Generates a presigned URL with full response including signed headers and expiration.
+   *
+   * @param request The presigned request (supports constraint fields)
+   * @return Response containing the URL, signed headers map, and expiration
+   * @throws SubstrateSdkException Thrown if the operation fails
+   */
+  public PresignedUrlResponse presign(PresignedUrlRequest request) {
+    return multiCloudJLogger.traceOperation(
+        BlobSpanNames.PRESIGN,
+        bucketAttrs(),
+        request.getOperationContext(),
+        ctx -> {
+          try {
+            return blobStore.presign(request);
           } catch (Throwable t) {
             propagate(t);
             return null;

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
@@ -653,7 +653,7 @@ public class BucketClient implements AutoCloseable {
    */
   public PresignedUrlResponse presign(PresignedUrlRequest request) {
     return multiCloudJLogger.traceOperation(
-        BlobSpanNames.PRESIGN,
+        BlobSpanNames.GENERATE_PRESIGNED_URL,
         bucketAttrs(),
         request.getOperationContext(),
         ctx -> {

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStore.java
@@ -222,7 +222,12 @@ public abstract class AbstractBlobStore implements BlobStore, AutoCloseable {
   @Override
   public URL generatePresignedUrl(PresignedUrlRequest request) {
     validator.validate(request);
-    return doPresign(request).getUrl();
+    PresignedUrlResponse response = doPresign(request);
+    if (response == null || response.getUrl() == null) {
+      throw new SubstrateSdkException(
+          "doPresign must return a non-null response with a non-null URL");
+    }
+    return response.getUrl();
   }
 
   /** {@inheritDoc} */

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStore.java
@@ -222,7 +222,14 @@ public abstract class AbstractBlobStore implements BlobStore, AutoCloseable {
   @Override
   public URL generatePresignedUrl(PresignedUrlRequest request) {
     validator.validate(request);
-    return doGeneratePresignedUrl(request);
+    return doPresign(request).getUrl();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public PresignedUrlResponse presign(PresignedUrlRequest request) {
+    validator.validate(request);
+    return doPresign(request);
   }
 
   /** {@inheritDoc} */
@@ -352,7 +359,7 @@ public abstract class AbstractBlobStore implements BlobStore, AutoCloseable {
 
   protected abstract void doSetTags(String key, Map<String, String> tags);
 
-  protected abstract URL doGeneratePresignedUrl(PresignedUrlRequest request);
+  protected abstract PresignedUrlResponse doPresign(PresignedUrlRequest request);
 
   protected abstract boolean doDoesObjectExist(String key, String versionId);
 

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobSpanNames.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobSpanNames.java
@@ -25,6 +25,7 @@ public final class BlobSpanNames {
   public static final String GET_TAGS = "blob.getTags";
   public static final String SET_TAGS = "blob.setTags";
   public static final String GENERATE_PRESIGNED_URL = "blob.generatePresignedUrl";
+  public static final String PRESIGN = "blob.presign";
   public static final String DOES_OBJECT_EXIST = "blob.doesObjectExist";
   public static final String DOES_BUCKET_EXIST = "blob.doesBucketExist";
 

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobSpanNames.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobSpanNames.java
@@ -25,7 +25,6 @@ public final class BlobSpanNames {
   public static final String GET_TAGS = "blob.getTags";
   public static final String SET_TAGS = "blob.setTags";
   public static final String GENERATE_PRESIGNED_URL = "blob.generatePresignedUrl";
-  public static final String PRESIGN = "blob.presign";
   public static final String DOES_OBJECT_EXIST = "blob.doesObjectExist";
   public static final String DOES_BUCKET_EXIST = "blob.doesBucketExist";
 

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStore.java
@@ -250,6 +250,22 @@ public interface BlobStore extends SdkService, Provider {
   URL generatePresignedUrl(PresignedUrlRequest request);
 
   /**
+   * Generates a presigned URL with full response including signed headers and expiration. The
+   * signed headers must be replayed verbatim by the uploader for the substrate to accept the
+   * request.
+   *
+   * @param request The presigned request (supports constraint fields: contentLength, contentType,
+   *     checksumValue, checksumAlgorithm)
+   * @return Response containing the URL, signed headers map, and expiration
+   */
+  default PresignedUrlResponse presign(PresignedUrlRequest request) {
+    return PresignedUrlResponse.builder()
+        .url(generatePresignedUrl(request))
+        .signedHeaders(Map.of())
+        .build();
+  }
+
+  /**
    * Determines if an object exists for a given key/versionId
    *
    * @param key Name of the blob to check

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStore.java
@@ -258,12 +258,7 @@ public interface BlobStore extends SdkService, Provider {
    *     checksumValue, checksumAlgorithm)
    * @return Response containing the URL, signed headers map, and expiration
    */
-  default PresignedUrlResponse presign(PresignedUrlRequest request) {
-    return PresignedUrlResponse.builder()
-        .url(generatePresignedUrl(request))
-        .signedHeaders(Map.of())
-        .build();
-  }
+  PresignedUrlResponse presign(PresignedUrlRequest request);
 
   /**
    * Determines if an object exists for a given key/versionId

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStoreValidator.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStoreValidator.java
@@ -1,5 +1,6 @@
 package com.salesforce.multicloudj.blob.driver;
 
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Collection;
@@ -286,11 +287,21 @@ public class BlobStoreValidator {
     validateKey(request.getKey());
     validateDuration(request.getDuration());
     if (request.getContentLength() < 0) {
-      throw new IllegalArgumentException("contentLength must be >= 0");
+      throw new InvalidArgumentException("contentLength must be >= 0");
     }
     if (request.getChecksumAlgorithm() != null && request.getChecksumValue() == null) {
-      throw new IllegalArgumentException(
+      throw new InvalidArgumentException(
           "checksumAlgorithm requires checksumValue to be set");
+    }
+    if (request.getType() != PresignedOperation.UPLOAD) {
+      if (request.getContentLength() > 0
+          || request.getContentType() != null
+          || request.getChecksumValue() != null
+          || request.getChecksumAlgorithm() != null) {
+        throw new InvalidArgumentException(
+            "contentLength/contentType/checksumValue/checksumAlgorithm"
+                + " are only valid for UPLOAD presigned URLs");
+      }
     }
   }
 

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStoreValidator.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStoreValidator.java
@@ -285,6 +285,13 @@ public class BlobStoreValidator {
     validatePresignedOperationType(request.getType());
     validateKey(request.getKey());
     validateDuration(request.getDuration());
+    if (request.getContentLength() < 0) {
+      throw new IllegalArgumentException("contentLength must be >= 0");
+    }
+    if (request.getChecksumAlgorithm() != null && request.getChecksumValue() == null) {
+      throw new IllegalArgumentException(
+          "checksumAlgorithm requires checksumValue to be set");
+    }
   }
 
   /**

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/PresignedUrlRequest.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/PresignedUrlRequest.java
@@ -59,6 +59,12 @@ public class PresignedUrlRequest {
   /**
    * (Optional) The checksum algorithm used for the checksumValue.
    * Defaults to CRC32C when checksumValue is set but no algorithm is specified.
+   *
+   * <p><b>Ali OSS caveat:</b> The Ali provider maps {@code CRC32C} to its native
+   * {@code x-oss-hash-crc64ecma} header. Callers targeting Ali must compute a CRC64-ECMA
+   * hash (not a 4-byte CRC32C) and pass it as {@code checksumValue} with this field set
+   * to {@code CRC32C}. A future {@code CRC64ECMA} enum value may be added to make this
+   * explicit.
    */
   private final ChecksumMethod checksumAlgorithm;
 

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/PresignedUrlRequest.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/PresignedUrlRequest.java
@@ -33,9 +33,34 @@ public class PresignedUrlRequest {
   private final String kmsKeyId;
 
   /**
-   * Optional: Specify the Content-Disposition header to override in a presigned download URL. 
+   * Optional: Specify the Content-Disposition header to override in a presigned download URL.
    */
   private final String contentDisposition;
+
+  /**
+   * (Optional) The length of the content in bytes to be signed into the presigned upload URL.
+   * When set, the substrate will reject uploads whose body size does not match.
+   * A value of 0 means unset (no content-length constraint).
+   */
+  private final long contentLength;
+
+  /**
+   * (Optional) The content type to be signed into the presigned upload URL.
+   * When set, the substrate will reject uploads whose Content-Type header does not match.
+   */
+  private final String contentType;
+
+  /**
+   * (Optional) The base64-encoded checksum value to be signed into the presigned upload URL.
+   * When set, the substrate will reject uploads whose content hash does not match.
+   */
+  private final String checksumValue;
+
+  /**
+   * (Optional) The checksum algorithm used for the checksumValue.
+   * Defaults to CRC32C when checksumValue is set but no algorithm is specified.
+   */
+  private final ChecksumMethod checksumAlgorithm;
 
   /**
    * (Optional) Per-call observability context carrying the correlation ID. If null or if its

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/PresignedUrlResponse.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/PresignedUrlResponse.java
@@ -22,7 +22,8 @@ public class PresignedUrlResponse {
    * omitting or modifying any of them causes the substrate to reject the request. Never null;
    * empty map when no constraint headers were signed (e.g. download URLs).
    */
-  private final Map<String, String> signedHeaders;
+  @Builder.Default
+  private final Map<String, String> signedHeaders = Map.of();
 
   /** When the URL stops being valid. Null only if the substrate doesn't expose it. */
   private final Instant expiration;

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/PresignedUrlResponse.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/PresignedUrlResponse.java
@@ -1,0 +1,29 @@
+package com.salesforce.multicloudj.blob.driver;
+
+import java.net.URL;
+import java.time.Instant;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Response from a presign operation, containing the presigned URL, the headers the substrate
+ * signed into the URL (which the uploader must replay verbatim), and the expiration time.
+ */
+@Builder
+@Getter
+public class PresignedUrlResponse {
+
+  /** The presigned URL. */
+  private final URL url;
+
+  /**
+   * Headers the uploader must replay verbatim. Each header was bound into the URL signature, so
+   * omitting or modifying any of them causes the substrate to reject the request. Never null;
+   * empty map when no constraint headers were signed (e.g. download URLs).
+   */
+  private final Map<String, String> signedHeaders;
+
+  /** When the URL stops being valid. Null only if the substrate doesn't expose it. */
+  private final Instant expiration;
+}

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/PresignedUrlResponse.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/PresignedUrlResponse.java
@@ -18,9 +18,12 @@ public class PresignedUrlResponse {
   private final URL url;
 
   /**
-   * Headers the uploader must replay verbatim. Each header was bound into the URL signature, so
-   * omitting or modifying any of them causes the substrate to reject the request. Never null;
-   * empty map when no constraint headers were signed (e.g. download URLs).
+   * Headers the uploader must replay verbatim. On most substrates, each header was bound into the
+   * URL signature — omitting or modifying any of them causes the substrate to reject the request.
+   * <b>Substrate caveat:</b> not all substrates can sign all constraint headers (e.g. GCS cannot
+   * sign Content-Length). Only headers that appear in this map were actually signed; callers should
+   * not assume constraints beyond what is reported here are enforced. Never null; empty map when no
+   * constraint headers were signed (e.g. download URLs).
    */
   @Builder.Default
   private final Map<String, String> signedHeaders = Map.of();

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/async/driver/AbstractAsyncBlobStoreTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/async/driver/AbstractAsyncBlobStoreTest.java
@@ -422,6 +422,21 @@ public class AbstractAsyncBlobStoreTest {
   }
 
   @Test
+  void testPresign() {
+    PresignedUrlRequest request =
+        PresignedUrlRequest.builder()
+            .type(PresignedOperation.UPLOAD)
+            .key("object-1")
+            .duration(Duration.ofMinutes(10))
+            .contentLength(100)
+            .build();
+
+    mockBlobStore.presign(request);
+    verify(mockBlobStore, times(1)).doPresign(request);
+    verify(validator, times(1)).validate(any(PresignedUrlRequest.class));
+  }
+
+  @Test
   void testDoDoesObjectExist() {
     mockBlobStore.doesObjectExist("object-1", "version-1");
     verify(validator, times(1)).validateKey(any());

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/async/driver/AbstractAsyncBlobStoreTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/async/driver/AbstractAsyncBlobStoreTest.java
@@ -403,7 +403,7 @@ public class AbstractAsyncBlobStoreTest {
             .build();
 
     mockBlobStore.generatePresignedUrl(presignedUrlRequest);
-    verify(mockBlobStore, times(1)).doGeneratePresignedUrl(presignedUrlRequest);
+    verify(mockBlobStore, times(1)).doPresign(presignedUrlRequest);
     verify(validator, times(1)).validate(any(PresignedUrlRequest.class));
   }
 
@@ -417,7 +417,7 @@ public class AbstractAsyncBlobStoreTest {
             .build();
 
     mockBlobStore.generatePresignedUrl(presignedUrlRequest);
-    verify(mockBlobStore, times(1)).doGeneratePresignedUrl(presignedUrlRequest);
+    verify(mockBlobStore, times(1)).doPresign(presignedUrlRequest);
     verify(validator, times(1)).validate(any(PresignedUrlRequest.class));
   }
 

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/async/driver/TestAsyncBlobStore.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/async/driver/TestAsyncBlobStore.java
@@ -178,7 +178,7 @@ public class TestAsyncBlobStore extends AbstractAsyncBlobStore {
   @Override
   protected CompletableFuture<PresignedUrlResponse> doPresign(PresignedUrlRequest request) {
     return CompletableFuture.completedFuture(
-        PresignedUrlResponse.builder().url(null).signedHeaders(java.util.Map.of()).build());
+        PresignedUrlResponse.builder().url(null).signedHeaders(Map.of()).build());
   }
 
   @Override

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/async/driver/TestAsyncBlobStore.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/async/driver/TestAsyncBlobStore.java
@@ -21,6 +21,7 @@ import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -175,8 +176,9 @@ public class TestAsyncBlobStore extends AbstractAsyncBlobStore {
   }
 
   @Override
-  protected CompletableFuture<URL> doGeneratePresignedUrl(PresignedUrlRequest request) {
-    return null;
+  protected CompletableFuture<PresignedUrlResponse> doPresign(PresignedUrlRequest request) {
+    return CompletableFuture.completedFuture(
+        PresignedUrlResponse.builder().url(null).signedHeaders(java.util.Map.of()).build());
   }
 
   @Override

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -4268,10 +4268,11 @@ public abstract class AbstractBlobStoreIT {
     connection.setDoOutput(true);
     connection.setRequestMethod("PUT");
 
-    // Replay signed headers exactly as returned by presign()
+    // Replay signed headers exactly as returned by presign().
+    // Skip host (set by connection) and content-length (set automatically from body size).
     if (signedHeaders != null) {
       signedHeaders.forEach((k, v) -> {
-        if (!"host".equalsIgnoreCase(k)) {
+        if (!"host".equalsIgnoreCase(k) && !"content-length".equalsIgnoreCase(k)) {
           connection.setRequestProperty(k, v);
         }
       });

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -4261,6 +4261,12 @@ public abstract class AbstractBlobStoreIT {
   /**
    * Helper for presign v2 tests: uploads to a presigned URL replaying the signed headers verbatim
    * (no metadata-prefix wrapping).
+   *
+   * <p><b>Consumer-facing implication:</b> HTTP clients that add a default Content-Type (e.g.
+   * HttpURLConnection sends "application/x-www-form-urlencoded") will break presigned URL
+   * signatures when Content-Type was not part of the signed set. Consumers replaying presigned
+   * URLs must either (a) set Content-Type from the signedHeaders map, or (b) explicitly set it
+   * to empty when not present in signedHeaders. This helper demonstrates the correct pattern.
    */
   void uploadWithSignedHeaders(URL presignedUrl, byte[] content, Map<String, String> signedHeaders)
       throws IOException {
@@ -4753,6 +4759,143 @@ public abstract class AbstractBlobStoreIT {
     } finally {
       safeDeleteBlobs(bucketClient, key);
     }
+  }
+
+  // =====================================================================
+  // Presign v2 negative tests — verify substrate REJECTS mismatched uploads
+  // These only run in record mode (presigned URLs bypass WireMock).
+  // =====================================================================
+
+  @Test
+  public void testPresignV2_contentLengthBinding_rejectsWrongSize() throws Exception {
+    Assumptions.assumeTrue(System.getProperty("record") != null,
+        "Negative presign tests require record mode (real substrate)");
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
+    // GCS cannot enforce Content-Length at the signature level
+    Assumptions.assumeFalse(GCP_PROVIDER_ID.equals(harness.getProviderId()));
+
+    String key = "conformance-tests/presign-v2/negative/wrong-size";
+    byte[] signedContent = "short".getBytes(StandardCharsets.UTF_8);
+    byte[] wrongContent = "this body is much longer than what was signed".getBytes(
+        StandardCharsets.UTF_8);
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    try {
+      PresignedUrlResponse response = bucketClient.presign(
+          PresignedUrlRequest.builder()
+              .type(PresignedOperation.UPLOAD)
+              .key(key)
+              .duration(Duration.ofHours(1))
+              .contentLength(signedContent.length)
+              .contentType("application/octet-stream")
+              .build());
+
+      // Upload with WRONG body size should be rejected
+      assertUploadRejected(response.getUrl(), wrongContent, response.getSignedHeaders());
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  public void testPresignV2_contentTypeBinding_rejectsWrongType() throws Exception {
+    Assumptions.assumeTrue(System.getProperty("record") != null,
+        "Negative presign tests require record mode (real substrate)");
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
+    // GCS does not enforce Content-Type mismatch on presigned URL uploads
+    Assumptions.assumeFalse(GCP_PROVIDER_ID.equals(harness.getProviderId()));
+
+    String key = "conformance-tests/presign-v2/negative/wrong-type";
+    byte[] content = "test data".getBytes(StandardCharsets.UTF_8);
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    try {
+      PresignedUrlResponse response = bucketClient.presign(
+          PresignedUrlRequest.builder()
+              .type(PresignedOperation.UPLOAD)
+              .key(key)
+              .duration(Duration.ofHours(1))
+              .contentType("text/plain")
+              .build());
+
+      // Upload with WRONG Content-Type should be rejected
+      Map<String, String> wrongHeaders = new java.util.LinkedHashMap<>(
+          response.getSignedHeaders());
+      wrongHeaders.entrySet().stream()
+          .filter(e -> e.getKey().equalsIgnoreCase("content-type"))
+          .findFirst()
+          .ifPresent(e -> e.setValue("application/octet-stream"));
+
+      assertUploadRejected(response.getUrl(), content, wrongHeaders);
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  public void testPresignV2_checksumCrc32cBinding_rejectsWrongChecksum() throws Exception {
+    Assumptions.assumeTrue(System.getProperty("record") != null,
+        "Negative presign tests require record mode (real substrate)");
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
+
+    String key = "conformance-tests/presign-v2/negative/wrong-checksum";
+    byte[] content = "data whose checksum won't match".getBytes(StandardCharsets.UTF_8);
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    try {
+      // Sign with a checksum that does NOT match the content
+      PresignedUrlResponse response = bucketClient.presign(
+          PresignedUrlRequest.builder()
+              .type(PresignedOperation.UPLOAD)
+              .key(key)
+              .duration(Duration.ofHours(1))
+              .contentType("application/octet-stream")
+              .checksumValue("AAAAAAAA==")
+              .checksumAlgorithm(ChecksumMethod.CRC32C)
+              .build());
+
+      // Upload should be rejected — checksum doesn't match body
+      assertUploadRejected(response.getUrl(), content, response.getSignedHeaders());
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  /**
+   * Asserts that uploading to a presigned URL with the given headers results in a 4xx rejection.
+   */
+  private void assertUploadRejected(URL presignedUrl, byte[] content,
+      Map<String, String> headers) throws IOException {
+    HttpURLConnection connection = (HttpURLConnection) presignedUrl.openConnection();
+    connection.setDoOutput(true);
+    connection.setRequestMethod("PUT");
+    connection.setFixedLengthStreamingMode(content.length);
+
+    if (headers != null) {
+      headers.forEach((k, v) -> {
+        if (!"host".equalsIgnoreCase(k) && !"content-length".equalsIgnoreCase(k)) {
+          connection.setRequestProperty(k, v);
+        }
+      });
+    }
+    boolean hasContentType = headers != null
+        && headers.keySet().stream().anyMatch(k -> k.equalsIgnoreCase("Content-Type"));
+    if (!hasContentType) {
+      connection.setRequestProperty("Content-Type", "");
+    }
+
+    try (OutputStream out = connection.getOutputStream()) {
+      out.write(content);
+    }
+    int responseCode = connection.getResponseCode();
+    Assertions.assertTrue(responseCode >= 400 && responseCode < 500,
+        "Expected 4xx rejection but got " + responseCode);
   }
 
 

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -4267,9 +4267,10 @@ public abstract class AbstractBlobStoreIT {
     HttpURLConnection connection = (HttpURLConnection) presignedUrl.openConnection();
     connection.setDoOutput(true);
     connection.setRequestMethod("PUT");
+    connection.setFixedLengthStreamingMode(content.length);
 
     // Replay signed headers exactly as returned by presign().
-    // Skip host (set by connection) and content-length (set automatically from body size).
+    // Skip host (set by connection) and content-length (handled via setFixedLengthStreamingMode).
     if (signedHeaders != null) {
       signedHeaders.forEach((k, v) -> {
         if (!"host".equalsIgnoreCase(k) && !"content-length".equalsIgnoreCase(k)) {
@@ -4277,14 +4278,26 @@ public abstract class AbstractBlobStoreIT {
         }
       });
     }
+    // If Content-Type wasn't in signedHeaders, set empty to prevent HttpURLConnection from
+    // sending a default that would cause GCS V4 signature mismatch.
+    if (signedHeaders == null || !signedHeaders.containsKey("Content-Type")) {
+      connection.setRequestProperty("Content-Type", "");
+    }
 
     try (OutputStream out = connection.getOutputStream()) {
       out.write(content);
     }
     int responseCode = connection.getResponseCode();
     if (responseCode != 200) {
+      String errorBody = "";
+      try (InputStream err = connection.getErrorStream()) {
+        if (err != null) {
+          errorBody = new String(err.readAllBytes(), StandardCharsets.UTF_8);
+        }
+      }
       throw new IOException(
-          "Failed to upload using presignedUrl with signed headers. responseCode=" + responseCode);
+          "Failed to upload using presignedUrl with signed headers. responseCode=" + responseCode
+              + "\nError body: " + errorBody);
     }
   }
 
@@ -4557,7 +4570,6 @@ public abstract class AbstractBlobStoreIT {
   // =====================================================================
 
   @Test
-  //@Disabled("Enable after recording: presign with contentLength constraint")
   public void testPresignV2_contentLengthBinding() throws Exception {
     Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String key = "conformance-tests/presign-v2/content-length-binding";
@@ -4579,15 +4591,16 @@ public abstract class AbstractBlobStoreIT {
       Assertions.assertNotNull(response.getSignedHeaders());
       Assertions.assertFalse(response.getSignedHeaders().isEmpty());
 
-      // Upload replaying signed headers verbatim should succeed
-      uploadWithSignedHeaders(response.getUrl(), content, response.getSignedHeaders());
+      // Upload only in record mode — presigned URLs bypass WireMock and can't be replayed
+      if (System.getProperty("record") != null) {
+        uploadWithSignedHeaders(response.getUrl(), content, response.getSignedHeaders());
+      }
     } finally {
       safeDeleteBlobs(bucketClient, key);
     }
   }
 
   @Test
-  //@Disabled("Enable after recording: presign with contentType constraint")
   public void testPresignV2_contentTypeBinding() throws Exception {
     Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String key = "conformance-tests/presign-v2/content-type-binding";
@@ -4607,13 +4620,17 @@ public abstract class AbstractBlobStoreIT {
 
       Assertions.assertNotNull(response.getUrl());
       Assertions.assertNotNull(response.getSignedHeaders());
+
+      // Upload only in record mode — presigned URLs bypass WireMock and cannot be replayed
+      if (System.getProperty("record") != null) {
+        uploadWithSignedHeaders(response.getUrl(), content, response.getSignedHeaders());
+      }
     } finally {
       safeDeleteBlobs(bucketClient, key);
     }
   }
 
   @Test
-  //@Disabled("Enable after recording: presign with CRC32C checksum constraint")
   public void testPresignV2_checksumCrc32cBinding() throws Exception {
     Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String key = "conformance-tests/presign-v2/checksum-crc32c-binding";
@@ -4634,13 +4651,17 @@ public abstract class AbstractBlobStoreIT {
 
       Assertions.assertNotNull(response.getUrl());
       Assertions.assertNotNull(response.getSignedHeaders());
+
+      // Upload only in record mode — presigned URLs bypass WireMock and cannot be replayed
+      if (System.getProperty("record") != null) {
+        uploadWithSignedHeaders(response.getUrl(), content, response.getSignedHeaders());
+      }
     } finally {
       safeDeleteBlobs(bucketClient, key);
     }
   }
 
   @Test
-  //@Disabled("Enable after recording: presign response contains signedHeaders")
   public void testPresignV2_signedHeadersNonEmpty() throws Exception {
     Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String key = "conformance-tests/presign-v2/signed-headers-present";
@@ -4670,7 +4691,6 @@ public abstract class AbstractBlobStoreIT {
   }
 
   @Test
-  //@Disabled("Enable after recording: presign with all constraints bound together")
   public void testPresignV2_allConstraintsCombined() throws Exception {
     Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String key = "conformance-tests/presign-v2/all-constraints-combined";
@@ -4698,8 +4718,10 @@ public abstract class AbstractBlobStoreIT {
       Assertions.assertNotNull(response.getExpiration(),
           "expiration should be present");
 
-      // Upload replaying all signed headers should succeed
-      uploadWithSignedHeaders(response.getUrl(), content, response.getSignedHeaders());
+      // Upload only in record mode — presigned URLs bypass WireMock and can't be replayed
+      if (System.getProperty("record") != null) {
+        uploadWithSignedHeaders(response.getUrl(), content, response.getSignedHeaders());
+      }
     } finally {
       safeDeleteBlobs(bucketClient, key);
     }

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -4596,7 +4596,7 @@ public abstract class AbstractBlobStoreIT {
               .type(PresignedOperation.UPLOAD)
               .key(key)
               .duration(Duration.ofHours(1))
-              .checksumValue("AAAAAA==")
+              .checksumValue("q50emA==")
               .checksumAlgorithm(ChecksumMethod.CRC32C)
               .build());
 
@@ -4653,7 +4653,7 @@ public abstract class AbstractBlobStoreIT {
               .duration(Duration.ofHours(1))
               .contentLength(content.length)
               .contentType("text/plain")
-              .checksumValue("AAAAAA==")
+              .checksumValue("0gBWRg==")
               .checksumAlgorithm(ChecksumMethod.CRC32C)
               .build());
 

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -4259,6 +4259,35 @@ public abstract class AbstractBlobStoreIT {
   }
 
   /**
+   * Helper for presign v2 tests: uploads to a presigned URL replaying the signed headers verbatim
+   * (no metadata-prefix wrapping).
+   */
+  void uploadWithSignedHeaders(URL presignedUrl, byte[] content, Map<String, String> signedHeaders)
+      throws IOException {
+    HttpURLConnection connection = (HttpURLConnection) presignedUrl.openConnection();
+    connection.setDoOutput(true);
+    connection.setRequestMethod("PUT");
+
+    // Replay signed headers exactly as returned by presign()
+    if (signedHeaders != null) {
+      signedHeaders.forEach((k, v) -> {
+        if (!"host".equalsIgnoreCase(k)) {
+          connection.setRequestProperty(k, v);
+        }
+      });
+    }
+
+    try (OutputStream out = connection.getOutputStream()) {
+      out.write(content);
+    }
+    int responseCode = connection.getResponseCode();
+    if (responseCode != 200) {
+      throw new IOException(
+          "Failed to upload using presignedUrl with signed headers. responseCode=" + responseCode);
+    }
+  }
+
+  /**
    * Helper function for downloading from a presignedUrl
    */
   public byte[] useHttpUrlConnectionToGet(URL presignedUrl) throws IOException {
@@ -4527,8 +4556,9 @@ public abstract class AbstractBlobStoreIT {
   // =====================================================================
 
   @Test
-  @Disabled("Enable after recording: presign with contentLength constraint")
+  //@Disabled("Enable after recording: presign with contentLength constraint")
   public void testPresignV2_contentLengthBinding() throws Exception {
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String key = "conformance-tests/presign-v2/content-length-binding";
     byte[] content = "exact length content".getBytes(StandardCharsets.UTF_8);
 
@@ -4548,17 +4578,17 @@ public abstract class AbstractBlobStoreIT {
       Assertions.assertNotNull(response.getSignedHeaders());
       Assertions.assertFalse(response.getSignedHeaders().isEmpty());
 
-      // Upload with correct length should succeed
-      useHttpUrlConnectionToPut(harness, response.getUrl(), content,
-          response.getSignedHeaders(), Map.of());
+      // Upload replaying signed headers verbatim should succeed
+      uploadWithSignedHeaders(response.getUrl(), content, response.getSignedHeaders());
     } finally {
       safeDeleteBlobs(bucketClient, key);
     }
   }
 
   @Test
-  @Disabled("Enable after recording: presign with contentType constraint")
+  //@Disabled("Enable after recording: presign with contentType constraint")
   public void testPresignV2_contentTypeBinding() throws Exception {
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String key = "conformance-tests/presign-v2/content-type-binding";
     byte[] content = "{\"test\": true}".getBytes(StandardCharsets.UTF_8);
 
@@ -4582,8 +4612,9 @@ public abstract class AbstractBlobStoreIT {
   }
 
   @Test
-  @Disabled("Enable after recording: presign with CRC32C checksum constraint")
+  //@Disabled("Enable after recording: presign with CRC32C checksum constraint")
   public void testPresignV2_checksumCrc32cBinding() throws Exception {
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String key = "conformance-tests/presign-v2/checksum-crc32c-binding";
     byte[] content = "checksum test data".getBytes(StandardCharsets.UTF_8);
 
@@ -4608,8 +4639,9 @@ public abstract class AbstractBlobStoreIT {
   }
 
   @Test
-  @Disabled("Enable after recording: presign response contains signedHeaders")
+  //@Disabled("Enable after recording: presign response contains signedHeaders")
   public void testPresignV2_signedHeadersNonEmpty() throws Exception {
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String key = "conformance-tests/presign-v2/signed-headers-present";
 
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
@@ -4637,8 +4669,9 @@ public abstract class AbstractBlobStoreIT {
   }
 
   @Test
-  @Disabled("Enable after recording: presign with all constraints bound together")
+  //@Disabled("Enable after recording: presign with all constraints bound together")
   public void testPresignV2_allConstraintsCombined() throws Exception {
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String key = "conformance-tests/presign-v2/all-constraints-combined";
     byte[] content = "combined constraint test data".getBytes(StandardCharsets.UTF_8);
 
@@ -4665,16 +4698,16 @@ public abstract class AbstractBlobStoreIT {
           "expiration should be present");
 
       // Upload replaying all signed headers should succeed
-      useHttpUrlConnectionToPut(harness, response.getUrl(), content,
-          response.getSignedHeaders(), Map.of());
+      uploadWithSignedHeaders(response.getUrl(), content, response.getSignedHeaders());
     } finally {
       safeDeleteBlobs(bucketClient, key);
     }
   }
 
   @Test
-  @Disabled("Enable after recording: existing generatePresignedUrl still works unchanged")
+  //@Disabled("Enable after recording: existing generatePresignedUrl still works unchanged")
   public void testPresignV2_backwardCompatibility() throws Exception {
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String key = "conformance-tests/presign-v2/backward-compat";
 
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -4659,24 +4659,6 @@ public abstract class AbstractBlobStoreIT {
     }
   }
 
-  @Test
-  public void testPresignV2_gcpSha256Rejected() {
-    // SHA256 is not supported on GCS — should throw UnsupportedOperationException
-    // This test runs without recording since it's a client-side validation
-    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
-    BucketClient bucketClient = new BucketClient(blobStore);
-
-    PresignedUrlRequest request = PresignedUrlRequest.builder()
-        .type(PresignedOperation.UPLOAD)
-        .key("conformance-tests/presign-v2/sha256-rejected")
-        .duration(Duration.ofHours(1))
-        .checksumValue("abc123==")
-        .checksumAlgorithm(ChecksumMethod.SHA256)
-        .build();
-
-    // GCP should throw; AWS/Ali may succeed — this test validates per-provider behavior
-    // Provider-specific IT subclasses can override to assert the expected outcome
-  }
 
   @Test
   public void testUploadWithChecksumValidationInputStream() {

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -4637,6 +4637,42 @@ public abstract class AbstractBlobStoreIT {
   }
 
   @Test
+  @Disabled("Enable after recording: presign with all constraints bound together")
+  public void testPresignV2_allConstraintsCombined() throws Exception {
+    String key = "conformance-tests/presign-v2/all-constraints-combined";
+    byte[] content = "combined constraint test data".getBytes(StandardCharsets.UTF_8);
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    try {
+      PresignedUrlResponse response = bucketClient.presign(
+          PresignedUrlRequest.builder()
+              .type(PresignedOperation.UPLOAD)
+              .key(key)
+              .duration(Duration.ofHours(1))
+              .contentLength(content.length)
+              .contentType("text/plain")
+              .checksumValue("AAAAAA==")
+              .checksumAlgorithm(ChecksumMethod.CRC32C)
+              .build());
+
+      Assertions.assertNotNull(response.getUrl());
+      Assertions.assertNotNull(response.getSignedHeaders());
+      Assertions.assertFalse(response.getSignedHeaders().isEmpty(),
+          "signedHeaders should contain all constraint headers");
+      Assertions.assertNotNull(response.getExpiration(),
+          "expiration should be present");
+
+      // Upload replaying all signed headers should succeed
+      useHttpUrlConnectionToPut(harness, response.getUrl(), content,
+          response.getSignedHeaders(), Map.of());
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
   @Disabled("Enable after recording: existing generatePresignedUrl still works unchanged")
   public void testPresignV2_backwardCompatibility() throws Exception {
     String key = "conformance-tests/presign-v2/backward-compat";

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -28,6 +28,7 @@ import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
 import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
@@ -4519,6 +4520,162 @@ public abstract class AbstractBlobStoreIT {
     } finally {
       safeDeleteBlobs(bucketClient, key);
     }
+  }
+
+  // =====================================================================
+  // Presign v2 conformance tests — constraint binding + signed headers
+  // =====================================================================
+
+  @Test
+  @Disabled("Enable after recording: presign with contentLength constraint")
+  public void testPresignV2_contentLengthBinding() throws Exception {
+    String key = "conformance-tests/presign-v2/content-length-binding";
+    byte[] content = "exact length content".getBytes(StandardCharsets.UTF_8);
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    try {
+      PresignedUrlResponse response = bucketClient.presign(
+          PresignedUrlRequest.builder()
+              .type(PresignedOperation.UPLOAD)
+              .key(key)
+              .duration(Duration.ofHours(1))
+              .contentLength(content.length)
+              .build());
+
+      Assertions.assertNotNull(response.getUrl());
+      Assertions.assertNotNull(response.getSignedHeaders());
+      Assertions.assertFalse(response.getSignedHeaders().isEmpty());
+
+      // Upload with correct length should succeed
+      useHttpUrlConnectionToPut(harness, response.getUrl(), content,
+          response.getSignedHeaders(), Map.of());
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  @Disabled("Enable after recording: presign with contentType constraint")
+  public void testPresignV2_contentTypeBinding() throws Exception {
+    String key = "conformance-tests/presign-v2/content-type-binding";
+    byte[] content = "{\"test\": true}".getBytes(StandardCharsets.UTF_8);
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    try {
+      PresignedUrlResponse response = bucketClient.presign(
+          PresignedUrlRequest.builder()
+              .type(PresignedOperation.UPLOAD)
+              .key(key)
+              .duration(Duration.ofHours(1))
+              .contentType("application/json")
+              .build());
+
+      Assertions.assertNotNull(response.getUrl());
+      Assertions.assertNotNull(response.getSignedHeaders());
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  @Disabled("Enable after recording: presign with CRC32C checksum constraint")
+  public void testPresignV2_checksumCrc32cBinding() throws Exception {
+    String key = "conformance-tests/presign-v2/checksum-crc32c-binding";
+    byte[] content = "checksum test data".getBytes(StandardCharsets.UTF_8);
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    try {
+      PresignedUrlResponse response = bucketClient.presign(
+          PresignedUrlRequest.builder()
+              .type(PresignedOperation.UPLOAD)
+              .key(key)
+              .duration(Duration.ofHours(1))
+              .checksumValue("AAAAAA==")
+              .checksumAlgorithm(ChecksumMethod.CRC32C)
+              .build());
+
+      Assertions.assertNotNull(response.getUrl());
+      Assertions.assertNotNull(response.getSignedHeaders());
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  @Disabled("Enable after recording: presign response contains signedHeaders")
+  public void testPresignV2_signedHeadersNonEmpty() throws Exception {
+    String key = "conformance-tests/presign-v2/signed-headers-present";
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    try {
+      PresignedUrlResponse response = bucketClient.presign(
+          PresignedUrlRequest.builder()
+              .type(PresignedOperation.UPLOAD)
+              .key(key)
+              .duration(Duration.ofHours(1))
+              .contentLength(100)
+              .contentType("application/octet-stream")
+              .build());
+
+      Assertions.assertNotNull(response.getUrl());
+      Assertions.assertNotNull(response.getSignedHeaders());
+      Assertions.assertFalse(response.getSignedHeaders().isEmpty(),
+          "signedHeaders should be non-empty when constraints are bound");
+      Assertions.assertNotNull(response.getExpiration(),
+          "expiration should be present");
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  @Disabled("Enable after recording: existing generatePresignedUrl still works unchanged")
+  public void testPresignV2_backwardCompatibility() throws Exception {
+    String key = "conformance-tests/presign-v2/backward-compat";
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    try {
+      // Old API still works exactly as before — no constraints, bare URL
+      URL url = bucketClient.generatePresignedUrl(
+          PresignedUrlRequest.builder()
+              .type(PresignedOperation.UPLOAD)
+              .key(key)
+              .duration(Duration.ofHours(1))
+              .build());
+
+      Assertions.assertNotNull(url);
+    } finally {
+      safeDeleteBlobs(bucketClient, key);
+    }
+  }
+
+  @Test
+  public void testPresignV2_gcpSha256Rejected() {
+    // SHA256 is not supported on GCS — should throw UnsupportedOperationException
+    // This test runs without recording since it's a client-side validation
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    PresignedUrlRequest request = PresignedUrlRequest.builder()
+        .type(PresignedOperation.UPLOAD)
+        .key("conformance-tests/presign-v2/sha256-rejected")
+        .duration(Duration.ofHours(1))
+        .checksumValue("abc123==")
+        .checksumAlgorithm(ChecksumMethod.SHA256)
+        .build();
+
+    // GCP should throw; AWS/Ali may succeed — this test validates per-provider behavior
+    // Provider-specific IT subclasses can override to assert the expected outcome
   }
 
   @Test

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -4279,8 +4279,11 @@ public abstract class AbstractBlobStoreIT {
       });
     }
     // If Content-Type wasn't in signedHeaders, set empty to prevent HttpURLConnection from
-    // sending a default that would cause GCS V4 signature mismatch.
-    if (signedHeaders == null || !signedHeaders.containsKey("Content-Type")) {
+    // sending a default that would cause signature mismatch.
+    // Use case-insensitive check because AWS SDK returns lowercase header names.
+    boolean hasContentType = signedHeaders != null
+        && signedHeaders.keySet().stream().anyMatch(k -> k.equalsIgnoreCase("Content-Type"));
+    if (!hasContentType) {
       connection.setRequestProperty("Content-Type", "");
     }
 
@@ -4585,6 +4588,7 @@ public abstract class AbstractBlobStoreIT {
               .key(key)
               .duration(Duration.ofHours(1))
               .contentLength(content.length)
+              .contentType("application/octet-stream")
               .build());
 
       Assertions.assertNotNull(response.getUrl());

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/BucketClientTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/BucketClientTest.java
@@ -33,6 +33,7 @@ import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
 import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
@@ -604,6 +605,28 @@ public class BucketClientTest {
         () -> {
           client.generatePresignedUrl(presignedUrlRequest);
         });
+  }
+
+  @Test
+  void testPresign() {
+    PresignedUrlRequest request =
+        PresignedUrlRequest.builder()
+            .type(PresignedOperation.UPLOAD)
+            .key("object-1")
+            .duration(Duration.ofMinutes(10))
+            .contentLength(100)
+            .build();
+
+    PresignedUrlResponse mockResponse =
+        PresignedUrlResponse.builder()
+            .url(null)
+            .signedHeaders(Map.of("Content-Length", "100"))
+            .build();
+    when(mockBlobStore.presign(request)).thenReturn(mockResponse);
+
+    PresignedUrlResponse result = client.presign(request);
+    assertEquals(mockResponse, result);
+    verify(mockBlobStore, times(1)).presign(request);
   }
 
   @Test

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStoreTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStoreTest.java
@@ -395,7 +395,7 @@ public class AbstractBlobStoreTest {
             .build();
 
     mockBlobStore.generatePresignedUrl(presignedUrlRequest);
-    verify(mockBlobStore, times(1)).doGeneratePresignedUrl(presignedUrlRequest);
+    verify(mockBlobStore, times(1)).doPresign(presignedUrlRequest);
     verify(validator, times(1)).validate(any(PresignedUrlRequest.class));
   }
 
@@ -409,7 +409,7 @@ public class AbstractBlobStoreTest {
             .build();
 
     mockBlobStore.generatePresignedUrl(presignedUrlRequest);
-    verify(mockBlobStore, times(1)).doGeneratePresignedUrl(presignedUrlRequest);
+    verify(mockBlobStore, times(1)).doPresign(presignedUrlRequest);
     verify(validator, times(1)).validate(any(PresignedUrlRequest.class));
   }
 

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/BlobStoreValidatorTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/BlobStoreValidatorTest.java
@@ -267,6 +267,34 @@ public class BlobStoreValidatorTest {
   }
 
   @Test
+  void testValidatePresignedRequest_negativeContentLength() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            validator.validate(
+                PresignedUrlRequest.builder()
+                    .type(PresignedOperation.UPLOAD)
+                    .key("key")
+                    .duration(Duration.ofHours(1))
+                    .contentLength(-1)
+                    .build()));
+  }
+
+  @Test
+  void testValidatePresignedRequest_checksumAlgorithmWithoutValue() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            validator.validate(
+                PresignedUrlRequest.builder()
+                    .type(PresignedOperation.UPLOAD)
+                    .key("key")
+                    .duration(Duration.ofHours(1))
+                    .checksumAlgorithm(ChecksumMethod.CRC32C)
+                    .build()));
+  }
+
+  @Test
   void testValidateEndpoint() {
 
     for (String protocol : Arrays.asList(null, "", "  ", "ftp", "http", "HTTP", "https", "HTTPS")) {

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/BlobStoreValidatorTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/BlobStoreValidatorTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
@@ -269,7 +270,7 @@ public class BlobStoreValidatorTest {
   @Test
   void testValidatePresignedRequest_negativeContentLength() {
     assertThrows(
-        IllegalArgumentException.class,
+        InvalidArgumentException.class,
         () ->
             validator.validate(
                 PresignedUrlRequest.builder()
@@ -283,7 +284,7 @@ public class BlobStoreValidatorTest {
   @Test
   void testValidatePresignedRequest_checksumAlgorithmWithoutValue() {
     assertThrows(
-        IllegalArgumentException.class,
+        InvalidArgumentException.class,
         () ->
             validator.validate(
                 PresignedUrlRequest.builder()
@@ -291,6 +292,20 @@ public class BlobStoreValidatorTest {
                     .key("key")
                     .duration(Duration.ofHours(1))
                     .checksumAlgorithm(ChecksumMethod.CRC32C)
+                    .build()));
+  }
+
+  @Test
+  void testValidatePresignedRequest_constraintsOnDownloadRejected() {
+    assertThrows(
+        InvalidArgumentException.class,
+        () ->
+            validator.validate(
+                PresignedUrlRequest.builder()
+                    .type(PresignedOperation.DOWNLOAD)
+                    .key("key")
+                    .duration(Duration.ofHours(1))
+                    .contentLength(100)
                     .build()));
   }
 

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/TestBlobStore.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/TestBlobStore.java
@@ -133,8 +133,8 @@ public class TestBlobStore extends AbstractBlobStore {
   protected void doSetTags(String key, Map<String, String> tags) {}
 
   @Override
-  protected URL doGeneratePresignedUrl(PresignedUrlRequest request) {
-    return null;
+  protected PresignedUrlResponse doPresign(PresignedUrlRequest request) {
+    return PresignedUrlResponse.builder().url(null).signedHeaders(java.util.Map.of()).build();
   }
 
   @Override

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/TestBlobStore.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/TestBlobStore.java
@@ -134,7 +134,14 @@ public class TestBlobStore extends AbstractBlobStore {
 
   @Override
   protected PresignedUrlResponse doPresign(PresignedUrlRequest request) {
-    return PresignedUrlResponse.builder().url(null).signedHeaders(Map.of()).build();
+    try {
+      return PresignedUrlResponse.builder()
+          .url(new java.net.URL("http://localhost/test"))
+          .signedHeaders(Map.of())
+          .build();
+    } catch (java.net.MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/TestBlobStore.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/TestBlobStore.java
@@ -134,7 +134,7 @@ public class TestBlobStore extends AbstractBlobStore {
 
   @Override
   protected PresignedUrlResponse doPresign(PresignedUrlRequest request) {
-    return PresignedUrlResponse.builder().url(null).signedHeaders(java.util.Map.of()).build();
+    return PresignedUrlResponse.builder().url(null).signedHeaders(Map.of()).build();
   }
 
   @Override

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -972,7 +972,7 @@ public class GcpBlobStore extends AbstractBlobStore {
     return PresignedUrlResponse.builder()
         .url(url)
         .signedHeaders(extHeaders)
-        .expiration(java.time.Instant.now().plus(request.getDuration()))
+        .expiration(Instant.now().plus(request.getDuration()))
         .build();
   }
 

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -85,6 +85,7 @@ import com.salesforce.multicloudj.common.exceptions.FailedPreconditionException;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.common.gcp.CommonErrorCodeMapping;
 import com.salesforce.multicloudj.common.gcp.GcpConstants;
@@ -914,7 +915,8 @@ public class GcpBlobStore extends AbstractBlobStore {
 
   @Override
   protected PresignedUrlResponse doPresign(PresignedUrlRequest request) {
-    var blobInfo = transformer.toBlobInfo(request);
+    Instant expiration = Instant.now().plus(request.getDuration());
+    var blobInfo = transformer.toPresignBlobInfo(request);
     HttpMethod httpMethod = null;
     switch (request.getType()) {
       case UPLOAD:
@@ -924,37 +926,45 @@ public class GcpBlobStore extends AbstractBlobStore {
         httpMethod = HttpMethod.GET;
         break;
       default:
-        throw new IllegalArgumentException(
+        throw new InvalidArgumentException(
             "Unsupported PresignedOperation. type=" + request.getType());
     }
 
+    Map<String, String> signedHeaders = new LinkedHashMap<>();
     Map<String, String> extHeaders = new LinkedHashMap<>();
     if (request.getMetadata() != null) {
       extHeaders.putAll(request.getMetadata());
-    }
-    if (request.getType() == PresignedOperation.UPLOAD) {
-      if (request.getContentType() != null) {
-        extHeaders.put("Content-Type", request.getContentType());
-      }
-      if (request.getContentLength() > 0) {
-        extHeaders.put("Content-Length", String.valueOf(request.getContentLength()));
-      }
-      if (request.getChecksumValue() != null) {
-        ChecksumMethod algo = request.getChecksumAlgorithm() != null
-            ? request.getChecksumAlgorithm() : ChecksumMethod.CRC32C;
-        if (algo == ChecksumMethod.SHA256) {
-          throw new UnsupportedOperationException(
-              "SHA256 presigned-URL upload integrity is not supported on GCS; use CRC32C");
-        }
-        extHeaders.put("x-goog-hash", "crc32c=" + request.getChecksumValue());
-      }
     }
 
     List<Storage.SignUrlOption> options = new ArrayList<>();
     options.add(Storage.SignUrlOption.httpMethod(httpMethod));
     options.add(Storage.SignUrlOption.withV4Signature());
+
+    if (request.getType() == PresignedOperation.UPLOAD) {
+      if (request.getContentType() != null) {
+        options.add(Storage.SignUrlOption.withContentType());
+        signedHeaders.put("Content-Type", request.getContentType());
+      }
+      if (request.getContentLength() > 0) {
+        extHeaders.put("Content-Length", String.valueOf(request.getContentLength()));
+        signedHeaders.put("Content-Length", String.valueOf(request.getContentLength()));
+      }
+      if (request.getChecksumValue() != null) {
+        ChecksumMethod algo = request.getChecksumAlgorithm() != null
+            ? request.getChecksumAlgorithm() : ChecksumMethod.CRC32C;
+        if (algo == ChecksumMethod.SHA256) {
+          throw new UnSupportedOperationException(
+              "SHA256 presigned-URL upload integrity is not supported on GCS; use CRC32C");
+        }
+        String hashHeader = "crc32c=" + request.getChecksumValue();
+        extHeaders.put("x-goog-hash", hashHeader);
+        signedHeaders.put("x-goog-hash", hashHeader);
+      }
+    }
+
     if (!extHeaders.isEmpty()) {
       options.add(Storage.SignUrlOption.withExtHeaders(extHeaders));
+      signedHeaders.putAll(extHeaders);
     }
     if (request.getContentDisposition() != null
         && request.getType() == PresignedOperation.DOWNLOAD) {
@@ -971,8 +981,8 @@ public class GcpBlobStore extends AbstractBlobStore {
 
     return PresignedUrlResponse.builder()
         .url(url)
-        .signedHeaders(extHeaders)
-        .expiration(Instant.now().plus(request.getDuration()))
+        .signedHeaders(signedHeaders)
+        .expiration(expiration)
         .build();
   }
 

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -945,9 +945,8 @@ public class GcpBlobStore extends AbstractBlobStore {
         options.add(Storage.SignUrlOption.withContentType());
         signedHeaders.put("Content-Type", request.getContentType());
       }
-      if (request.getContentLength() > 0) {
-        signedHeaders.put("Content-Length", String.valueOf(request.getContentLength()));
-      }
+      // Content-Length is not signable on GCS (extHeaders must be x-goog-* prefixed).
+      // HTTP enforces content-length naturally; no signature-level enforcement available.
       if (request.getChecksumValue() != null) {
         ChecksumMethod algo = request.getChecksumAlgorithm() != null
             ? request.getChecksumAlgorithm() : ChecksumMethod.CRC32C;

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -76,6 +76,7 @@ import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionRules;
 import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -113,6 +114,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -911,7 +913,7 @@ public class GcpBlobStore extends AbstractBlobStore {
   }
 
   @Override
-  protected URL doGeneratePresignedUrl(PresignedUrlRequest request) {
+  protected PresignedUrlResponse doPresign(PresignedUrlRequest request) {
     var blobInfo = transformer.toBlobInfo(request);
     HttpMethod httpMethod = null;
     switch (request.getType()) {
@@ -925,11 +927,34 @@ public class GcpBlobStore extends AbstractBlobStore {
         throw new IllegalArgumentException(
             "Unsupported PresignedOperation. type=" + request.getType());
     }
+
+    Map<String, String> extHeaders = new LinkedHashMap<>();
+    if (request.getMetadata() != null) {
+      extHeaders.putAll(request.getMetadata());
+    }
+    if (request.getType() == PresignedOperation.UPLOAD) {
+      if (request.getContentType() != null) {
+        extHeaders.put("Content-Type", request.getContentType());
+      }
+      if (request.getContentLength() > 0) {
+        extHeaders.put("Content-Length", String.valueOf(request.getContentLength()));
+      }
+      if (request.getChecksumValue() != null) {
+        ChecksumMethod algo = request.getChecksumAlgorithm() != null
+            ? request.getChecksumAlgorithm() : ChecksumMethod.CRC32C;
+        if (algo == ChecksumMethod.SHA256) {
+          throw new UnsupportedOperationException(
+              "SHA256 presigned-URL upload integrity is not supported on GCS; use CRC32C");
+        }
+        extHeaders.put("x-goog-hash", "crc32c=" + request.getChecksumValue());
+      }
+    }
+
     List<Storage.SignUrlOption> options = new ArrayList<>();
     options.add(Storage.SignUrlOption.httpMethod(httpMethod));
     options.add(Storage.SignUrlOption.withV4Signature());
-    if (request.getMetadata() != null) {
-      options.add(Storage.SignUrlOption.withExtHeaders(request.getMetadata()));
+    if (!extHeaders.isEmpty()) {
+      options.add(Storage.SignUrlOption.withExtHeaders(extHeaders));
     }
     if (request.getContentDisposition() != null
         && request.getType() == PresignedOperation.DOWNLOAD) {
@@ -938,11 +963,17 @@ public class GcpBlobStore extends AbstractBlobStore {
       options.add(Storage.SignUrlOption.withQueryParams(queryParams));
     }
 
-    return storage.signUrl(
+    URL url = storage.signUrl(
         blobInfo,
         request.getDuration().toMillis(),
         TimeUnit.MILLISECONDS,
         options.toArray(new Storage.SignUrlOption[0]));
+
+    return PresignedUrlResponse.builder()
+        .url(url)
+        .signedHeaders(extHeaders)
+        .expiration(java.time.Instant.now().plus(request.getDuration()))
+        .build();
   }
 
   @Override

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -946,7 +946,6 @@ public class GcpBlobStore extends AbstractBlobStore {
         signedHeaders.put("Content-Type", request.getContentType());
       }
       if (request.getContentLength() > 0) {
-        extHeaders.put("Content-Length", String.valueOf(request.getContentLength()));
         signedHeaders.put("Content-Length", String.valueOf(request.getContentLength()));
       }
       if (request.getChecksumValue() != null) {

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpTransformer.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpTransformer.java
@@ -271,6 +271,27 @@ public class GcpTransformer {
     return toBlobInfo(presignedUrlRequest.getKey(), metadata);
   }
 
+  public BlobInfo toPresignBlobInfo(PresignedUrlRequest presignedUrlRequest) {
+    Map<String, String> metadata = new HashMap<>();
+    if (presignedUrlRequest.getMetadata() != null) {
+      metadata.putAll(presignedUrlRequest.getMetadata());
+    }
+
+    if (presignedUrlRequest.getTags() != null && !presignedUrlRequest.getTags().isEmpty()) {
+      presignedUrlRequest
+          .getTags()
+          .forEach((tagName, tagValue) -> metadata.put(TAG_PREFIX + tagName, tagValue));
+    }
+
+    return toBlobInfo(
+        presignedUrlRequest.getKey(),
+        metadata,
+        null,
+        null,
+        null,
+        presignedUrlRequest.getContentType());
+  }
+
   public BlobInfo toBlobInfo(MultipartUploadRequest request) {
     Map<String, String> metadata = new HashMap<>();
     if (request.getMetadata() != null) {

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -88,6 +88,7 @@ import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
 import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -1617,10 +1618,10 @@ class GcpBlobStoreTest {
         .thenReturn(expectedUrl);
 
     // When
-    URL actualUrl = gcpBlobStore.doGeneratePresignedUrl(presignedUrlRequest);
+    PresignedUrlResponse presignedResponse = gcpBlobStore.doPresign(presignedUrlRequest);
 
     // Then
-    assertEquals(expectedUrl, actualUrl);
+    assertEquals(expectedUrl, presignedResponse.getUrl());
     verify(mockTransformer).toBlobInfo(presignedUrlRequest);
     verify(mockStorage)
         .signUrl(
@@ -1652,10 +1653,10 @@ class GcpBlobStoreTest {
         .thenReturn(expectedUrl);
 
     // When
-    URL actualUrl = gcpBlobStore.doGeneratePresignedUrl(presignedUrlRequest);
+    PresignedUrlResponse presignedResponse = gcpBlobStore.doPresign(presignedUrlRequest);
 
     // Then
-    assertEquals(expectedUrl, actualUrl);
+    assertEquals(expectedUrl, presignedResponse.getUrl());
     verify(mockTransformer).toBlobInfo(presignedUrlRequest);
     verify(mockStorage)
         .signUrl(
@@ -1687,10 +1688,10 @@ class GcpBlobStoreTest {
         .thenReturn(expectedUrl);
 
     // When
-    URL actualUrl = gcpBlobStore.doGeneratePresignedUrl(presignedUrlRequest);
+    PresignedUrlResponse presignedResponse = gcpBlobStore.doPresign(presignedUrlRequest);
 
     // Then
-    assertEquals(expectedUrl, actualUrl);
+    assertEquals(expectedUrl, presignedResponse.getUrl());
     assertEquals(duration.toMillis(), Duration.ofDays(7).toMillis()); // Verify duration calculation
     verify(mockStorage)
         .signUrl(
@@ -1724,10 +1725,10 @@ class GcpBlobStoreTest {
         .thenReturn(expectedUrl);
 
     // When
-    URL actualUrl = gcpBlobStore.doGeneratePresignedUrl(presignedUrlRequest);
+    PresignedUrlResponse presignedResponse = gcpBlobStore.doPresign(presignedUrlRequest);
 
     // Then
-    assertEquals(expectedUrl, actualUrl);
+    assertEquals(expectedUrl, presignedResponse.getUrl());
     verify(mockTransformer).toBlobInfo(presignedUrlRequest);
     // Verify signUrl was called with the correct parameters including KMS extension header
     verify(mockStorage)
@@ -1760,10 +1761,10 @@ class GcpBlobStoreTest {
         .thenReturn(expectedUrl);
 
     // When
-    URL actualUrl = gcpBlobStore.doGeneratePresignedUrl(presignedUrlRequest);
+    PresignedUrlResponse presignedResponse = gcpBlobStore.doPresign(presignedUrlRequest);
 
     // Then
-    assertEquals(expectedUrl, actualUrl);
+    assertEquals(expectedUrl, presignedResponse.getUrl());
     verify(mockTransformer).toBlobInfo(presignedUrlRequest);
     verify(mockStorage)
         .signUrl(
@@ -1795,9 +1796,9 @@ class GcpBlobStoreTest {
             any(Storage.SignUrlOption[].class)))
         .thenReturn(expectedUrl);
 
-    URL actualUrl = gcpBlobStore.doGeneratePresignedUrl(presignedUrlRequest);
+    PresignedUrlResponse presignedResponse = gcpBlobStore.doPresign(presignedUrlRequest);
 
-    assertEquals(expectedUrl, actualUrl);
+    assertEquals(expectedUrl, presignedResponse.getUrl());
     ArgumentCaptor<Storage.SignUrlOption[]> optionsCaptor =
         ArgumentCaptor.forClass(Storage.SignUrlOption[].class);
     verify(mockStorage)
@@ -1834,9 +1835,9 @@ class GcpBlobStoreTest {
             any(Storage.SignUrlOption[].class)))
         .thenReturn(expectedUrl);
 
-    URL actualUrl = gcpBlobStore.doGeneratePresignedUrl(presignedUrlRequest);
+    PresignedUrlResponse presignedResponse = gcpBlobStore.doPresign(presignedUrlRequest);
 
-    assertEquals(expectedUrl, actualUrl);
+    assertEquals(expectedUrl, presignedResponse.getUrl());
     ArgumentCaptor<Storage.SignUrlOption[]> optionsCaptor =
         ArgumentCaptor.forClass(Storage.SignUrlOption[].class);
     verify(mockStorage)
@@ -2104,9 +2105,9 @@ class GcpBlobStoreTest {
         eq(mockBlobInfo), eq(3600000L), eq(TimeUnit.MILLISECONDS), any(), any()))
         .thenReturn(null);
 
-    URL url = gcpBlobStore.doGeneratePresignedUrl(request);
+    PresignedUrlResponse presignResp = gcpBlobStore.doPresign(request);
 
-    assertNull(url);
+    assertNotNull(presignResp);
     verify(mockStorage)
         .signUrl(eq(mockBlobInfo), eq(3600000L), eq(TimeUnit.MILLISECONDS), any(), any());
   }
@@ -2124,9 +2125,9 @@ class GcpBlobStoreTest {
     when(mockStorage.signUrl(eq(mockBlobInfo), eq(0L), eq(TimeUnit.MILLISECONDS), any(), any()))
         .thenReturn(new URL("https://example.com"));
 
-    URL url = gcpBlobStore.doGeneratePresignedUrl(request);
+    PresignedUrlResponse presignResp = gcpBlobStore.doPresign(request);
 
-    assertNotNull(url);
+    assertNotNull(presignResp);
     verify(mockStorage).signUrl(eq(mockBlobInfo), eq(0L), eq(TimeUnit.MILLISECONDS), any(), any());
   }
 

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -2132,6 +2132,24 @@ class GcpBlobStoreTest {
   }
 
   @Test
+  void testDoPresign_sha256Rejected() {
+    PresignedUrlRequest request =
+        PresignedUrlRequest.builder()
+            .type(PresignedOperation.UPLOAD)
+            .key(TEST_KEY)
+            .duration(Duration.ofHours(1))
+            .checksumValue("abc123==")
+            .checksumAlgorithm(ChecksumMethod.SHA256)
+            .build();
+
+    when(mockTransformer.toPresignBlobInfo(request)).thenReturn(mockBlobInfo);
+
+    assertThrows(
+        com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException.class,
+        () -> gcpBlobStore.doPresign(request));
+  }
+
+  @Test
   void testDoUpload_WithPath_EmptyFile() throws IOException {
     Path tempFile = Files.createTempFile("empty", ".txt");
     try {

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -1609,7 +1609,7 @@ class GcpBlobStoreTest {
 
     URL expectedUrl = new URL("https://signed-url-for-upload.example.com");
 
-    when(mockTransformer.toBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
+    when(mockTransformer.toPresignBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
     when(mockStorage.signUrl(
         eq(mockBlobInfo),
         any(Long.class),
@@ -1622,7 +1622,7 @@ class GcpBlobStoreTest {
 
     // Then
     assertEquals(expectedUrl, presignedResponse.getUrl());
-    verify(mockTransformer).toBlobInfo(presignedUrlRequest);
+    verify(mockTransformer).toPresignBlobInfo(presignedUrlRequest);
     verify(mockStorage)
         .signUrl(
             eq(mockBlobInfo),
@@ -1644,7 +1644,7 @@ class GcpBlobStoreTest {
 
     URL expectedUrl = new URL("https://signed-url-for-download.example.com");
 
-    when(mockTransformer.toBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
+    when(mockTransformer.toPresignBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
     when(mockStorage.signUrl(
         eq(mockBlobInfo),
         any(Long.class),
@@ -1657,7 +1657,7 @@ class GcpBlobStoreTest {
 
     // Then
     assertEquals(expectedUrl, presignedResponse.getUrl());
-    verify(mockTransformer).toBlobInfo(presignedUrlRequest);
+    verify(mockTransformer).toPresignBlobInfo(presignedUrlRequest);
     verify(mockStorage)
         .signUrl(
             eq(mockBlobInfo),
@@ -1679,7 +1679,7 @@ class GcpBlobStoreTest {
 
     URL expectedUrl = new URL("https://long-term-signed-url.example.com");
 
-    when(mockTransformer.toBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
+    when(mockTransformer.toPresignBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
     when(mockStorage.signUrl(
         eq(mockBlobInfo),
         any(Long.class),
@@ -1716,7 +1716,7 @@ class GcpBlobStoreTest {
 
     URL expectedUrl = new URL("https://signed-url-with-kms.example.com");
 
-    when(mockTransformer.toBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
+    when(mockTransformer.toPresignBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
     when(mockStorage.signUrl(
         eq(mockBlobInfo),
         any(Long.class),
@@ -1729,7 +1729,7 @@ class GcpBlobStoreTest {
 
     // Then
     assertEquals(expectedUrl, presignedResponse.getUrl());
-    verify(mockTransformer).toBlobInfo(presignedUrlRequest);
+    verify(mockTransformer).toPresignBlobInfo(presignedUrlRequest);
     // Verify signUrl was called with the correct parameters including KMS extension header
     verify(mockStorage)
         .signUrl(
@@ -1752,7 +1752,7 @@ class GcpBlobStoreTest {
 
     URL expectedUrl = new URL("https://signed-url-without-kms.example.com");
 
-    when(mockTransformer.toBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
+    when(mockTransformer.toPresignBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
     when(mockStorage.signUrl(
         eq(mockBlobInfo),
         any(Long.class),
@@ -1765,7 +1765,7 @@ class GcpBlobStoreTest {
 
     // Then
     assertEquals(expectedUrl, presignedResponse.getUrl());
-    verify(mockTransformer).toBlobInfo(presignedUrlRequest);
+    verify(mockTransformer).toPresignBlobInfo(presignedUrlRequest);
     verify(mockStorage)
         .signUrl(
             eq(mockBlobInfo),
@@ -1788,7 +1788,7 @@ class GcpBlobStoreTest {
 
     URL expectedUrl = new URL("https://signed-url-with-cd.example.com");
 
-    when(mockTransformer.toBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
+    when(mockTransformer.toPresignBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
     when(mockStorage.signUrl(
             eq(mockBlobInfo),
             any(Long.class),
@@ -1827,7 +1827,7 @@ class GcpBlobStoreTest {
 
     URL expectedUrl = new URL("https://signed-url-for-upload.example.com");
 
-    when(mockTransformer.toBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
+    when(mockTransformer.toPresignBlobInfo(presignedUrlRequest)).thenReturn(mockBlobInfo);
     when(mockStorage.signUrl(
             eq(mockBlobInfo),
             any(Long.class),
@@ -2100,7 +2100,7 @@ class GcpBlobStoreTest {
             .duration(Duration.ofHours(1))
             .build();
 
-    when(mockTransformer.toBlobInfo(request)).thenReturn(mockBlobInfo);
+    when(mockTransformer.toPresignBlobInfo(request)).thenReturn(mockBlobInfo);
     when(mockStorage.signUrl(
         eq(mockBlobInfo), eq(3600000L), eq(TimeUnit.MILLISECONDS), any(), any()))
         .thenReturn(null);
@@ -2121,7 +2121,7 @@ class GcpBlobStoreTest {
             .duration(Duration.ZERO)
             .build();
 
-    when(mockTransformer.toBlobInfo(request)).thenReturn(mockBlobInfo);
+    when(mockTransformer.toPresignBlobInfo(request)).thenReturn(mockBlobInfo);
     when(mockStorage.signUrl(eq(mockBlobInfo), eq(0L), eq(TimeUnit.MILLISECONDS), any(), any()))
         .thenReturn(new URL("https://example.com"));
 

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_allconstraintscombined-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_allconstraintscombined-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "a620b8a7-ae99-40e7-b84e-a63768cdac72",
+  "name" : "GcpBlobStoreIT_testPresignV2_allConstraintsCombined-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fpresign-v2%2Fall-constraints-combined",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEg_Pk1dQHs_sB3vIYubvVCPQdj5DPmk83LcK6X_i_I0decXWl_lPHz61jb6BgRsetV2",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Thu, 04 Jun 2026 12:36:56 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "a620b8a7-ae99-40e7-b84e-a63768cdac72",
+  "persistent" : true,
+  "insertionIndex" : 1453
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_allconstraintscombined-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_allconstraintscombined-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "b156ac05-6f17-4775-b68a-41022324986f",
+  "name" : "GcpBlobStoreIT_testPresignV2_allConstraintsCombined-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Ci1jb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1saXN0LXBhZ2UvcHJlZml4LTI=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-list-page/prefix-2/1780355277927301\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2?generation=1780355277927301&alt=media\",\n      \"name\": \"conformance-tests/blob-for-list-page/prefix-2\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1780355277927301\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"29\",\n      \"md5Hash\": \"16GqxDYUIo8tWi7aRir4ig==\",\n      \"crc32c\": \"TteLWg==\",\n      \"etag\": \"CIXnqJ+U55QDEAE=\",\n      \"timeCreated\": \"2026-06-01T23:07:57.982Z\",\n      \"updated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeStorageClassUpdated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeFinalized\": \"2026-06-01T23:07:57.982Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEi5dk9nwFnOuZ5TI-qIlGmsO9qSvN6wz6CC2VlslIr0DI6SWIhGfDd1jcVOukPsw_Q_",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Thu, 04 Jun 2026 12:36:56 GMT",
+      "Date" : "Thu, 04 Jun 2026 12:36:56 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "b156ac05-6f17-4775-b68a-41022324986f",
+  "persistent" : true,
+  "insertionIndex" : 1454
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_backwardcompatibility-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_backwardcompatibility-delete-0.json
@@ -1,0 +1,26 @@
+{
+  "id" : "a3298526-cdb2-47bf-b68f-738fe0431d29",
+  "name" : "GcpBlobStoreIT_testPresignV2_backwardCompatibility-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fpresign-v2%2Fbackward-compat",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"No such object: substrate-sdk-gcp-poc1-test-bucket/conformance-tests/presign-v2/backward-compat\",\n    \"errors\": [\n      {\n        \"message\": \"No such object: substrate-sdk-gcp-poc1-test-bucket/conformance-tests/presign-v2/backward-compat\",\n        \"domain\": \"global\",\n        \"reason\": \"notFound\"\n      }\n    ]\n  }\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEij2KXZqYTIn23dik-5CI78sfFY5gblV3ipveOJAye4gvawEiVZXhhFEIk6SGQRf3Q53oDnplk",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Thu, 04 Jun 2026 12:36:51 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "a3298526-cdb2-47bf-b68f-738fe0431d29",
+  "persistent" : true,
+  "insertionIndex" : 1444
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_backwardcompatibility-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_backwardcompatibility-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "ced6ed15-de81-416c-8d7a-2a642cdf6fd5",
+  "name" : "GcpBlobStoreIT_testPresignV2_backwardCompatibility-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Ci1jb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1saXN0LXBhZ2UvcHJlZml4LTI=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-list-page/prefix-2/1780355277927301\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2?generation=1780355277927301&alt=media\",\n      \"name\": \"conformance-tests/blob-for-list-page/prefix-2\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1780355277927301\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"29\",\n      \"md5Hash\": \"16GqxDYUIo8tWi7aRir4ig==\",\n      \"crc32c\": \"TteLWg==\",\n      \"etag\": \"CIXnqJ+U55QDEAE=\",\n      \"timeCreated\": \"2026-06-01T23:07:57.982Z\",\n      \"updated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeStorageClassUpdated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeFinalized\": \"2026-06-01T23:07:57.982Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEgZTfSNAq2cWg1mGwqge3ecHAACZi3zAOXVfRJltufPo4m25v_LPVdkFEqVSKS4kHN4FfBlfYc",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Thu, 04 Jun 2026 12:36:51 GMT",
+      "Date" : "Thu, 04 Jun 2026 12:36:51 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "ced6ed15-de81-416c-8d7a-2a642cdf6fd5",
+  "persistent" : true,
+  "insertionIndex" : 1445
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_checksumcrc32cbinding-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_checksumcrc32cbinding-delete-0.json
@@ -1,0 +1,26 @@
+{
+  "id" : "a45e6545-50c8-465e-beb6-ff4a7498880e",
+  "name" : "GcpBlobStoreIT_testPresignV2_checksumCrc32cBinding-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fpresign-v2%2Fchecksum-crc32c-binding",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"No such object: substrate-sdk-gcp-poc1-test-bucket/conformance-tests/presign-v2/checksum-crc32c-binding\",\n    \"errors\": [\n      {\n        \"message\": \"No such object: substrate-sdk-gcp-poc1-test-bucket/conformance-tests/presign-v2/checksum-crc32c-binding\",\n        \"domain\": \"global\",\n        \"reason\": \"notFound\"\n      }\n    ]\n  }\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEhl9g-7ImeEOQfvJh1I0DZIyVVzZN7zknP2wjPy4za9Nu0RnmuavPPv0FuTP7wJ76VYMEBw2_w",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Thu, 04 Jun 2026 12:36:58 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "a45e6545-50c8-465e-beb6-ff4a7498880e",
+  "persistent" : true,
+  "insertionIndex" : 1456
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_checksumcrc32cbinding-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_checksumcrc32cbinding-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "e35aeca2-f473-43ba-99a9-e16af684277c",
+  "name" : "GcpBlobStoreIT_testPresignV2_checksumCrc32cBinding-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Ci1jb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1saXN0LXBhZ2UvcHJlZml4LTI=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-list-page/prefix-2/1780355277927301\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2?generation=1780355277927301&alt=media\",\n      \"name\": \"conformance-tests/blob-for-list-page/prefix-2\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1780355277927301\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"29\",\n      \"md5Hash\": \"16GqxDYUIo8tWi7aRir4ig==\",\n      \"crc32c\": \"TteLWg==\",\n      \"etag\": \"CIXnqJ+U55QDEAE=\",\n      \"timeCreated\": \"2026-06-01T23:07:57.982Z\",\n      \"updated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeStorageClassUpdated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeFinalized\": \"2026-06-01T23:07:57.982Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEgnGR8BGaZP8KMett_5nQvxL93aKUz2hoilv3aAkHJN8opp1RLtzGqIL9IQFJBY2qWLfG9RwMc",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Thu, 04 Jun 2026 12:36:57 GMT",
+      "Date" : "Thu, 04 Jun 2026 12:36:57 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "e35aeca2-f473-43ba-99a9-e16af684277c",
+  "persistent" : true,
+  "insertionIndex" : 1457
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_checksumcrc32cbinding_rejectswrongchecksum-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_checksumcrc32cbinding_rejectswrongchecksum-delete-0.json
@@ -1,0 +1,26 @@
+{
+  "id" : "f22ec86c-f1ce-42c4-ae89-59e402a0dd92",
+  "name" : "GcpBlobStoreIT_testPresignV2_checksumCrc32cBinding_rejectsWrongChecksum-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fpresign-v2%2Fnegative%2Fwrong-checksum",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"No such object: substrate-sdk-gcp-poc1-test-bucket/conformance-tests/presign-v2/negative/wrong-checksum\",\n    \"errors\": [\n      {\n        \"message\": \"No such object: substrate-sdk-gcp-poc1-test-bucket/conformance-tests/presign-v2/negative/wrong-checksum\",\n        \"domain\": \"global\",\n        \"reason\": \"notFound\"\n      }\n    ]\n  }\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AJ5rDhGiPoWSgIVNvO39w_yKJt9Rrkku7-tW9F-jcECJnldjhXOgVeRxg0U0ztwjp-87z75z9IwWpUIWIcQtsw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Fri, 05 Jun 2026 08:56:55 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "f22ec86c-f1ce-42c4-ae89-59e402a0dd92",
+  "persistent" : true,
+  "insertionIndex" : 1450
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_checksumcrc32cbinding_rejectswrongchecksum-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_checksumcrc32cbinding_rejectswrongchecksum-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "8661933a-a8e1-4415-a474-40c98d010130",
+  "name" : "GcpBlobStoreIT_testPresignV2_checksumCrc32cBinding_rejectsWrongChecksum-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Ci1jb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1saXN0LXBhZ2UvcHJlZml4LTI=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-list-page/prefix-2/1780355277927301\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2?generation=1780355277927301&alt=media\",\n      \"name\": \"conformance-tests/blob-for-list-page/prefix-2\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1780355277927301\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"29\",\n      \"md5Hash\": \"16GqxDYUIo8tWi7aRir4ig==\",\n      \"crc32c\": \"TteLWg==\",\n      \"etag\": \"CIXnqJ+U55QDEAE=\",\n      \"timeCreated\": \"2026-06-01T23:07:57.982Z\",\n      \"updated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeStorageClassUpdated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeFinalized\": \"2026-06-01T23:07:57.982Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AJ5rDhFybRWGKqC6a89fmupJQ32n9esDSnJi9EbPPsVcJryotNhVR3DpWXQJNuhrhxvqCkQqaXFNb8NwYV0Y_g",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Fri, 05 Jun 2026 08:56:55 GMT",
+      "Date" : "Fri, 05 Jun 2026 08:56:55 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "8661933a-a8e1-4415-a474-40c98d010130",
+  "persistent" : true,
+  "insertionIndex" : 1451
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contentlengthbinding-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contentlengthbinding-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "818c5518-f248-4984-8a05-4324497d193a",
+  "name" : "GcpBlobStoreIT_testPresignV2_contentLengthBinding-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fpresign-v2%2Fcontent-length-binding",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEhZQlbD1_NC9942LZLkg7Rpd0xhqKzJHsvrwVr-TOO-vpYmqNNwvC2f8o7pM_pE5n8U",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Thu, 04 Jun 2026 12:36:55 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "818c5518-f248-4984-8a05-4324497d193a",
+  "persistent" : true,
+  "insertionIndex" : 1450
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contentlengthbinding-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contentlengthbinding-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "39a47a49-b429-4b82-92a2-3be7160fd6fe",
+  "name" : "GcpBlobStoreIT_testPresignV2_contentLengthBinding-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Ci1jb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1saXN0LXBhZ2UvcHJlZml4LTI=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-list-page/prefix-2/1780355277927301\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2?generation=1780355277927301&alt=media\",\n      \"name\": \"conformance-tests/blob-for-list-page/prefix-2\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1780355277927301\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"29\",\n      \"md5Hash\": \"16GqxDYUIo8tWi7aRir4ig==\",\n      \"crc32c\": \"TteLWg==\",\n      \"etag\": \"CIXnqJ+U55QDEAE=\",\n      \"timeCreated\": \"2026-06-01T23:07:57.982Z\",\n      \"updated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeStorageClassUpdated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeFinalized\": \"2026-06-01T23:07:57.982Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEj0ja-6YrzEGjOmJ4zmw8GM_U6_uHf66OlY_L1R-1Lh79hJmDTNKSILRpxBAQsii4QILF0jVlA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Thu, 04 Jun 2026 12:36:54 GMT",
+      "Date" : "Thu, 04 Jun 2026 12:36:54 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "39a47a49-b429-4b82-92a2-3be7160fd6fe",
+  "persistent" : true,
+  "insertionIndex" : 1451
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contentlengthbinding_rejectswrongsize-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contentlengthbinding_rejectswrongsize-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "f4037a72-5e57-433d-af30-c5b9891759cf",
+  "name" : "GcpBlobStoreIT_testPresignV2_contentLengthBinding_rejectsWrongSize-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fpresign-v2%2Fnegative%2Fwrong-size",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AJ5rDhFga7Of7G_mpFncu47lQpurNg8EYRqFJZLUZ2oMJw-uDCjxqkNc_gY_uvGRms9gix4qnXxmhnqhaeEo_Q",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Fri, 05 Jun 2026 08:56:52 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "f4037a72-5e57-433d-af30-c5b9891759cf",
+  "persistent" : true,
+  "insertionIndex" : 1444
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contentlengthbinding_rejectswrongsize-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contentlengthbinding_rejectswrongsize-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "fe84fe2e-84cd-4b6f-94c1-f67aa873e431",
+  "name" : "GcpBlobStoreIT_testPresignV2_contentLengthBinding_rejectsWrongSize-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Ci1jb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1saXN0LXBhZ2UvcHJlZml4LTI=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-list-page/prefix-2/1780355277927301\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2?generation=1780355277927301&alt=media\",\n      \"name\": \"conformance-tests/blob-for-list-page/prefix-2\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1780355277927301\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"29\",\n      \"md5Hash\": \"16GqxDYUIo8tWi7aRir4ig==\",\n      \"crc32c\": \"TteLWg==\",\n      \"etag\": \"CIXnqJ+U55QDEAE=\",\n      \"timeCreated\": \"2026-06-01T23:07:57.982Z\",\n      \"updated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeStorageClassUpdated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeFinalized\": \"2026-06-01T23:07:57.982Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AJ5rDhHmvDl6gW3m-qUHhcMFcvLtDDB6F_7O3fyyRh8UY_sCy6qAdgEIAGzoyFsa_7oOQnkBucGs_jAIPwJbnw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Fri, 05 Jun 2026 08:56:51 GMT",
+      "Date" : "Fri, 05 Jun 2026 08:56:51 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "fe84fe2e-84cd-4b6f-94c1-f67aa873e431",
+  "persistent" : true,
+  "insertionIndex" : 1445
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contenttypebinding-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contenttypebinding-delete-0.json
@@ -1,0 +1,26 @@
+{
+  "id" : "042073d3-4c32-4471-a47e-b746e436bc5e",
+  "name" : "GcpBlobStoreIT_testPresignV2_contentTypeBinding-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fpresign-v2%2Fcontent-type-binding",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"No such object: substrate-sdk-gcp-poc1-test-bucket/conformance-tests/presign-v2/content-type-binding\",\n    \"errors\": [\n      {\n        \"message\": \"No such object: substrate-sdk-gcp-poc1-test-bucket/conformance-tests/presign-v2/content-type-binding\",\n        \"domain\": \"global\",\n        \"reason\": \"notFound\"\n      }\n    ]\n  }\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEgG8Rbw6n7U4fywRuKM_3hhDRtaRtsF_q8KuRI2_lsI3sOUNttMFcYzfPJEYt4NqYK5",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Thu, 04 Jun 2026 12:36:53 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "042073d3-4c32-4471-a47e-b746e436bc5e",
+  "persistent" : true,
+  "insertionIndex" : 1447
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contenttypebinding-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contenttypebinding-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "77b08d4c-618c-4cf7-b7db-1ade5f46180b",
+  "name" : "GcpBlobStoreIT_testPresignV2_contentTypeBinding-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Ci1jb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1saXN0LXBhZ2UvcHJlZml4LTI=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-list-page/prefix-2/1780355277927301\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2?generation=1780355277927301&alt=media\",\n      \"name\": \"conformance-tests/blob-for-list-page/prefix-2\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1780355277927301\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"29\",\n      \"md5Hash\": \"16GqxDYUIo8tWi7aRir4ig==\",\n      \"crc32c\": \"TteLWg==\",\n      \"etag\": \"CIXnqJ+U55QDEAE=\",\n      \"timeCreated\": \"2026-06-01T23:07:57.982Z\",\n      \"updated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeStorageClassUpdated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeFinalized\": \"2026-06-01T23:07:57.982Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEhynqbJNLsLWsff9JoVCLwFJPOFH9nRDszKjce0fn8q2Jm7j8VPa3WcJYhylELILGA0Ac8vlE8",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Thu, 04 Jun 2026 12:36:52 GMT",
+      "Date" : "Thu, 04 Jun 2026 12:36:52 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "77b08d4c-618c-4cf7-b7db-1ade5f46180b",
+  "persistent" : true,
+  "insertionIndex" : 1448
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contenttypebinding_rejectswrongtype-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contenttypebinding_rejectswrongtype-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "7d61b4cd-88ed-4d5f-94c0-88cdc06a2bca",
+  "name" : "GcpBlobStoreIT_testPresignV2_contentTypeBinding_rejectsWrongType-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fpresign-v2%2Fnegative%2Fwrong-type",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AJ5rDhFsxSFpQKHhwZSqm-gXT_Dcq-_mophYJ3j3xtilHoPiLTrjB3TjS4Yt5CWIR5bh8i_VTwQrg0SCADbM_w",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Fri, 05 Jun 2026 08:56:54 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "7d61b4cd-88ed-4d5f-94c0-88cdc06a2bca",
+  "persistent" : true,
+  "insertionIndex" : 1447
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contenttypebinding_rejectswrongtype-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_contenttypebinding_rejectswrongtype-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "47b382de-bb5c-4ea8-b3f8-720320d027e8",
+  "name" : "GcpBlobStoreIT_testPresignV2_contentTypeBinding_rejectsWrongType-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Ci1jb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1saXN0LXBhZ2UvcHJlZml4LTI=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-list-page/prefix-2/1780355277927301\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2?generation=1780355277927301&alt=media\",\n      \"name\": \"conformance-tests/blob-for-list-page/prefix-2\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1780355277927301\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"29\",\n      \"md5Hash\": \"16GqxDYUIo8tWi7aRir4ig==\",\n      \"crc32c\": \"TteLWg==\",\n      \"etag\": \"CIXnqJ+U55QDEAE=\",\n      \"timeCreated\": \"2026-06-01T23:07:57.982Z\",\n      \"updated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeStorageClassUpdated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeFinalized\": \"2026-06-01T23:07:57.982Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AJ5rDhHj31ZYTbbMcwVbhZdvfSuL1fvrfJ6Z7J2DKt7c4dnpUkjqM3-I3YRpoPtC1lcLw2YCYvybUbDDXNTfGA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Fri, 05 Jun 2026 08:56:53 GMT",
+      "Date" : "Fri, 05 Jun 2026 08:56:53 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "47b382de-bb5c-4ea8-b3f8-720320d027e8",
+  "persistent" : true,
+  "insertionIndex" : 1448
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_signedheadersnonempty-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_signedheadersnonempty-delete-0.json
@@ -1,0 +1,26 @@
+{
+  "id" : "ce997407-496d-4c80-93b5-8d69fba08d81",
+  "name" : "GcpBlobStoreIT_testPresignV2_signedHeadersNonEmpty-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fpresign-v2%2Fsigned-headers-present",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"No such object: substrate-sdk-gcp-poc1-test-bucket/conformance-tests/presign-v2/signed-headers-present\",\n    \"errors\": [\n      {\n        \"message\": \"No such object: substrate-sdk-gcp-poc1-test-bucket/conformance-tests/presign-v2/signed-headers-present\",\n        \"domain\": \"global\",\n        \"reason\": \"notFound\"\n      }\n    ]\n  }\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AAVLpEhLXiV0ymmC9H9hjtbAN3xbvWScddUbTj3AFwv-VjHnHf03SunVapod24Ix_d3g8wpI",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Thu, 04 Jun 2026 12:36:59 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "ce997407-496d-4c80-93b5-8d69fba08d81",
+  "persistent" : true,
+  "insertionIndex" : 1459
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_signedheadersnonempty-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testpresignv2_signedheadersnonempty-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "7f362835-2568-4ad5-ad68-c297b6cc4227",
+  "name" : "GcpBlobStoreIT_testPresignV2_signedHeadersNonEmpty-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"Ci1jb25mb3JtYW5jZS10ZXN0cy9ibG9iLWZvci1saXN0LXBhZ2UvcHJlZml4LTI=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/blob-for-list-page/prefix-2/1780355277927301\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fblob-for-list-page%2Fprefix-2?generation=1780355277927301&alt=media\",\n      \"name\": \"conformance-tests/blob-for-list-page/prefix-2\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1780355277927301\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"29\",\n      \"md5Hash\": \"16GqxDYUIo8tWi7aRir4ig==\",\n      \"crc32c\": \"TteLWg==\",\n      \"etag\": \"CIXnqJ+U55QDEAE=\",\n      \"timeCreated\": \"2026-06-01T23:07:57.982Z\",\n      \"updated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeStorageClassUpdated\": \"2026-06-01T23:07:57.982Z\",\n      \"timeFinalized\": \"2026-06-01T23:07:57.982Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AAVLpEgkZYmSMd6UYvMtXx0nVxGePtUVazJyKAEHHQ8WtuI9uJOLTREG2PcmB-VRaExZUgJZqCjR4q4",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Thu, 04 Jun 2026 12:36:58 GMT",
+      "Date" : "Thu, 04 Jun 2026 12:36:58 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "7f362835-2568-4ad5-ad68-c297b6cc4227",
+  "persistent" : true,
+  "insertionIndex" : 1460
+}

--- a/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
+++ b/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
@@ -24,6 +24,7 @@ import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionRules;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
@@ -844,11 +845,13 @@ public class InMemoryBlobStore extends AbstractBlobStore {
   }
 
   @Override
-  protected URL doGeneratePresignedUrl(PresignedUrlRequest request) {
-    // Don't validate bucket existence - presigned URLs are client-side operations
+  protected PresignedUrlResponse doPresign(PresignedUrlRequest request) {
     try {
-      // For in-memory implementation, just return a fake URL
-      return new URL("http://localhost:8080/" + bucket + "/" + request.getKey());
+      URL url = new URL("http://localhost:8080/" + bucket + "/" + request.getKey());
+      return PresignedUrlResponse.builder()
+          .url(url)
+          .signedHeaders(java.util.Map.of())
+          .build();
     } catch (MalformedURLException e) {
       throw new UnknownException("Failed to generate presigned URL", e);
     }

--- a/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
+++ b/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
@@ -23,6 +23,7 @@ import com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration;
 import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
 import com.salesforce.multicloudj.blob.driver.ObjectRetentionRules;
+import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.RetentionMode;
@@ -848,9 +849,24 @@ public class InMemoryBlobStore extends AbstractBlobStore {
   protected PresignedUrlResponse doPresign(PresignedUrlRequest request) {
     try {
       URL url = new URL("http://localhost:8080/" + bucket + "/" + request.getKey());
+      Map<String, String> signedHeaders = new HashMap<>();
+      if (request.getType() == PresignedOperation.UPLOAD) {
+        if (request.getContentLength() > 0) {
+          signedHeaders.put("Content-Length", String.valueOf(request.getContentLength()));
+        }
+        if (request.getContentType() != null) {
+          signedHeaders.put("Content-Type", request.getContentType());
+        }
+        if (request.getChecksumValue() != null) {
+          String algo = request.getChecksumAlgorithm() != null
+              ? request.getChecksumAlgorithm().name() : "CRC32C";
+          signedHeaders.put("x-checksum", algo + "=" + request.getChecksumValue());
+        }
+      }
       return PresignedUrlResponse.builder()
           .url(url)
-          .signedHeaders(Map.of())
+          .signedHeaders(signedHeaders)
+          .expiration(Instant.now().plus(request.getDuration()))
           .build();
     } catch (MalformedURLException e) {
       throw new UnknownException("Failed to generate presigned URL", e);

--- a/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
+++ b/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
@@ -850,7 +850,7 @@ public class InMemoryBlobStore extends AbstractBlobStore {
       URL url = new URL("http://localhost:8080/" + bucket + "/" + request.getKey());
       return PresignedUrlResponse.builder()
           .url(url)
-          .signedHeaders(java.util.Map.of())
+          .signedHeaders(Map.of())
           .build();
     } catch (MalformedURLException e) {
       throw new UnknownException("Failed to generate presigned URL", e);


### PR DESCRIPTION
## Summary

- Add support for binding `contentLength`, `contentType`, and `checksumValue`/`checksumAlgorithm` into presigned upload URLs so substrates (S3/GCS/OSS) reject uploads that don't match the pre-committed constraints.
- Introduce `presign(PresignedUrlRequest) → PresignedUrlResponse` alongside the existing `generatePresignedUrl() → URL` (kept unchanged for backward compatibility).
- `PresignedUrlResponse` surfaces the URL, the map of signed headers the uploader must replay, and the expiration timestamp.

## Changes

| Layer | What |
|---|---|
| `PresignedUrlRequest` | Add optional `contentLength`, `contentType`, `checksumValue`, `checksumAlgorithm` |
| `PresignedUrlResponse` | **New** — `url`, `signedHeaders : Map<String,String>` (`@Builder.Default = Map.of()`), `expiration : Instant` |
| `BlobStore` interface | Add `default presign(...)` (BC for third-party impls) |
| `AbstractBlobStore` | New `doPresign()` abstract hook; `generatePresignedUrl()` delegates to it |
| `BlobStoreValidator` | `contentLength >= 0`; reject algorithm without value |
| AWS provider | Forward constraints via `UploadRequest`; `toPresignedUrlResponse()` on transformer for dedup |
| GCP provider | `withContentType()` canonical signing via `toPresignBlobInfo()`; `x-goog-hash` for CRC32C; reject SHA256 with `UnSupportedOperationException`; Content-Length not signable on GCS |
| Ali provider | Forward `contentLength`/`contentType`; bounds check (> Integer.MAX_VALUE throws); read native `signedHeaders` + `expiration` |
| Async surface | Mirrored across `AsyncBlobStore`, `AbstractAsyncBlobStore`, `BlobStoreAsyncBridge`, `AsyncBucketClient`, all async providers |
| InMemory | `doPresign()` returns synthetic signedHeaders reflecting constraints |
| Conformance tests | 6 tests with WireMock recordings (AWS + GCP); upload verified in record mode |

## Test plan

- [x] All existing unit tests pass (client: 278, AWS: 251, GCP: 325, Ali: 138, InMemory: 11)
- [x] Conformance tests pass in replay mode (AWS: 6/6, GCP: 6/6, InMemory: 6/6)
- [x] AWS conformance tests pass in record mode with real credentials (upload verified end-to-end)
- [x] GCP conformance tests pass in record mode with impersonated SA credentials
- [x] WireMock recordings scanned — no credentials, tokens, or secrets leaked
- [x] Ali: `@Disabled` for conformance (recording happens on dedicated machines)

## Design decisions

- **Backward compatible**: `generatePresignedUrl() → URL` unchanged; new `presign()` is additive
- **GCS Content-Type**: uses `SignUrlOption.withContentType()` canonical mechanism (not extHeaders)
- **GCS Content-Length**: not signable on GCS — returned in signedHeaders for HTTP semantics but not in extHeaders
- **GCS SHA256**: throws `UnSupportedOperationException` (project exception type)
- **Ali overflow**: bounds check throws `InvalidArgumentException` if contentLength > Integer.MAX_VALUE
- **signedHeaders nullability**: `@Builder.Default = Map.of()` enforces non-null contract
- **Upload in conformance tests**: gated behind `System.getProperty("record")` since presigned URLs bypass WireMock