### PR TITLE
blobstore: implement object lock/retention for Ali OSS

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -12,9 +12,11 @@ import com.aliyun.sdk.service.oss2.models.CopyObjectRequest;
 import com.aliyun.sdk.service.oss2.models.CopyObjectResult;
 import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
 import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectLegalHoldResult;
 import com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectResult;
+import com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult;
 import com.aliyun.sdk.service.oss2.models.GetObjectTaggingRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectTaggingResult;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
@@ -52,15 +54,18 @@ import com.salesforce.multicloudj.blob.driver.MultipartPart;
 import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
+import com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration;
 import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
+import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
+import com.salesforce.multicloudj.blob.driver.ObjectRetentionRules;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.ali.AliConstants;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
-import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.common.provider.Provider;
 import java.io.ByteArrayOutputStream;
@@ -194,7 +199,32 @@ public class AliBlobStore extends AbstractBlobStore {
     PutObjectResult result =
         ossClient.putObject(request,
             OperationOptions.defaults());
-    return transformer.toUploadResponse(uploadRequest, result);
+    UploadResponse response =
+        transformer.toUploadResponse(uploadRequest, result);
+    applyObjectLockAfterUpload(
+        uploadRequest.getKey(), response.getVersionId(),
+        uploadRequest.getObjectLock());
+    return response;
+  }
+
+  private void applyObjectLockAfterUpload(
+      String key, String versionId,
+      ObjectLockConfiguration lockConfig) {
+    if (lockConfig == null) {
+      return;
+    }
+    if (lockConfig.getMode() != null && lockConfig.getRetainUntilDate() != null) {
+      ossClient.putObjectRetention(
+          transformer.toPutObjectRetentionRequest(
+              key, versionId, lockConfig.getMode(),
+              lockConfig.getRetainUntilDate(), false),
+          OperationOptions.defaults());
+    }
+    if (lockConfig.isLegalHold()) {
+      ossClient.putObjectLegalHold(
+          transformer.toPutObjectLegalHoldRequest(key, versionId, true),
+          OperationOptions.defaults());
+    }
   }
 
   /**
@@ -522,6 +552,9 @@ public class AliBlobStore extends AbstractBlobStore {
     CompleteMultipartUploadResult result =
         ossClient.completeMultipartUpload(request,
             OperationOptions.defaults());
+    // OSS does not support object lock headers on multipart initiation, so apply retention
+    // and legal hold after the object is assembled.
+    applyObjectLockAfterUpload(mpu.getKey(), result.versionId(), mpu.getObjectLock());
     return new MultipartUploadResponse(
         stripQuotes(result.completeMultipartUpload().eTag()));
   }
@@ -594,23 +627,124 @@ public class AliBlobStore extends AbstractBlobStore {
         OperationOptions.defaults());
   }
 
-  /** {@inheritdoc} */
   @Override
   public ObjectLockInfo getObjectLock(String key, String versionId) {
-    throw new UnSupportedOperationException("Alibaba OSS does not support object lock");
+    // OSS exposes retention and legal hold as two separate calls, and returns 404
+    // (NoSuchObjectRetention / NoSuchObjectLegalHoldConfiguration) when that specific
+    // configuration was never set on the object. An object may have retention but no
+    // legal hold (or vice versa), so each absence is treated as "not configured"
+    // rather than an error.
+    GetObjectRetentionResult retentionResult = null;
+    try {
+      retentionResult = ossClient.getObjectRetention(
+          transformer.toGetObjectRetentionRequest(key, versionId),
+          OperationOptions.defaults());
+    } catch (Exception e) {
+      if (!isNoSuchConfiguration(e)) {
+        throw e;
+      }
+    }
+
+    GetObjectLegalHoldResult legalHoldResult = null;
+    try {
+      legalHoldResult = ossClient.getObjectLegalHold(
+          transformer.toGetObjectLegalHoldRequest(key, versionId),
+          OperationOptions.defaults());
+    } catch (Exception e) {
+      if (!isNoSuchConfiguration(e)) {
+        throw e;
+      }
+    }
+
+    return transformer.toObjectLockInfo(retentionResult, legalHoldResult);
   }
 
-  /** {@inheritdoc} */
+  /**
+   * Returns true when the throwable represents an OSS "configuration not found" response
+   * for retention or legal hold — i.e. the object exists but simply does not have that
+   * lock configuration set. This is NOT an error for {@link #getObjectLock}.
+   *
+   * <p>Matches 404 errors with codes like {@code NoSuchObjectRetentionConfiguration} or
+   * {@code NoSuchObjectLegalHoldConfiguration}, but explicitly excludes {@code NoSuchKey}
+   * (object does not exist) which should propagate as an error.
+   */
+  private static boolean isNoSuchConfiguration(Throwable t) {
+    ServiceException se = extractServiceException(t);
+    if (se == null) {
+      return false;
+    }
+    String errorCode = se.errorCode();
+    return se.statusCode() == 404
+        && errorCode != null
+        && errorCode.startsWith("NoSuch")
+        && !"NoSuchKey".equals(errorCode);
+  }
+
+  private static ServiceException extractServiceException(Throwable t) {
+    if (t instanceof ServiceException) {
+      return (ServiceException) t;
+    } else if (t instanceof OperationException
+        && t.getCause() instanceof ServiceException) {
+      return (ServiceException) t.getCause();
+    }
+    return null;
+  }
+
+  // TODO(objectlock): OSS stores/returns retention timestamps at coarser (second/millisecond)
+  // precision than the Instant we send (Instant.now() carries micro/nanoseconds), so a
+  // round-tripped retainUntilDate is truncated. The shorten check below
+  // (ObjectRetentionRules.resolveAndValidate -> config.getRetainUntilDate().isBefore(
+  // currentRetainUntil)) compares the caller's full-precision value against the truncated
+  // stored value; at sub-second boundaries this could misclassify an extend vs. shorten.
+  // Negligible under whole-second usage (conformance tests use whole-second constants), but
+  // revisit if sub-second retain dates are ever supported — likely normalize/truncate to
+  // seconds on both the inbound config and the parsed current value before comparing.
   @Override
-  public void updateObjectRetention(
-      String key, String versionId, java.time.Instant retainUntilDate) {
-    throw new UnSupportedOperationException("Alibaba OSS does not support object lock/retention");
+  protected void doUpdateObjectRetention(
+      String key, String versionId, ObjectRetentionConfig config) {
+    // Fetch current retention state. OSS returns 404 NoSuchObjectRetentionConfiguration
+    // when the object has no retention set — treat that as "no current retention" so
+    // ObjectRetentionRules.resolveAndValidate can reject with FailedPreconditionException.
+    GetObjectRetentionResult currentResult = null;
+    try {
+      currentResult = ossClient.getObjectRetention(
+          transformer.toGetObjectRetentionRequest(key, versionId),
+          OperationOptions.defaults());
+    } catch (Exception e) {
+      if (!isNoSuchConfiguration(e)) {
+        throw e;
+      }
+      // currentResult stays null → no current retention
+    }
+
+    RetentionMode currentMode = null;
+    java.time.Instant currentRetainUntil = null;
+    if (currentResult != null && currentResult.retention() != null) {
+      currentMode = AliTransformer.toRetentionMode(
+          com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType
+              .fromString(currentResult.retention().mode()));
+      if (currentResult.retention().retainUntilDate() != null) {
+        currentRetainUntil = java.time.Instant.parse(
+            currentResult.retention().retainUntilDate());
+      }
+    }
+
+    RetentionMode resolvedMode = ObjectRetentionRules.resolveAndValidate(
+        currentMode, currentRetainUntil, config);
+
+    ossClient.putObjectRetention(
+        transformer.toPutObjectRetentionRequest(
+            key, versionId, resolvedMode,
+            config.getRetainUntilDate(),
+            config.getBypassGovernanceRetention()),
+        OperationOptions.defaults());
   }
 
-  /** {@inheritdoc} */
   @Override
   public void updateLegalHold(String key, String versionId, boolean legalHold) {
-    throw new UnSupportedOperationException("Alibaba OSS does not support object lock/legal hold");
+    ossClient.putObjectLegalHold(
+        transformer.toPutObjectLegalHoldRequest(key, versionId, legalHold),
+        OperationOptions.defaults());
   }
 
   /**

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -10,23 +10,33 @@ import com.aliyun.sdk.service.oss2.models.CopyObjectResult;
 import com.aliyun.sdk.service.oss2.models.Delete;
 import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
 import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectLegalHoldRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectLegalHoldResult;
 import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectResult;
+import com.aliyun.sdk.service.oss2.models.GetObjectRetentionRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult;
 import com.aliyun.sdk.service.oss2.models.GetObjectTaggingResult;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
 import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult;
+import com.aliyun.sdk.service.oss2.models.LegalHold;
 import com.aliyun.sdk.service.oss2.models.ListObjectsV2Request;
 import com.aliyun.sdk.service.oss2.models.ListObjectsV2Result;
 import com.aliyun.sdk.service.oss2.models.ListPartsRequest;
 import com.aliyun.sdk.service.oss2.models.ListPartsResult;
 import com.aliyun.sdk.service.oss2.models.ObjectIdentifier;
+import com.aliyun.sdk.service.oss2.models.ObjectLegalHoldStatusType;
+import com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType;
 import com.aliyun.sdk.service.oss2.models.Part;
+import com.aliyun.sdk.service.oss2.models.PutObjectLegalHoldRequest;
 import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
 import com.aliyun.sdk.service.oss2.models.PutObjectResult;
+import com.aliyun.sdk.service.oss2.models.PutObjectRetentionRequest;
 import com.aliyun.sdk.service.oss2.models.PutObjectTaggingRequest;
+import com.aliyun.sdk.service.oss2.models.Retention;
 import com.aliyun.sdk.service.oss2.models.Tag;
 import com.aliyun.sdk.service.oss2.models.TagSet;
 import com.aliyun.sdk.service.oss2.models.Tagging;
@@ -54,7 +64,9 @@ import com.salesforce.multicloudj.blob.driver.ListBlobsRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartPart;
 import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
+import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
@@ -421,6 +433,7 @@ public class AliTransformer {
         .checksumEnabled(request.isChecksumEnabled())
         .checksumAlgorithm(request.getChecksumAlgorithm())
         .contentType(request.getContentType())
+        .objectLock(request.getObjectLock())
         .build();
   }
 
@@ -683,5 +696,119 @@ public class AliTransformer {
     return blobList.stream()
         .map(blob -> new BlobIdentifier(blob.getKey(), null))
         .collect(Collectors.toList());
+  }
+
+  public GetObjectRetentionRequest toGetObjectRetentionRequest(
+      String key, String versionId) {
+    GetObjectRetentionRequest.Builder builder = GetObjectRetentionRequest.newBuilder()
+        .bucket(bucket)
+        .key(key);
+    if (versionId != null) {
+      builder.versionId(versionId);
+    }
+    return builder.build();
+  }
+
+  public GetObjectLegalHoldRequest toGetObjectLegalHoldRequest(
+      String key, String versionId) {
+    GetObjectLegalHoldRequest.Builder builder = GetObjectLegalHoldRequest.newBuilder()
+        .bucket(bucket)
+        .key(key);
+    if (versionId != null) {
+      builder.versionId(versionId);
+    }
+    return builder.build();
+  }
+
+  public ObjectLockInfo toObjectLockInfo(
+      GetObjectRetentionResult retentionResult,
+      GetObjectLegalHoldResult legalHoldResult) {
+    RetentionMode mode = null;
+    Instant retainUntilDate = null;
+
+    if (retentionResult != null && retentionResult.retention() != null) {
+      Retention retention = retentionResult.retention();
+      mode = toRetentionMode(
+          ObjectRetentionModeType.fromString(retention.mode()));
+      if (retention.retainUntilDate() != null) {
+        retainUntilDate = Instant.parse(retention.retainUntilDate());
+      }
+    }
+
+    boolean legalHold = false;
+    if (legalHoldResult != null && legalHoldResult.legalHold() != null) {
+      legalHold = ObjectLegalHoldStatusType.ON.toString()
+          .equalsIgnoreCase(legalHoldResult.legalHold().status());
+    }
+
+    return ObjectLockInfo.builder()
+        .mode(mode)
+        .retainUntilDate(retainUntilDate)
+        .legalHold(legalHold)
+        .build();
+  }
+
+  public PutObjectRetentionRequest toPutObjectRetentionRequest(
+      String key, String versionId, RetentionMode mode,
+      Instant retainUntilDate, Boolean bypassGovernance) {
+    Retention retention = Retention.newBuilder()
+        .mode(toOssRetentionMode(mode))
+        .retainUntilDate(
+            DateTimeFormatter.ISO_INSTANT.format(retainUntilDate))
+        .build();
+
+    PutObjectRetentionRequest.Builder builder =
+        PutObjectRetentionRequest.newBuilder()
+            .bucket(bucket)
+            .key(key)
+            .retention(retention);
+    if (versionId != null) {
+      builder.versionId(versionId);
+    }
+    if (Boolean.TRUE.equals(bypassGovernance)) {
+      builder.bypassGovernanceRetention(true);
+    }
+    return builder.build();
+  }
+
+  public PutObjectLegalHoldRequest toPutObjectLegalHoldRequest(
+      String key, String versionId, boolean legalHold) {
+    LegalHold hold = LegalHold.newBuilder()
+        .status(legalHold
+            ? ObjectLegalHoldStatusType.ON
+            : ObjectLegalHoldStatusType.OFF)
+        .build();
+
+    PutObjectLegalHoldRequest.Builder builder =
+        PutObjectLegalHoldRequest.newBuilder()
+            .bucket(bucket)
+            .key(key)
+            .legalHold(hold);
+    if (versionId != null) {
+      builder.versionId(versionId);
+    }
+    return builder.build();
+  }
+
+  public static RetentionMode toRetentionMode(ObjectRetentionModeType ossMode) {
+    switch (ossMode) {
+      case GOVERNANCE:
+        return RetentionMode.GOVERNANCE;
+      case COMPLIANCE:
+        return RetentionMode.COMPLIANCE;
+      default:
+        return null;
+    }
+  }
+
+  public static ObjectRetentionModeType toOssRetentionMode(RetentionMode mode) {
+    switch (mode) {
+      case GOVERNANCE:
+        return ObjectRetentionModeType.GOVERNANCE;
+      case COMPLIANCE:
+        return ObjectRetentionModeType.COMPLIANCE;
+      default:
+        throw new InvalidArgumentException("Unsupported retention mode: " + mode);
+    }
   }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
@@ -115,7 +115,7 @@ public class AliBlobStoreIT extends AbstractBlobStoreIT {
 
     @Override
     public boolean isObjectLockSupported() {
-      return false;
+      return true;
     }
 
     @Override

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -45,7 +45,6 @@ import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.ali.AliConstants;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
-import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.CredentialsType;
@@ -1105,46 +1104,308 @@ public class AliBlobStoreTest {
   }
 
   @Test
-  void testGetObjectLock_ThrowsUnsupportedException() {
-    // Given
+  void testGetObjectLock() {
     String key = "test-key";
     String versionId = "version-1";
 
-    // When/Then
-    assertThrows(
-        UnSupportedOperationException.class,
-        () -> {
-          ali.getObjectLock(key, versionId);
-        });
+    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult retentionResult =
+        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
+            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
+                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.GOVERNANCE)
+                .retainUntilDate("2030-01-01T00:00:00Z")
+                .build())
+            .build();
+    com.aliyun.sdk.service.oss2.models.GetObjectLegalHoldResult legalHoldResult =
+        com.aliyun.sdk.service.oss2.models.GetObjectLegalHoldResult.newBuilder()
+            .legalHold(com.aliyun.sdk.service.oss2.models.LegalHold.newBuilder()
+                .status(com.aliyun.sdk.service.oss2.models.ObjectLegalHoldStatusType.ON)
+                .build())
+            .build();
+
+    when(mockOssClient.getObjectRetention(any(), any())).thenReturn(retentionResult);
+    when(mockOssClient.getObjectLegalHold(any(), any())).thenReturn(legalHoldResult);
+
+    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+        ali.getObjectLock(key, versionId);
+
+    assertEquals(
+        com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE, info.getMode());
+    assertEquals(Instant.parse("2030-01-01T00:00:00Z"), info.getRetainUntilDate());
+    assertTrue(info.isLegalHold());
   }
 
   @Test
-  void testUpdateObjectRetention_ThrowsUnsupportedException() {
-    // Given
+  void testGetObjectLockWithRetentionButNoLegalHold() {
     String key = "test-key";
     String versionId = "version-1";
-    Instant retainUntil = Instant.now().plusSeconds(3600);
 
-    // When/Then
-    assertThrows(
-        UnSupportedOperationException.class,
-        () -> {
-          ali.updateObjectRetention(key, versionId, retainUntil);
-        });
+    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult retentionResult =
+        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
+            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
+                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.GOVERNANCE)
+                .retainUntilDate("2030-01-01T00:00:00Z")
+                .build())
+            .build();
+    when(mockOssClient.getObjectRetention(any(), any())).thenReturn(retentionResult);
+
+    // OSS returns 404 NoSuchObjectLegalHoldConfiguration when an object has retention
+    // but no legal hold set. getObjectLock must treat this as "no legal hold", not fail.
+    ServiceException serviceException = mock(ServiceException.class);
+    when(serviceException.statusCode()).thenReturn(404);
+    when(serviceException.errorCode()).thenReturn("NoSuchObjectLegalHoldConfiguration");
+    OperationException operationException =
+        new OperationException("GetObjectLegalHold", serviceException);
+    when(mockOssClient.getObjectLegalHold(any(), any())).thenThrow(operationException);
+
+    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+        ali.getObjectLock(key, versionId);
+
+    assertEquals(
+        com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE, info.getMode());
+    assertEquals(Instant.parse("2030-01-01T00:00:00Z"), info.getRetainUntilDate());
+    assertFalse(info.isLegalHold());
   }
 
   @Test
-  void testUpdateLegalHold_ThrowsUnsupportedException() {
-    // Given
+  void testUpdateLegalHold() {
     String key = "test-key";
     String versionId = "version-1";
 
-    // When/Then
+    when(mockOssClient.putObjectLegalHold(any(), any()))
+        .thenReturn(
+            com.aliyun.sdk.service.oss2.models.PutObjectLegalHoldResult.newBuilder().build());
+
+    ali.updateLegalHold(key, versionId, true);
+
+    verify(mockOssClient).putObjectLegalHold(any(), any());
+  }
+
+  @Test
+  void testDoUpdateObjectRetention() {
+    String key = "test-key";
+    String versionId = "version-1";
+
+    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult currentResult =
+        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
+            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
+                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.GOVERNANCE)
+                .retainUntilDate("2030-01-01T00:00:00Z")
+                .build())
+            .build();
+
+    when(mockOssClient.getObjectRetention(any(), any())).thenReturn(currentResult);
+    when(mockOssClient.putObjectRetention(any(), any()))
+        .thenReturn(
+            com.aliyun.sdk.service.oss2.models.PutObjectRetentionResult.newBuilder().build());
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(Instant.parse("2031-01-01T00:00:00Z"))
+            .bypassGovernanceRetention(false)
+            .build();
+
+    ali.updateObjectRetention(key, versionId, config);
+
+    verify(mockOssClient).putObjectRetention(any(), any());
+  }
+
+  @Test
+  void testGetObjectLock_nonexistentKey_throws() {
+    String key = "no-such-key";
+    String versionId = null;
+
+    // OSS returns 404 with error code "NoSuchKey" when the object does not exist.
+    // This must NOT be swallowed as "no configuration" — it should propagate as an error.
+    ServiceException serviceException = mock(ServiceException.class);
+    when(serviceException.statusCode()).thenReturn(404);
+    when(serviceException.errorCode()).thenReturn("NoSuchKey");
+    OperationException operationException =
+        new OperationException("GetObjectRetention", serviceException);
+    when(mockOssClient.getObjectRetention(any(), any())).thenThrow(operationException);
+
+    assertThrows(OperationException.class, () -> ali.getObjectLock(key, versionId));
+  }
+
+  @Test
+  void testGetObjectLock_noRetentionNoLegalHold_returnsDefaults() {
+    String key = "test-key";
+    String versionId = "version-1";
+
+    // Both retention and legal hold return 404 NoSuchConfiguration — object exists but
+    // has no lock configuration. Should return an ObjectLockInfo with null mode and false hold.
+    ServiceException retentionException = mock(ServiceException.class);
+    when(retentionException.statusCode()).thenReturn(404);
+    when(retentionException.errorCode()).thenReturn("NoSuchObjectRetentionConfiguration");
+    OperationException retentionOpException =
+        new OperationException("GetObjectRetention", retentionException);
+    when(mockOssClient.getObjectRetention(any(), any())).thenThrow(retentionOpException);
+
+    ServiceException legalHoldException = mock(ServiceException.class);
+    when(legalHoldException.statusCode()).thenReturn(404);
+    when(legalHoldException.errorCode()).thenReturn("NoSuchObjectLegalHoldConfiguration");
+    OperationException legalHoldOpException =
+        new OperationException("GetObjectLegalHold", legalHoldException);
+    when(mockOssClient.getObjectLegalHold(any(), any())).thenThrow(legalHoldOpException);
+
+    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+        ali.getObjectLock(key, versionId);
+
+    assertNull(info.getMode());
+    assertNull(info.getRetainUntilDate());
+    assertFalse(info.isLegalHold());
+  }
+
+  @Test
+  void testDoUpdateObjectRetention_noCurrentRetention_throwsFailedPrecondition() {
+    String key = "test-key";
+    String versionId = "version-1";
+
+    // OSS returns 404 NoSuchObjectRetentionConfiguration for an object with no retention.
+    // doUpdateObjectRetention catches this and passes null currentMode to ObjectRetentionRules,
+    // which throws FailedPreconditionException.
+    ServiceException serviceException = mock(ServiceException.class);
+    when(serviceException.statusCode()).thenReturn(404);
+    when(serviceException.errorCode()).thenReturn("NoSuchObjectRetentionConfiguration");
+    OperationException operationException =
+        new OperationException("GetObjectRetention", serviceException);
+    when(mockOssClient.getObjectRetention(any(), any())).thenThrow(operationException);
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(Instant.parse("2031-01-01T00:00:00Z"))
+            .bypassGovernanceRetention(false)
+            .build();
+
     assertThrows(
-        UnSupportedOperationException.class,
-        () -> {
-          ali.updateLegalHold(key, versionId, true);
-        });
+        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        () -> ali.updateObjectRetention(key, versionId, config));
+  }
+
+  @Test
+  void testDoUpdateObjectRetention_complianceMode_shortenDate_throwsFailedPrecondition() {
+    String key = "test-key";
+    String versionId = "version-1";
+
+    // Object currently has COMPLIANCE mode with retain-until 2035. Attempting to shorten
+    // the date should throw FailedPreconditionException regardless of bypass flag.
+    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult currentResult =
+        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
+            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
+                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.COMPLIANCE)
+                .retainUntilDate("2035-01-01T00:00:00Z")
+                .build())
+            .build();
+    when(mockOssClient.getObjectRetention(any(), any())).thenReturn(currentResult);
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.COMPLIANCE)
+            .retainUntilDate(Instant.parse("2030-01-01T00:00:00Z"))
+            .bypassGovernanceRetention(true)
+            .build();
+
+    assertThrows(
+        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        () -> ali.updateObjectRetention(key, versionId, config));
+  }
+
+  @Test
+  void testDoUpdateObjectRetention_governanceMode_shortenWithoutBypass_throwsFailedPrecondition() {
+    String key = "test-key";
+    String versionId = "version-1";
+
+    // Object currently has GOVERNANCE mode with retain-until 2035. Attempting to shorten
+    // without bypass=true should throw FailedPreconditionException.
+    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult currentResult =
+        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
+            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
+                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.GOVERNANCE)
+                .retainUntilDate("2035-01-01T00:00:00Z")
+                .build())
+            .build();
+    when(mockOssClient.getObjectRetention(any(), any())).thenReturn(currentResult);
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(Instant.parse("2030-01-01T00:00:00Z"))
+            .bypassGovernanceRetention(false)
+            .build();
+
+    assertThrows(
+        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        () -> ali.updateObjectRetention(key, versionId, config));
+  }
+
+  @Test
+  void testDoCompleteMultipartUpload_withObjectLock_appliesRetentionAndLegalHold() {
+    // Verify that completing a multipart upload with an ObjectLockConfiguration
+    // triggers putObjectRetention and putObjectLegalHold calls.
+    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult mockResult =
+        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult.class);
+    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml mockXml =
+        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml.class);
+    when(mockResult.completeMultipartUpload()).thenReturn(mockXml);
+    when(mockResult.versionId()).thenReturn("ver-123");
+    when(mockXml.eTag()).thenReturn("\"result-etag\"");
+    when(mockOssClient.completeMultipartUpload(
+        any(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest.class),
+        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+    when(mockOssClient.putObjectRetention(any(), any()))
+        .thenReturn(
+            com.aliyun.sdk.service.oss2.models.PutObjectRetentionResult.newBuilder().build());
+    when(mockOssClient.putObjectLegalHold(any(), any()))
+        .thenReturn(
+            com.aliyun.sdk.service.oss2.models.PutObjectLegalHoldResult.newBuilder().build());
+
+    com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration lockConfig =
+        com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(Instant.parse("2100-01-01T00:00:00Z"))
+            .legalHold(true)
+            .build();
+
+    MultipartUpload multipartUpload = MultipartUpload.builder()
+        .bucket("bucket-1").key("object-1").id("mpu-id")
+        .objectLock(lockConfig)
+        .build();
+    List<com.salesforce.multicloudj.blob.driver.UploadPartResponse> listOfParts =
+        List.of(new com.salesforce.multicloudj.blob.driver.UploadPartResponse(1, "etag", 0));
+
+    ali.completeMultipartUpload(multipartUpload, listOfParts);
+
+    verify(mockOssClient).completeMultipartUpload(any(), any());
+    verify(mockOssClient).putObjectRetention(any(), any());
+    verify(mockOssClient).putObjectLegalHold(any(), any());
+  }
+
+  @Test
+  void testDoCompleteMultipartUpload_withoutObjectLock_doesNotApplyRetention() {
+    // Verify that completing a multipart upload WITHOUT ObjectLockConfiguration
+    // does NOT call putObjectRetention or putObjectLegalHold.
+    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult mockResult =
+        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult.class);
+    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml mockXml =
+        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml.class);
+    when(mockResult.completeMultipartUpload()).thenReturn(mockXml);
+    when(mockXml.eTag()).thenReturn("\"result-etag\"");
+    when(mockOssClient.completeMultipartUpload(
+        any(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest.class),
+        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+
+    MultipartUpload multipartUpload = MultipartUpload.builder()
+        .bucket("bucket-1").key("object-1").id("mpu-id")
+        .build();
+    List<com.salesforce.multicloudj.blob.driver.UploadPartResponse> listOfParts =
+        List.of(new com.salesforce.multicloudj.blob.driver.UploadPartResponse(1, "etag", 0));
+
+    ali.completeMultipartUpload(multipartUpload, listOfParts);
+
+    verify(mockOssClient).completeMultipartUpload(any(), any());
+    verify(mockOssClient, org.mockito.Mockito.never()).putObjectRetention(any(), any());
+    verify(mockOssClient, org.mockito.Mockito.never()).putObjectLegalHold(any(), any());
   }
 
   @Test

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_afteruploadwithretentiongovernance-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_afteruploadwithretentiongovernance-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "d8addd29-f5a9-4c0c-b4a0-2ab283e7ed60",
+  "name" : "AliBlobStoreIT_testGetObjectLock_afterUploadWithRetentionGovernance-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/retention-governance",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYsbK4sKyL1fQZIiA1NWEwNTNmODVmNzc0NGMzYjViZTczM2I4ZmI3ZTE1OQ--",
+      "x-oss-request-id" : "6A221E1FFA230831337551F0",
+      "x-oss-server-time" : "26",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:53:51 GMT"
+    }
+  },
+  "uuid" : "d8addd29-f5a9-4c0c-b4a0-2ab283e7ed60",
+  "persistent" : true,
+  "insertionIndex" : 1210
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_afteruploadwithretentiongovernance-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_afteruploadwithretentiongovernance-get-1.json
@@ -1,0 +1,37 @@
+{
+  "id" : "dadbb9cd-408e-433b-b449-cd9ceb37a426",
+  "name" : "AliBlobStoreIT_testGetObjectLock_afterUploadWithRetentionGovernance-GET-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/retention-governance",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legalHold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchObjectLegalHoldConfiguration</Code>\n  <Message>The specified object does not have an object legal hold configuration.</Message>\n  <RequestId>6A221E1E26F41933348F7A95</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <ObjectName>conformance-tests/objectlock/retention-governance</ObjectName>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A221E1E26F41933348F7A95",
+      "x-oss-server-time" : "6",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:53:50 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "dadbb9cd-408e-433b-b449-cd9ceb37a426",
+  "persistent" : true,
+  "insertionIndex" : 1211
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_afteruploadwithretentiongovernance-get-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_afteruploadwithretentiongovernance-get-2.json
@@ -1,0 +1,38 @@
+{
+  "id" : "c8409cc3-4d2c-4281-aa17-2e1de48a33ab",
+  "name" : "AliBlobStoreIT_testGetObjectLock_afterUploadWithRetentionGovernance-GET-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/retention-governance",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>GOVERNANCE</Mode>\n  <RetainUntilDate>2100-01-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY3t3er5iL1fQZIiA3ZGFiNTEzOTdiMTE0ZDA1OTYzYmNhNjUzMTQzZDc4OA--",
+      "x-oss-request-id" : "6A221E1CC15CCF3838023247",
+      "x-oss-server-time" : "18",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:53:48 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "c8409cc3-4d2c-4281-aa17-2e1de48a33ab",
+  "persistent" : true,
+  "insertionIndex" : 1212
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_afteruploadwithretentiongovernance-put-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_afteruploadwithretentiongovernance-put-3.json
@@ -1,0 +1,44 @@
+{
+  "id" : "0de13ff3-8e7f-4b8a-8217-1cbd724f51f4",
+  "name" : "AliBlobStoreIT_testGetObjectLock_afterUploadWithRetentionGovernance-PUT-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/retention-governance",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQjAkY3t3er5iL1fQZIiA3ZGFiNTEzOTdiMTE0ZDA1OTYzYmNhNjUzMTQzZDc4OA--"
+        } ]
+      },
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>GOVERNANCE</Mode><RetainUntilDate>2100-01-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY3t3er5iL1fQZIiA3ZGFiNTEzOTdiMTE0ZDA1OTYzYmNhNjUzMTQzZDc4OA--",
+      "x-oss-request-id" : "6A221E1BFB200F3735ABFFA1",
+      "x-oss-server-time" : "13",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:53:47 GMT"
+    }
+  },
+  "uuid" : "0de13ff3-8e7f-4b8a-8217-1cbd724f51f4",
+  "persistent" : true,
+  "insertionIndex" : 1213
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_afteruploadwithretentiongovernance-put-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_afteruploadwithretentiongovernance-put-4.json
@@ -1,0 +1,32 @@
+{
+  "id" : "3cbad419-9a48-4bcc-aabd-bae9975aa9ab",
+  "name" : "AliBlobStoreIT_testGetObjectLock_afterUploadWithRetentionGovernance-PUT-4",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/retention-governance",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "T2JqZWN0IGxvY2sgcmV0ZW50aW9uIGdvdmVybmFuY2UgdGVzdA=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY3t3er5iL1fQZIiA3ZGFiNTEzOTdiMTE0ZDA1OTYzYmNhNjUzMTQzZDc4OA--",
+      "x-oss-request-id" : "6A221E1AE05A523738DCE1C4",
+      "x-oss-server-time" : "41",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "4303325961431456286",
+      "ETag" : "\"7E7CEE74A915A322EF6C75C3AB034D4F\"",
+      "Date" : "Fri, 05 Jun 2026 00:53:46 GMT",
+      "Content-MD5" : "fnzudKkVoyLvbHXDqwNNTw=="
+    }
+  },
+  "uuid" : "3cbad419-9a48-4bcc-aabd-bae9975aa9ab",
+  "persistent" : true,
+  "insertionIndex" : 1214
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_nonexistentkey_throws-get-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_nonexistentkey_throws-get-0.json
@@ -1,0 +1,38 @@
+{
+  "id" : "545056ba-334c-4b55-8977-36e3ccc14c7f",
+  "name" : "AliBlobStoreIT_testGetObjectLock_nonexistentKey_throws-GET-0",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/nonexistent",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchKey</Code>\n  <Message>The specified key does not exist.</Message>\n  <RequestId>6A221CD5079ACC38320A3E41</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <Key>conformance-tests/objectlock/nonexistent</Key>\n  <EC>0026-00000001</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0026-00000001</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A221CD5079ACC38320A3E41",
+      "x-oss-server-time" : "12",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0026-00000001",
+      "Date" : "Fri, 05 Jun 2026 00:48:21 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "545056ba-334c-4b55-8977-36e3ccc14c7f",
+  "persistent" : true,
+  "insertionIndex" : 795
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_objectwithoutlock_returnsnullornoretention-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_objectwithoutlock_returnsnullornoretention-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "8e41a493-195b-4938-b1bf-885e6f16dd12",
+  "name" : "AliBlobStoreIT_testGetObjectLock_objectWithoutLock_returnsNullOrNoRetention-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/no-lock",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYppK42On81PQZIiAzNWRiM2JmN2I2YjA0Mzg0OTQyODAwNDFmYjRiNWNjOQ--",
+      "x-oss-request-id" : "6A221C4483DA733033E7256E",
+      "x-oss-server-time" : "17",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:45:56 GMT"
+    }
+  },
+  "uuid" : "8e41a493-195b-4938-b1bf-885e6f16dd12",
+  "persistent" : true,
+  "insertionIndex" : 636
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_objectwithoutlock_returnsnullornoretention-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_objectwithoutlock_returnsnullornoretention-get-1.json
@@ -1,0 +1,37 @@
+{
+  "id" : "b215e130-9ed5-4cfe-b10e-e0c8c1b83cfe",
+  "name" : "AliBlobStoreIT_testGetObjectLock_objectWithoutLock_returnsNullOrNoRetention-GET-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/no-lock",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legalHold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchObjectLegalHoldConfiguration</Code>\n  <Message>The specified object does not have an object legal hold configuration.</Message>\n  <RequestId>6A221C43BA04B93433CE378E</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <ObjectName>conformance-tests/objectlock/no-lock</ObjectName>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A221C43BA04B93433CE378E",
+      "x-oss-server-time" : "8",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:45:55 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "b215e130-9ed5-4cfe-b10e-e0c8c1b83cfe",
+  "persistent" : true,
+  "insertionIndex" : 637
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_objectwithoutlock_returnsnullornoretention-get-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_objectwithoutlock_returnsnullornoretention-get-2.json
@@ -1,0 +1,37 @@
+{
+  "id" : "528adf96-47b8-43ae-b20c-7e68bf801162",
+  "name" : "AliBlobStoreIT_testGetObjectLock_objectWithoutLock_returnsNullOrNoRetention-GET-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/no-lock",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchObjectRetentionConfiguration</Code>\n  <Message>The specified object does not have an object retention configuration.</Message>\n  <RequestId>6A221C418896FB37365E93F5</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <ObjectName>conformance-tests/objectlock/no-lock</ObjectName>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A221C418896FB37365E93F5",
+      "x-oss-server-time" : "15",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:45:53 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "528adf96-47b8-43ae-b20c-7e68bf801162",
+  "persistent" : true,
+  "insertionIndex" : 638
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_objectwithoutlock_returnsnullornoretention-put-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testgetobjectlock_objectwithoutlock_returnsnullornoretention-put-3.json
@@ -1,0 +1,32 @@
+{
+  "id" : "6733dfb1-590b-40ef-9150-2c05505065be",
+  "name" : "AliBlobStoreIT_testGetObjectLock_objectWithoutLock_returnsNullOrNoRetention-PUT-3",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/no-lock",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "T2JqZWN0IHdpdGhvdXQgbG9jayB0ZXN0"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY5onwr9381PQZIiBhOTgwOWIxMjhlODg0MWQ1YjA5ODNiZWJlN2UyMTNiMg--",
+      "x-oss-request-id" : "6A221C4082E54D383280EF81",
+      "x-oss-server-time" : "33",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "2823524111274785938",
+      "ETag" : "\"FDD2C398FD6D009C474F1F9A02D38EC5\"",
+      "Date" : "Fri, 05 Jun 2026 00:45:52 GMT",
+      "Content-MD5" : "/dLDmP1tAJxHTx+aAtOOxQ=="
+    }
+  },
+  "uuid" : "6733dfb1-590b-40ef-9150-2c05505065be",
+  "persistent" : true,
+  "insertionIndex" : 639
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "17b2fdf3-9769-4ef0-990e-a5764fe64ce1",
+  "name" : "AliBlobStoreIT_testTagging_withObjectLock-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-tagging-objectlock-fake",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYi8TJ8qD81PQZIiBhNzRiZDBjMTk1ZTE0ZDVhYTVkNDNiN2E2ZjU1ZTMwMg--",
+      "x-oss-request-id" : "6A221C3183DA7338362DA56D",
+      "x-oss-server-time" : "71",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:45:37 GMT"
+    }
+  },
+  "uuid" : "17b2fdf3-9769-4ef0-990e-a5764fe64ce1",
+  "persistent" : true,
+  "insertionIndex" : 613
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-delete-1.json
@@ -1,0 +1,27 @@
+{
+  "id" : "2ca16672-3c2f-48bf-8a04-ce8dfa4b5fb2",
+  "name" : "AliBlobStoreIT_testTagging_withObjectLock-DELETE-1",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-tagging-objectlock",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYoLGbsJ381PQZIiA1NDU5YTZiNzFlODI0Y2E0OGJjZDljZTViNjljNjc4YQ--",
+      "x-oss-request-id" : "6A221C301FE7723132AEE05F",
+      "x-oss-server-time" : "29",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:45:36 GMT"
+    }
+  },
+  "uuid" : "2ca16672-3c2f-48bf-8a04-ce8dfa4b5fb2",
+  "persistent" : true,
+  "insertionIndex" : 614
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-get-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-get-3.json
@@ -1,0 +1,40 @@
+{
+  "id" : "7e11728c-59c1-45ac-9f83-331770bf0796",
+  "name" : "AliBlobStoreIT_testTagging_withObjectLock-GET-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/blob-for-tagging-objectlock",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "tagging" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Tagging>\n  <TagSet>\n    <Tag>\n      <Key>tag3</Key>\n      <Value>value3</Value>\n    </Tag>\n  </TagSet>\n</Tagging>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYzYzJ0Iz81PQZIiBhYzZjMWMyNWI1OTk0ZDg5OWRkNmM2Y2Q1ZGM4ZTIxNg--",
+      "x-oss-request-id" : "6A221C2EE05A523632406BB7",
+      "x-oss-server-time" : "34",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:45:34 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "7e11728c-59c1-45ac-9f83-331770bf0796",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-blob-for-tagging-objectlock",
+  "requiredScenarioState" : "scenario-1-conformance-tests-blob-for-tagging-objectlock-2",
+  "insertionIndex" : 616
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-get-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-get-5.json
@@ -1,0 +1,41 @@
+{
+  "id" : "a92b1ed6-7c3f-4850-b93b-e4f37ed3cafa",
+  "name" : "AliBlobStoreIT_testTagging_withObjectLock-GET-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/blob-for-tagging-objectlock",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "tagging" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Tagging>\n  <TagSet>\n    <Tag>\n      <Key>tag1</Key>\n      <Value>value1</Value>\n    </Tag>\n  </TagSet>\n</Tagging>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYzYzJ0Iz81PQZIiBhYzZjMWMyNWI1OTk0ZDg5OWRkNmM2Y2Q1ZGM4ZTIxNg--",
+      "x-oss-request-id" : "6A221C2D945E9F3638BCADE2",
+      "x-oss-server-time" : "18",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:45:33 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "a92b1ed6-7c3f-4850-b93b-e4f37ed3cafa",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-blob-for-tagging-objectlock",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-conformance-tests-blob-for-tagging-objectlock-2",
+  "insertionIndex" : 618
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-put-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-put-2.json
@@ -1,0 +1,43 @@
+{
+  "id" : "fd77083e-f51f-4e8f-ab82-1767e5c0653d",
+  "name" : "AliBlobStoreIT_testTagging_withObjectLock-PUT-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/blob-for-tagging-objectlock-fake",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "tagging" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Tagging><TagSet><Tag><Key>tag5</Key><Value>value5</Value></Tag></TagSet></Tagging>"
+    } ]
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchKey</Code>\n  <Message>The specified key does not exist.</Message>\n  <RequestId>6A221C2FFB200F3136469A94</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <Key>conformance-tests/blob-for-tagging-objectlock-fake</Key>\n  <EC>0026-00000001</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0026-00000001</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY5oDu3pfu1PQZIiA5OTFjNTE5OGE3OGM0ODYxYmRiNDAzYTg5M2E1MDEwOQ--",
+      "x-oss-request-id" : "6A221C2FFB200F3136469A94",
+      "x-oss-server-time" : "35",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0026-00000001",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:45:35 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "fd77083e-f51f-4e8f-ab82-1767e5c0653d",
+  "persistent" : true,
+  "insertionIndex" : 615
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-put-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-put-4.json
@@ -1,0 +1,39 @@
+{
+  "id" : "6d682514-dbed-4f2f-9995-b923d98f358a",
+  "name" : "AliBlobStoreIT_testTagging_withObjectLock-PUT-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/blob-for-tagging-objectlock",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "tagging" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Tagging><TagSet><Tag><Key>tag3</Key><Value>value3</Value></Tag></TagSet></Tagging>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYzYzJ0Iz81PQZIiBhYzZjMWMyNWI1OTk0ZDg5OWRkNmM2Y2Q1ZGM4ZTIxNg--",
+      "x-oss-request-id" : "6A221C2D933F91363382D718",
+      "x-oss-server-time" : "31",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:45:33 GMT"
+    }
+  },
+  "uuid" : "6d682514-dbed-4f2f-9995-b923d98f358a",
+  "persistent" : true,
+  "insertionIndex" : 617
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testtagging_withobjectlock-put-6.json
@@ -1,0 +1,32 @@
+{
+  "id" : "9ee7742e-6222-4b62-b206-36c0990745ff",
+  "name" : "AliBlobStoreIT_testTagging_withObjectLock-PUT-6",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-tagging-objectlock",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "VGFnZ2luZyB3aXRoIG9iamVjdCBsb2NrIHRlc3QgZGF0YQ=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYzYzJ0Iz81PQZIiBhYzZjMWMyNWI1OTk0ZDg5OWRkNmM2Y2Q1ZGM4ZTIxNg--",
+      "x-oss-request-id" : "6A221C2C5E372634302568E1",
+      "x-oss-server-time" : "36",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "1121081735445369706",
+      "ETag" : "\"7E1A180EDDE38BEB3774924B70DCBFC7\"",
+      "Date" : "Fri, 05 Jun 2026 00:45:32 GMT",
+      "Content-MD5" : "fhoYDt3ji+s3dJJLcNy/xw=="
+    }
+  },
+  "uuid" : "9ee7742e-6222-4b62-b206-36c0990745ff",
+  "persistent" : true,
+  "insertionIndex" : 619
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "dcd30b69-6109-4ea2-a949-16373303c9e4",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/comp-extend",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY_dTVkOSD1fQZIiA4M2I4YTM2OTViYWQ0MWQyOTA2MmI5YzZjOWRjNmNiOA--",
+      "x-oss-request-id" : "6A221D27E4C5F83631E0C989",
+      "x-oss-server-time" : "66",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:49:43 GMT"
+    }
+  },
+  "uuid" : "dcd30b69-6109-4ea2-a949-16373303c9e4",
+  "persistent" : true,
+  "insertionIndex" : 905
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-1.json
@@ -1,0 +1,37 @@
+{
+  "id" : "7a601383-6320-4bc5-8222-4d0d98807ba3",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/comp-extend",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legalHold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchObjectLegalHoldConfiguration</Code>\n  <Message>The specified object does not have an object legal hold configuration.</Message>\n  <RequestId>6A221D27A73E4C393345DE5D</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <ObjectName>conformance-tests/objectlock/update/comp-extend</ObjectName>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A221D27A73E4C393345DE5D",
+      "x-oss-server-time" : "49",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:49:43 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "7a601383-6320-4bc5-8222-4d0d98807ba3",
+  "persistent" : true,
+  "insertionIndex" : 906
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-2.json
@@ -1,0 +1,40 @@
+{
+  "id" : "39974217-a2a9-411e-874e-158f24c214a3",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/comp-extend",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>COMPLIANCE</Mode>\n  <RetainUntilDate>2030-06-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYwo7esNCD1fQZIiA3NjZjN2E5ZTVmNDE0NzFmYjk3N2M0MTkyMzk3YzgxZg--",
+      "x-oss-request-id" : "6A221D2610827E393538779A",
+      "x-oss-server-time" : "13",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:49:42 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "39974217-a2a9-411e-874e-158f24c214a3",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-objectlock-update-comp-extend",
+  "requiredScenarioState" : "scenario-1-conformance-tests-objectlock-update-comp-extend-2",
+  "insertionIndex" : 907
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-get-4.json
@@ -1,0 +1,41 @@
+{
+  "id" : "ad35fa60-aff6-434a-993f-653dda5c611f",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-GET-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/comp-extend",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>COMPLIANCE</Mode>\n  <RetainUntilDate>2030-01-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYwo7esNCD1fQZIiA3NjZjN2E5ZTVmNDE0NzFmYjk3N2M0MTkyMzk3YzgxZg--",
+      "x-oss-request-id" : "6A221D242BFAFA3731BA6414",
+      "x-oss-server-time" : "5",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:49:40 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "ad35fa60-aff6-434a-993f-653dda5c611f",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-objectlock-update-comp-extend",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-conformance-tests-objectlock-update-comp-extend-2",
+  "insertionIndex" : 909
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-3.json
@@ -1,0 +1,39 @@
+{
+  "id" : "0226aa7a-455d-4a65-b302-7d85e17b4a76",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-PUT-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/comp-extend",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>COMPLIANCE</Mode><RetainUntilDate>2030-06-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYwo7esNCD1fQZIiA3NjZjN2E5ZTVmNDE0NzFmYjk3N2M0MTkyMzk3YzgxZg--",
+      "x-oss-request-id" : "6A221D259E87C13533F3C86E",
+      "x-oss-server-time" : "65",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:49:41 GMT"
+    }
+  },
+  "uuid" : "0226aa7a-455d-4a65-b302-7d85e17b4a76",
+  "persistent" : true,
+  "insertionIndex" : 908
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-5.json
@@ -1,0 +1,44 @@
+{
+  "id" : "dfbe5558-2ead-437f-9688-a0bc6a6ad227",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-PUT-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/comp-extend",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQjAkYwo7esNCD1fQZIiA3NjZjN2E5ZTVmNDE0NzFmYjk3N2M0MTkyMzk3YzgxZg--"
+        } ]
+      },
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>COMPLIANCE</Mode><RetainUntilDate>2030-01-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYwo7esNCD1fQZIiA3NjZjN2E5ZTVmNDE0NzFmYjk3N2M0MTkyMzk3YzgxZg--",
+      "x-oss-request-id" : "6A221D230710A83130AB9F3E",
+      "x-oss-server-time" : "11",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:49:39 GMT"
+    }
+  },
+  "uuid" : "dfbe5558-2ead-437f-9688-a0bc6a6ad227",
+  "persistent" : true,
+  "insertionIndex" : 910
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_extend_succeeds-put-6.json
@@ -1,0 +1,32 @@
+{
+  "id" : "e512802c-0107-44ad-8a5e-8eae111fb3ad",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_compliance_extend_succeeds-PUT-6",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/comp-extend",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9jb21wLWV4dGVuZA=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYwo7esNCD1fQZIiA3NjZjN2E5ZTVmNDE0NzFmYjk3N2M0MTkyMzk3YzgxZg--",
+      "x-oss-request-id" : "6A221D2258FB013433A685B0",
+      "x-oss-server-time" : "33",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "15522380419852632896",
+      "ETag" : "\"BD63E27D8E1FFC7B2A7E82AB64A21FEA\"",
+      "Date" : "Fri, 05 Jun 2026 00:49:38 GMT",
+      "Content-MD5" : "vWPifY4f/HsqfoKrZKIf6g=="
+    }
+  },
+  "uuid" : "e512802c-0107-44ad-8a5e-8eae111fb3ad",
+  "persistent" : true,
+  "insertionIndex" : 911
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "28dd5ec3-a365-4f57-86a2-9cf6fba1aa9f",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/comp-shorten-bypass",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYrrnI6dyH1fQZIiBiMTc4MjAyOTM5OWE0ODg3OTU5NTU3NmVjNmY3MDJiMw--",
+      "x-oss-request-id" : "6A221DA94C586D3436AC2963",
+      "x-oss-server-time" : "49",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:51:53 GMT"
+    }
+  },
+  "uuid" : "28dd5ec3-a365-4f57-86a2-9cf6fba1aa9f",
+  "persistent" : true,
+  "insertionIndex" : 1076
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-get-1.json
@@ -1,0 +1,38 @@
+{
+  "id" : "149588b1-5595-48f3-a7ee-22ce5ff35ce6",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-GET-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/comp-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>COMPLIANCE</Mode>\n  <RetainUntilDate>2030-06-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYwsGmzNKH1fQZIiBjMGQzYzYzMDZlNmQ0NjJlYTYyMTFkNzRjOGJlNmQ4NQ--",
+      "x-oss-request-id" : "6A221DA8EF9B98323453F535",
+      "x-oss-server-time" : "4",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:51:52 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "149588b1-5595-48f3-a7ee-22ce5ff35ce6",
+  "persistent" : true,
+  "insertionIndex" : 1077
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-put-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-put-2.json
@@ -1,0 +1,44 @@
+{
+  "id" : "87894860-9680-4cf6-b863-5214793bb604",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-PUT-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/comp-shorten-bypass",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQjAkYwsGmzNKH1fQZIiBjMGQzYzYzMDZlNmQ0NjJlYTYyMTFkNzRjOGJlNmQ4NQ--"
+        } ]
+      },
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>COMPLIANCE</Mode><RetainUntilDate>2030-06-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYwsGmzNKH1fQZIiBjMGQzYzYzMDZlNmQ0NjJlYTYyMTFkNzRjOGJlNmQ4NQ--",
+      "x-oss-request-id" : "6A221DA765B5FD3533615189",
+      "x-oss-server-time" : "20",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:51:51 GMT"
+    }
+  },
+  "uuid" : "87894860-9680-4cf6-b863-5214793bb604",
+  "persistent" : true,
+  "insertionIndex" : 1078
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-put-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_compliance_shorten_evenwithbypass_throws-put-3.json
@@ -1,0 +1,32 @@
+{
+  "id" : "d4498a80-3dd4-46b7-a257-ba604d6070a3",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_compliance_shorten_evenWithBypass_throws-PUT-3",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/comp-shorten-bypass",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9jb21wLXNob3J0ZW4tYnlwYXNz"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYwsGmzNKH1fQZIiBjMGQzYzYzMDZlNmQ0NjJlYTYyMTFkNzRjOGJlNmQ4NQ--",
+      "x-oss-request-id" : "6A221DA681731C393478962F",
+      "x-oss-server-time" : "47",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "1821900555964995052",
+      "ETag" : "\"C22727D8B05A74BF68F7B644FA388E74\"",
+      "Date" : "Fri, 05 Jun 2026 00:51:50 GMT",
+      "Content-MD5" : "wicn2LBadL9o97ZE+jiOdA=="
+    }
+  },
+  "uuid" : "d4498a80-3dd4-46b7-a257-ba604d6070a3",
+  "persistent" : true,
+  "insertionIndex" : 1079
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "36402efa-6a78-4353-ab8b-386f42739a4f",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/gov-extend",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY_KvIxKuF1fQZIiA4Njk0NGMyMGIzY2U0OTY1YjBiYzZhMzA5MWI1OTU0NA--",
+      "x-oss-request-id" : "6A221D5A82F61D32373B1FC6",
+      "x-oss-server-time" : "35",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:50:35 GMT"
+    }
+  },
+  "uuid" : "36402efa-6a78-4353-ab8b-386f42739a4f",
+  "persistent" : true,
+  "insertionIndex" : 969
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-1.json
@@ -1,0 +1,37 @@
+{
+  "id" : "a928509c-c8f9-45fc-a3a7-71cc00a1e78a",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/gov-extend",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legalHold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchObjectLegalHoldConfiguration</Code>\n  <Message>The specified object does not have an object legal hold configuration.</Message>\n  <RequestId>6A221D5AEF9B9836373ECE33</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <ObjectName>conformance-tests/objectlock/update/gov-extend</ObjectName>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A221D5AEF9B9836373ECE33",
+      "x-oss-server-time" : "5",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:50:34 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "a928509c-c8f9-45fc-a3a7-71cc00a1e78a",
+  "persistent" : true,
+  "insertionIndex" : 970
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-2.json
@@ -1,0 +1,40 @@
+{
+  "id" : "a8144e61-dc13-47fb-ab4b-1dd752e47317",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/gov-extend",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>GOVERNANCE</Mode>\n  <RetainUntilDate>2030-06-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYw86c2JeF1fQZIiBkM2RjNzFlMjg0MmE0ZmRlYjA4ZGI2OTQxZTdiYWZmZA--",
+      "x-oss-request-id" : "6A221D59F5C7C434322C6379",
+      "x-oss-server-time" : "8",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:50:33 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "a8144e61-dc13-47fb-ab4b-1dd752e47317",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-objectlock-update-gov-extend",
+  "requiredScenarioState" : "scenario-1-conformance-tests-objectlock-update-gov-extend-2",
+  "insertionIndex" : 971
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-get-4.json
@@ -1,0 +1,41 @@
+{
+  "id" : "0d469300-77f5-44b1-84e0-ee9aed3b0b4f",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-GET-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/gov-extend",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>GOVERNANCE</Mode>\n  <RetainUntilDate>2030-01-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYw86c2JeF1fQZIiBkM2RjNzFlMjg0MmE0ZmRlYjA4ZGI2OTQxZTdiYWZmZA--",
+      "x-oss-request-id" : "6A221D57F5C7C43835955579",
+      "x-oss-server-time" : "6",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:50:31 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "0d469300-77f5-44b1-84e0-ee9aed3b0b4f",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-objectlock-update-gov-extend",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-conformance-tests-objectlock-update-gov-extend-2",
+  "insertionIndex" : 973
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-3.json
@@ -1,0 +1,39 @@
+{
+  "id" : "916ff203-8aaa-4797-8457-7800b3efa066",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-PUT-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/gov-extend",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>GOVERNANCE</Mode><RetainUntilDate>2030-06-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYw86c2JeF1fQZIiBkM2RjNzFlMjg0MmE0ZmRlYjA4ZGI2OTQxZTdiYWZmZA--",
+      "x-oss-request-id" : "6A221D580710A83739191540",
+      "x-oss-server-time" : "9",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:50:32 GMT"
+    }
+  },
+  "uuid" : "916ff203-8aaa-4797-8457-7800b3efa066",
+  "persistent" : true,
+  "insertionIndex" : 972
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-5.json
@@ -1,0 +1,44 @@
+{
+  "id" : "7a748ecd-c996-4aea-9572-fa9d92af02a9",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-PUT-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/gov-extend",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQjAkYw86c2JeF1fQZIiBkM2RjNzFlMjg0MmE0ZmRlYjA4ZGI2OTQxZTdiYWZmZA--"
+        } ]
+      },
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>GOVERNANCE</Mode><RetainUntilDate>2030-01-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYw86c2JeF1fQZIiBkM2RjNzFlMjg0MmE0ZmRlYjA4ZGI2OTQxZTdiYWZmZA--",
+      "x-oss-request-id" : "6A221D56FB200F333375949C",
+      "x-oss-server-time" : "10",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:50:30 GMT"
+    }
+  },
+  "uuid" : "7a748ecd-c996-4aea-9572-fa9d92af02a9",
+  "persistent" : true,
+  "insertionIndex" : 974
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_extend_succeeds-put-6.json
@@ -1,0 +1,32 @@
+{
+  "id" : "bbd2cc24-b8d4-4350-9767-0d030c4e8b45",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_extend_succeeds-PUT-6",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/gov-extend",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9nb3YtZXh0ZW5k"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYw86c2JeF1fQZIiBkM2RjNzFlMjg0MmE0ZmRlYjA4ZGI2OTQxZTdiYWZmZA--",
+      "x-oss-request-id" : "6A221D5511D2913135E02528",
+      "x-oss-server-time" : "31",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "7180117724423120612",
+      "ETag" : "\"21599C7F1B469ED1CFFC796F3F269CA0\"",
+      "Date" : "Fri, 05 Jun 2026 00:50:29 GMT",
+      "Content-MD5" : "IVmcfxtGntHP/HlvPyacoA=="
+    }
+  },
+  "uuid" : "bbd2cc24-b8d4-4350-9767-0d030c4e8b45",
+  "persistent" : true,
+  "insertionIndex" : 975
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "0d0fac82-11eb-4154-b622-f18b8005ef7d",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYutqR0PmC1fQZIiBmZGI0ZDU1ZjY0MjI0NzUyYWRhZTA5OWE0YjBhMjk3Mg--",
+      "x-oss-request-id" : "6A221D0C46D89934384C64EE",
+      "x-oss-server-time" : "30",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:49:16 GMT"
+    }
+  },
+  "uuid" : "0d0fac82-11eb-4154-b622-f18b8005ef7d",
+  "persistent" : true,
+  "insertionIndex" : 865
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-1.json
@@ -1,0 +1,37 @@
+{
+  "id" : "3c27226a-f204-4e90-96dd-a778c745290e",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legalHold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchObjectLegalHoldConfiguration</Code>\n  <Message>The specified object does not have an object legal hold configuration.</Message>\n  <RequestId>6A221D0B46D8993735335EEE</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <ObjectName>conformance-tests/objectlock/update/gov-shorten-bypass</ObjectName>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A221D0B46D8993735335EEE",
+      "x-oss-server-time" : "37",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:49:15 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "3c27226a-f204-4e90-96dd-a778c745290e",
+  "persistent" : true,
+  "insertionIndex" : 866
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-2.json
@@ -1,0 +1,40 @@
+{
+  "id" : "57e93bc3-75b8-4ea9-955e-01158fc453d9",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>GOVERNANCE</Mode>\n  <RetainUntilDate>2030-02-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYm5eE1.WC1fQZIiA0NjY5OThiMTA0ODg0ODQ1YmQ0MGJhMmZmZmNlZTU3Ng--",
+      "x-oss-request-id" : "6A221D0B5C5E113838885E85",
+      "x-oss-server-time" : "5",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:49:15 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "57e93bc3-75b8-4ea9-955e-01158fc453d9",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-objectlock-update-gov-shorten-bypass",
+  "requiredScenarioState" : "scenario-1-conformance-tests-objectlock-update-gov-shorten-bypass-2",
+  "insertionIndex" : 867
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-get-4.json
@@ -1,0 +1,41 @@
+{
+  "id" : "861e08b3-8bec-439b-8b90-77143989bbd7",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-GET-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>GOVERNANCE</Mode>\n  <RetainUntilDate>2030-06-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYm5eE1.WC1fQZIiA0NjY5OThiMTA0ODg0ODQ1YmQ0MGJhMmZmZmNlZTU3Ng--",
+      "x-oss-request-id" : "6A221D09C15CCF3932708A3F",
+      "x-oss-server-time" : "4",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:49:13 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "861e08b3-8bec-439b-8b90-77143989bbd7",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-objectlock-update-gov-shorten-bypass",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-conformance-tests-objectlock-update-gov-shorten-bypass-2",
+  "insertionIndex" : 869
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-3.json
@@ -1,0 +1,39 @@
+{
+  "id" : "c1470d7f-13fc-4c54-bb5b-0a78a6bd17f7",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-PUT-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>GOVERNANCE</Mode><RetainUntilDate>2030-02-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYm5eE1.WC1fQZIiA0NjY5OThiMTA0ODg0ODQ1YmQ0MGJhMmZmZmNlZTU3Ng--",
+      "x-oss-request-id" : "6A221D0AD3D4973737C06106",
+      "x-oss-server-time" : "35",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:49:14 GMT"
+    }
+  },
+  "uuid" : "c1470d7f-13fc-4c54-bb5b-0a78a6bd17f7",
+  "persistent" : true,
+  "insertionIndex" : 868
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-5.json
@@ -1,0 +1,44 @@
+{
+  "id" : "1fed5a96-2489-47b0-b830-f05d1b2bd54c",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-PUT-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQjAkYm5eE1.WC1fQZIiA0NjY5OThiMTA0ODg0ODQ1YmQ0MGJhMmZmZmNlZTU3Ng--"
+        } ]
+      },
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>GOVERNANCE</Mode><RetainUntilDate>2030-06-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYm5eE1.WC1fQZIiA0NjY5OThiMTA0ODg0ODQ1YmQ0MGJhMmZmZmNlZTU3Ng--",
+      "x-oss-request-id" : "6A221D0858FB013136A4CEAF",
+      "x-oss-server-time" : "39",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:49:12 GMT"
+    }
+  },
+  "uuid" : "1fed5a96-2489-47b0-b830-f05d1b2bd54c",
+  "persistent" : true,
+  "insertionIndex" : 870
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withbypass_succeeds-put-6.json
@@ -1,0 +1,32 @@
+{
+  "id" : "f1692e06-d388-46a6-b832-eb908b84c586",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_shorten_withBypass_succeeds-PUT-6",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/gov-shorten-bypass",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9nb3Ytc2hvcnRlbi1ieXBhc3M="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYm5eE1.WC1fQZIiA0NjY5OThiMTA0ODg0ODQ1YmQ0MGJhMmZmZmNlZTU3Ng--",
+      "x-oss-request-id" : "6A221D07A4C9F93436EAA68D",
+      "x-oss-server-time" : "38",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "12334741772964116022",
+      "ETag" : "\"F4EC33C5495A94D4E19658B957CF308D\"",
+      "Date" : "Fri, 05 Jun 2026 00:49:11 GMT",
+      "Content-MD5" : "9OwzxUlalNThlli5V88wjQ=="
+    }
+  },
+  "uuid" : "f1692e06-d388-46a6-b832-eb908b84c586",
+  "persistent" : true,
+  "insertionIndex" : 871
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "3c34434f-993f-4666-90ee-c602eedd6492",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/gov-shorten-no-bypass",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYyrCHoMOD1fQZIiA1ZWRkNzNlODNiYzc0OGUyYmNkMjUzNTVhZTVlNjk0NA--",
+      "x-oss-request-id" : "6A221D1F06B2B23936EC2072",
+      "x-oss-server-time" : "19",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:49:35 GMT"
+    }
+  },
+  "uuid" : "3c34434f-993f-4666-90ee-c602eedd6492",
+  "persistent" : true,
+  "insertionIndex" : 892
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-get-1.json
@@ -1,0 +1,38 @@
+{
+  "id" : "f035c383-f5ea-4851-a9dc-31bc54763b64",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-GET-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/gov-shorten-no-bypass",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>GOVERNANCE</Mode>\n  <RetainUntilDate>2030-06-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY4sanurmD1fQZIiA1MjliZWViMjc3ZWM0ZTkzYjA3ZTkxZWNmMjk3M2M3Yw--",
+      "x-oss-request-id" : "6A221D1E6BF28E3135D9007E",
+      "x-oss-server-time" : "23",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:49:34 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "f035c383-f5ea-4851-a9dc-31bc54763b64",
+  "persistent" : true,
+  "insertionIndex" : 893
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-put-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-put-2.json
@@ -1,0 +1,44 @@
+{
+  "id" : "a21dde4c-6b1a-4f90-bafd-dc4f22183ca6",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-PUT-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/gov-shorten-no-bypass",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQjAkY4sanurmD1fQZIiA1MjliZWViMjc3ZWM0ZTkzYjA3ZTkxZWNmMjk3M2M3Yw--"
+        } ]
+      },
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>GOVERNANCE</Mode><RetainUntilDate>2030-06-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY4sanurmD1fQZIiA1MjliZWViMjc3ZWM0ZTkzYjA3ZTkxZWNmMjk3M2M3Yw--",
+      "x-oss-request-id" : "6A221D1D1FE7723935A15166",
+      "x-oss-server-time" : "16",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:49:33 GMT"
+    }
+  },
+  "uuid" : "a21dde4c-6b1a-4f90-bafd-dc4f22183ca6",
+  "persistent" : true,
+  "insertionIndex" : 894
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-put-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_governance_shorten_withoutbypass_throws-put-3.json
@@ -1,0 +1,32 @@
+{
+  "id" : "1a32a4de-867d-4f2f-8b4f-326a2b0a9caa",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_governance_shorten_withoutBypass_throws-PUT-3",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/gov-shorten-no-bypass",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9nb3Ytc2hvcnRlbi1uby1ieXBhc3M="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY4sanurmD1fQZIiA1MjliZWViMjc3ZWM0ZTkzYjA3ZTkxZWNmMjk3M2M3Yw--",
+      "x-oss-request-id" : "6A221D1DB6DF4E30356082F2",
+      "x-oss-server-time" : "47",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "11954709290918612562",
+      "ETag" : "\"E5F3CEEE6CCCDA95688019B1BD67CB85\"",
+      "Date" : "Fri, 05 Jun 2026 00:49:33 GMT",
+      "Content-MD5" : "5fPO7mzM2pVogBmxvWfLhQ=="
+    }
+  },
+  "uuid" : "1a32a4de-867d-4f2f-8b4f-326a2b0a9caa",
+  "persistent" : true,
+  "insertionIndex" : 895
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "9be585d6-bb7c-4d3b-b301-a0c79163b806",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY3bvLzeyF1fQZIiAxZTliZGUzZTNmOWQ0YmFiOGVjYWE3NGVlODBmNTQ4Mw--",
+      "x-oss-request-id" : "6A221D6B3A503C3132510BDA",
+      "x-oss-server-time" : "19",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:50:51 GMT"
+    }
+  },
+  "uuid" : "9be585d6-bb7c-4d3b-b301-a0c79163b806",
+  "persistent" : true,
+  "insertionIndex" : 989
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-2.json
@@ -1,0 +1,38 @@
+{
+  "id" : "df332749-8406-484a-ae54-f21b40e4473c",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legalHold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<LegalHold>\n  <Status>ON</Status>\n</LegalHold>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYo6vyi9GF1fQZIiA3Y2E4YzhiMDZjYjU0OGIxOGJhNGZmMmIxZGE1NmFlMw--",
+      "x-oss-request-id" : "6A221D693A503C3437D3FFD9",
+      "x-oss-server-time" : "6",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:50:49 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "df332749-8406-484a-ae54-f21b40e4473c",
+  "persistent" : true,
+  "insertionIndex" : 991
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-3.json
@@ -1,0 +1,40 @@
+{
+  "id" : "9757ae22-d130-410c-9083-d7a72adff773",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>GOVERNANCE</Mode>\n  <RetainUntilDate>2030-06-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYo6vyi9GF1fQZIiA3Y2E4YzhiMDZjYjU0OGIxOGJhNGZmMmIxZGE1NmFlMw--",
+      "x-oss-request-id" : "6A221D69A8BE26393443B2C9",
+      "x-oss-server-time" : "15",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:50:49 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "9757ae22-d130-410c-9083-d7a72adff773",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-objectlock-update-legalhold-preserved",
+  "requiredScenarioState" : "scenario-1-conformance-tests-objectlock-update-legalhold-preserved-2",
+  "insertionIndex" : 992
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-get-5.json
@@ -1,0 +1,41 @@
+{
+  "id" : "502b44f9-2e9e-46a2-9983-16c1a9707c7d",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-GET-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>GOVERNANCE</Mode>\n  <RetainUntilDate>2030-01-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYo6vyi9GF1fQZIiA3Y2E4YzhiMDZjYjU0OGIxOGJhNGZmMmIxZGE1NmFlMw--",
+      "x-oss-request-id" : "6A221D67F5C7C4393110CB79",
+      "x-oss-server-time" : "6",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:50:47 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "502b44f9-2e9e-46a2-9983-16c1a9707c7d",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-objectlock-update-legalhold-preserved",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-conformance-tests-objectlock-update-legalhold-preserved-2",
+  "insertionIndex" : 994
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-1.json
@@ -1,0 +1,39 @@
+{
+  "id" : "42d76c0b-1094-4ea1-8c0f-8aa14ec9f03a",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-PUT-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legalHold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<LegalHold><Status>OFF</Status></LegalHold>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYo6vyi9GF1fQZIiA3Y2E4YzhiMDZjYjU0OGIxOGJhNGZmMmIxZGE1NmFlMw--",
+      "x-oss-request-id" : "6A221D6A7FD7C236392BFDDC",
+      "x-oss-server-time" : "16",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:50:50 GMT"
+    }
+  },
+  "uuid" : "42d76c0b-1094-4ea1-8c0f-8aa14ec9f03a",
+  "persistent" : true,
+  "insertionIndex" : 990
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-4.json
@@ -1,0 +1,39 @@
+{
+  "id" : "1603d859-9ae0-47ab-ab70-83deddf4ffce",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-PUT-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>GOVERNANCE</Mode><RetainUntilDate>2030-06-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYo6vyi9GF1fQZIiA3Y2E4YzhiMDZjYjU0OGIxOGJhNGZmMmIxZGE1NmFlMw--",
+      "x-oss-request-id" : "6A221D6875B8B63931D74BC3",
+      "x-oss-server-time" : "8",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:50:48 GMT"
+    }
+  },
+  "uuid" : "1603d859-9ae0-47ab-ab70-83deddf4ffce",
+  "persistent" : true,
+  "insertionIndex" : 993
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-6.json
@@ -1,0 +1,44 @@
+{
+  "id" : "75388baf-9054-410d-856d-7d67ecce25ea",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-PUT-6",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQjAkYo6vyi9GF1fQZIiA3Y2E4YzhiMDZjYjU0OGIxOGJhNGZmMmIxZGE1NmFlMw--"
+        } ]
+      },
+      "legalHold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<LegalHold><Status>ON</Status></LegalHold>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYo6vyi9GF1fQZIiA3Y2E4YzhiMDZjYjU0OGIxOGJhNGZmMmIxZGE1NmFlMw--",
+      "x-oss-request-id" : "6A221D66D71A0E3735EADDFF",
+      "x-oss-server-time" : "26",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:50:46 GMT"
+    }
+  },
+  "uuid" : "75388baf-9054-410d-856d-7d67ecce25ea",
+  "persistent" : true,
+  "insertionIndex" : 995
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-7.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-7.json
@@ -1,0 +1,44 @@
+{
+  "id" : "ea44bb8d-9ae8-4bcc-98d8-722e827b3ef7",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-PUT-7",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQjAkYo6vyi9GF1fQZIiA3Y2E4YzhiMDZjYjU0OGIxOGJhNGZmMmIxZGE1NmFlMw--"
+        } ]
+      },
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>GOVERNANCE</Mode><RetainUntilDate>2030-01-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYo6vyi9GF1fQZIiA3Y2E4YzhiMDZjYjU0OGIxOGJhNGZmMmIxZGE1NmFlMw--",
+      "x-oss-request-id" : "6A221D65279F713934F5320B",
+      "x-oss-server-time" : "34",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:50:45 GMT"
+    }
+  },
+  "uuid" : "ea44bb8d-9ae8-4bcc-98d8-722e827b3ef7",
+  "persistent" : true,
+  "insertionIndex" : 996
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-8.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_legalholdpreservedacrossupdate-put-8.json
@@ -1,0 +1,32 @@
+{
+  "id" : "5b530ac2-1445-4cb3-97ba-5a26ea4d8ae1",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_legalHoldPreservedAcrossUpdate-PUT-8",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/legalhold-preserved",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "bGVnYWxob2xkLXByZXNlcnZlZA=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYo6vyi9GF1fQZIiA3Y2E4YzhiMDZjYjU0OGIxOGJhNGZmMmIxZGE1NmFlMw--",
+      "x-oss-request-id" : "6A221D6457D5143835D35280",
+      "x-oss-server-time" : "41",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "8731513130250404289",
+      "ETag" : "\"F30EE07767065C9F9CC31D17BCD69508\"",
+      "Date" : "Fri, 05 Jun 2026 00:50:44 GMT",
+      "Content-MD5" : "8w7gd2cGXJ+cwx0XvNaVCA=="
+    }
+  },
+  "uuid" : "5b530ac2-1445-4cb3-97ba-5a26ea4d8ae1",
+  "persistent" : true,
+  "insertionIndex" : 997
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "4fec5240-bb06-4c45-906d-90a319807b90",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/mode-downgrade",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY.bW678L71PQZIiA5OTU4ZjFkMzA5YTE0ODQxOTViZWFkMDE5MzA2ODkyZg--",
+      "x-oss-request-id" : "6A221C193870173737C6BBC0",
+      "x-oss-server-time" : "67",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:45:13 GMT"
+    }
+  },
+  "uuid" : "4fec5240-bb06-4c45-906d-90a319807b90",
+  "persistent" : true,
+  "insertionIndex" : 587
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-get-1.json
@@ -1,0 +1,38 @@
+{
+  "id" : "bf5e7b2e-8c3c-41c8-8797-87c3009dc9a6",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-GET-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/mode-downgrade",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>COMPLIANCE</Mode>\n  <RetainUntilDate>2030-01-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY6NeigLn71PQZIiBhNDhhMTJkZDI1MWU0ZjNjOTFkMjE3OTBjOTgxYTY1Mw--",
+      "x-oss-request-id" : "6A221C183E95CC36395AF198",
+      "x-oss-server-time" : "35",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:45:12 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "bf5e7b2e-8c3c-41c8-8797-87c3009dc9a6",
+  "persistent" : true,
+  "insertionIndex" : 588
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-put-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-put-2.json
@@ -1,0 +1,44 @@
+{
+  "id" : "47997429-bedb-4202-9882-5f676e0e16e2",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-PUT-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/mode-downgrade",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQjAkY6NeigLn71PQZIiBhNDhhMTJkZDI1MWU0ZjNjOTFkMjE3OTBjOTgxYTY1Mw--"
+        } ]
+      },
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>COMPLIANCE</Mode><RetainUntilDate>2030-01-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY6NeigLn71PQZIiBhNDhhMTJkZDI1MWU0ZjNjOTFkMjE3OTBjOTgxYTY1Mw--",
+      "x-oss-request-id" : "6A221C17D056AC3938EA4D2F",
+      "x-oss-server-time" : "27",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:45:11 GMT"
+    }
+  },
+  "uuid" : "47997429-bedb-4202-9882-5f676e0e16e2",
+  "persistent" : true,
+  "insertionIndex" : 589
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-put-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modedowngrade_compliancetogovernance_throws-put-3.json
@@ -1,0 +1,32 @@
+{
+  "id" : "d31ecab1-37d0-474a-99c0-e499a5835704",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_modeDowngrade_complianceToGovernance_throws-PUT-3",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/mode-downgrade",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9tb2RlLWRvd25ncmFkZQ=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY6NeigLn71PQZIiBhNDhhMTJkZDI1MWU0ZjNjOTFkMjE3OTBjOTgxYTY1Mw--",
+      "x-oss-request-id" : "6A221C16DC97B332347F1CB4",
+      "x-oss-server-time" : "68",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "17769024574023487473",
+      "ETag" : "\"3BCDA782607F16C89F0C4D3BD549A6D0\"",
+      "Date" : "Fri, 05 Jun 2026 00:45:10 GMT",
+      "Content-MD5" : "O82ngmB/FsifDE071Umm0A=="
+    }
+  },
+  "uuid" : "d31ecab1-37d0-474a-99c0-e499a5835704",
+  "persistent" : true,
+  "insertionIndex" : 590
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "3b0a119c-61ec-4208-9546-df90ed768c8a",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/mode-upgrade-no-bypass",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkY_8aim_iG1fQZIiA5Y2UzYmFmMWE5MWY0OTE2YWJhMzdiN2E1YTJiODgxYw--",
+      "x-oss-request-id" : "6A221D8FF40CB63036F435C1",
+      "x-oss-server-time" : "40",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:51:27 GMT"
+    }
+  },
+  "uuid" : "3b0a119c-61ec-4208-9546-df90ed768c8a",
+  "persistent" : true,
+  "insertionIndex" : 1042
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-get-1.json
@@ -1,0 +1,38 @@
+{
+  "id" : "01ec2cd7-bec3-4a1c-9d9f-5cb4ad46132c",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-GET-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/mode-upgrade-no-bypass",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>GOVERNANCE</Mode>\n  <RetainUntilDate>2030-01-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYypyPkOuG1fQZIiA2ZThiOGM4MzZhZjU0ODExODBmZTIwMDcwYTAyNWE1OQ--",
+      "x-oss-request-id" : "6A221D8DD056AC3531B29039",
+      "x-oss-server-time" : "28",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:51:25 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "01ec2cd7-bec3-4a1c-9d9f-5cb4ad46132c",
+  "persistent" : true,
+  "insertionIndex" : 1043
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-put-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-put-2.json
@@ -1,0 +1,44 @@
+{
+  "id" : "d3f1f5fc-7584-49a1-b795-4386ddad7a71",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-PUT-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/mode-upgrade-no-bypass",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQjAkYypyPkOuG1fQZIiA2ZThiOGM4MzZhZjU0ODExODBmZTIwMDcwYTAyNWE1OQ--"
+        } ]
+      },
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>GOVERNANCE</Mode><RetainUntilDate>2030-01-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYypyPkOuG1fQZIiA2ZThiOGM4MzZhZjU0ODExODBmZTIwMDcwYTAyNWE1OQ--",
+      "x-oss-request-id" : "6A221D8C85ECD63234F67AEE",
+      "x-oss-server-time" : "25",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:51:24 GMT"
+    }
+  },
+  "uuid" : "d3f1f5fc-7584-49a1-b795-4386ddad7a71",
+  "persistent" : true,
+  "insertionIndex" : 1044
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-put-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_modeupgrade_governancetocompliance_withoutbypass_throws-put-3.json
@@ -1,0 +1,32 @@
+{
+  "id" : "b757c70b-b4ba-4120-9195-c78b02bc924b",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withoutBypass_throws-PUT-3",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/mode-upgrade-no-bypass",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "cmV0ZW50aW9uLXVwZGF0ZS1jb25mb3JtYW5jZS10ZXN0cy9vYmplY3Rsb2NrL3VwZGF0ZS9tb2RlLXVwZ3JhZGUtbm8tYnlwYXNz"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYypyPkOuG1fQZIiA2ZThiOGM4MzZhZjU0ODExODBmZTIwMDcwYTAyNWE1OQ--",
+      "x-oss-request-id" : "6A221D8C78C4B533395D2F72",
+      "x-oss-server-time" : "18",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "4400770372990269271",
+      "ETag" : "\"857EB5CCA76700FE8C964E09C1B481AA\"",
+      "Date" : "Fri, 05 Jun 2026 00:51:24 GMT",
+      "Content-MD5" : "hX61zKdnAP6Mlk4JwbSBqg=="
+    }
+  },
+  "uuid" : "b757c70b-b4ba-4120-9195-c78b02bc924b",
+  "persistent" : true,
+  "insertionIndex" : 1045
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_nocurrentretention_throws-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_nocurrentretention_throws-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "893515f4-85f0-4753-bf42-2a15e2407524",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/no-current-retention",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYrvifntWB1fQZIiBmMDgwMWE3YWZmZjU0NjNkOTQ5OGQwOWI3NTNkOGIwNA--",
+      "x-oss-request-id" : "6A221CE226AA8C3032985F47",
+      "x-oss-server-time" : "23",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Fri, 05 Jun 2026 00:48:34 GMT"
+    }
+  },
+  "uuid" : "893515f4-85f0-4753-bf42-2a15e2407524",
+  "persistent" : true,
+  "insertionIndex" : 812
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_nocurrentretention_throws-get-1.json
@@ -1,0 +1,37 @@
+{
+  "id" : "d2114aba-a0de-4824-8177-55653b52926e",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-GET-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/objectlock/update/no-current-retention",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchObjectRetentionConfiguration</Code>\n  <Message>The specified object does not have an object retention configuration.</Message>\n  <RequestId>6A221CE15C5E113837CD4084</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <ObjectName>conformance-tests/objectlock/update/no-current-retention</ObjectName>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A221CE15C5E113837CD4084",
+      "x-oss-server-time" : "5",
+      "Server" : "AliyunOSS",
+      "Date" : "Fri, 05 Jun 2026 00:48:33 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "d2114aba-a0de-4824-8177-55653b52926e",
+  "persistent" : true,
+  "insertionIndex" : 813
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_nocurrentretention_throws-put-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testupdateobjectretention_nocurrentretention_throws-put-2.json
@@ -1,0 +1,32 @@
+{
+  "id" : "30a47e88-6fbe-460b-b394-2059eb28c9b8",
+  "name" : "AliBlobStoreIT_testUpdateObjectRetention_noCurrentRetention_throws-PUT-2",
+  "request" : {
+    "url" : "/conformance-tests/objectlock/update/no-current-retention",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "bm8tcmV0ZW50aW9u"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQjAkYzKLWxM6B1fQZIiA0Y2UxYTZkZjc3OTY0ZGI5YWVhODdlNWNjM2QyYmQ0Mw--",
+      "x-oss-request-id" : "6A221CE076ADAE3634DA5F72",
+      "x-oss-server-time" : "66",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "4410973210453914582",
+      "ETag" : "\"BFE1089CB37491A8A0F7E52B9F03B4AB\"",
+      "Date" : "Fri, 05 Jun 2026 00:48:32 GMT",
+      "Content-MD5" : "v+EInLN0kaig9+UrnwO0qw=="
+    }
+  },
+  "uuid" : "30a47e88-6fbe-460b-b394-2059eb28c9b8",
+  "persistent" : true,
+  "insertionIndex" : 814
+}

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -2640,6 +2640,9 @@ public abstract class AbstractBlobStoreIT {
   public void testGetObjectLock_afterUploadWithRetentionCompliance() throws IOException {
     Assumptions.assumeTrue(
         harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    // Ali: OBJECT_LOCK_RETAIN_UNTIL_COMPLIANCE constant is in the past; OSS rejects it in
+    // record mode. Requires cross-provider fix to the stale constant + re-recording all stubs.
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
 
     String key = "conformance-tests/objectlock/retention-compliance";
     byte[] content = "Object lock retention compliance test".getBytes(StandardCharsets.UTF_8);
@@ -2881,6 +2884,9 @@ public abstract class AbstractBlobStoreIT {
     // mirrors that and rejects upgrade without bypass.
     Assumptions.assumeTrue(
         harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    // OSS rejects mode upgrade (GOVERNANCE→COMPLIANCE) with 409 FileImmutable even with
+    // bypass — OSS does not support changing retention mode once set on an object version.
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String key = "conformance-tests/objectlock/update/mode-upgrade";
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
     BucketClient bucketClient = new BucketClient(blobStore);
@@ -5333,6 +5339,10 @@ public abstract class AbstractBlobStoreIT {
   public void testMultipartUpload_withObjectLock() {
     Assumptions.assumeTrue(
         harness.isObjectLockSupported(), "Object lock not supported by this provider");
+    // Ali: WireMock cannot replay 5MB multipart part bodies (body regex matching fails on large
+    // binary payloads). This is a WireMock harness limitation, not an object lock issue —
+    // the test passes in record mode against live OSS.
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
 
     String expectedKey = DEFAULT_MULTIPART_KEY_PREFIX + "withObjectLock";
     // Keep retainUntil in the future so record mode remains valid over time.


### PR DESCRIPTION
## Summary

Add blobstore support on object lock/retention for Ali with unit tests.

One note regarding the implementation - OSS does not support retention mode upgrade as it is set on an object version and considers it immutable, any attempt to change mode (regardless of bypass) returns a 409 FileImmutable.

Enabled existing conformance tests except the following:
- testGetObjectLock_afterUploadWithRetentionCompliance: stale date constant (cross-provider)
- testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds: OSS platform limitation (409 FileImmutable)
- testMultipartUpload_withObjectLock: WireMock body matching fails on 5MB parts

The above conformance tests are failing due to the reason provided. They will be addressed in subsequent PRs.

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
