### PR TITLE
blobstore: add transfer status logging for Ali OSS async directory ops

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -189,13 +189,48 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
 
   private CompletableFuture<UploadResponse> doUploadInternal(
       UploadRequest uploadRequest, BinaryData body) {
+    return doUploadInternal(uploadRequest, body, null);
+  }
+
+  /**
+   * Shared upload path. When {@code listener} is non-null (directory uploads only), it is attached
+   * to the {@link PutObjectRequest} so the OSS SDK drives {@code onProgress}/{@code onFinish} as
+   * the upload stream is consumed. When null (all single-file uploads), the request is built
+   * exactly as before and no progress instrumentation is attached — single-file behavior is
+   * unchanged.
+   */
+  private CompletableFuture<UploadResponse> doUploadInternal(
+      UploadRequest uploadRequest, BinaryData body,
+      OssLoggingTransferListener listener) {
     PutObjectRequest request =
         transformer.toPutObjectRequest(uploadRequest, body);
+    if (listener != null) {
+      request = request.toBuilder().progressListener(listener).build();
+    }
     return asyncClient
         .putObjectAsync(request, OperationOptions.defaults())
         .thenApply(
             result ->
                 transformer.toUploadResponse(uploadRequest, result));
+  }
+
+  /**
+   * Directory-upload variant of the path-based upload that threads a progress listener through to
+   * the shared upload path. Mirrors {@link #doUpload(UploadRequest, File)}'s {@link BinaryData}
+   * construction but attaches the per-file listener so byte accounting and (gated) logging run.
+   * Used only by {@link #doUploadDirectory}; single-file uploads never pass a listener.
+   */
+  private CompletableFuture<UploadResponse> doUploadFromPath(
+      UploadRequest uploadRequest, Path path, OssLoggingTransferListener listener) {
+    try {
+      BinaryData body = BinaryData.fromStream(
+          Files.newInputStream(path), Files.size(path));
+      return doUploadInternal(uploadRequest, body, listener);
+    } catch (IOException e) {
+      return CompletableFuture.failedFuture(
+          new SubstrateSdkException(
+              "Failed to read file for upload: " + path, e));
+    }
   }
 
   @Override
@@ -307,6 +342,54 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
       }
     } catch (IOException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Directory-download variant that streams the object body to {@code destinationPath}. When
+   * {@code listener} is non-null (transfer status logging enabled), it is driven from our own copy
+   * loop — the OSS SDK does not invoke {@code ProgressListener} on the download path, so, exactly
+   * as the SDK's own {@code transfermanager.Downloader} does, this loop counts bytes per buffer and
+   * calls {@code onProgress}/{@code onFinish} itself. When null (logging disabled, mirroring AWS
+   * which attaches no listener), no instrumentation runs. Used only by
+   * {@link #doDownloadDirectory}; single-file downloads keep their existing behavior.
+   */
+  private CompletableFuture<DownloadResponse> doDownloadToPath(
+      DownloadRequest request, Path destinationPath,
+      OssLoggingTransferListener listener) {
+    return doDownloadInternal(request).thenApply(result -> {
+      try (InputStream body = result.body();
+          OutputStream out = Files.newOutputStream(destinationPath)) {
+        copyStreamWithListener(body, out, listener);
+        if (listener != null) {
+          listener.onFinish();
+        }
+        return transformer.toDownloadResponse(request.getKey(), result);
+      } catch (IOException e) {
+        throw new SubstrateSdkException(
+            "Failed to download blob: " + request.getKey(), e);
+      }
+    });
+  }
+
+  private void copyStreamWithListener(
+      InputStream in, OutputStream out, OssLoggingTransferListener listener) {
+    try {
+      byte[] buffer = new byte[8192];
+      int bytesRead;
+      long cumulative = 0L;
+      while ((bytesRead = in.read(buffer)) != -1) {
+        out.write(buffer, 0, bytesRead);
+        cumulative += bytesRead;
+        if (listener != null) {
+          listener.onProgress(bytesRead, cumulative, -1L);
+        }
+      }
+    } catch (IOException e) {
+      // Throw SubstrateSdkException (not a raw RuntimeException) so the failure surfaces
+      // consistently with the rest of the driver instead of as a CompletionException
+      // wrapping an opaque RuntimeException.
+      throw new SubstrateSdkException("Stream copy failed during download", e);
     }
   }
 
@@ -587,7 +670,11 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
             }
           }
 
-          // Fan out per-file downloads.
+          // Fan out per-file downloads. When transfer status logging is enabled, a per-file
+          // listener shares the directory-scoped totalBytes counter and drives byte accounting
+          // and logging. When disabled, no listener is attached (mirrors AWS) — null.
+          boolean loggingEnabled =
+              directoryDownloadRequest.isTransferStatusLoggingEnabled();
           List<CompletableFuture<Void>> futures = blobInfos.stream()
               .map(blob -> {
                 String key = blob.getKey();
@@ -598,14 +685,19 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
                 DownloadRequest downloadRequest = DownloadRequest.builder()
                     .withKey(key)
                     .build();
-                return doDownload(downloadRequest, destination)
+                OssLoggingTransferListener listener = loggingEnabled
+                    ? OssLoggingTransferListener.create(
+                        OssLoggingTransferListener.Direction.DOWNLOAD,
+                        key, totalBytes, true)
+                    : null;
+                return doDownloadToPath(downloadRequest, destination, listener)
                     .thenAccept(response -> {
-                      if (directoryDownloadRequest
-                          .isTransferStatusLoggingEnabled()) {
-                        totalBytes.addAndGet(blob.getObjectSize());
-                      }
+                      // onFinish() is invoked inside doDownloadToPath's copy loop.
                     })
                     .exceptionally(ex -> {
+                      if (listener != null) {
+                        listener.transferFailed(ex);
+                      }
                       failures.add(FailedBlobDownload.builder()
                           .destination(destination)
                           .exception(ex)
@@ -670,6 +762,11 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
           if (fileSizes.isEmpty()) {
             return CompletableFuture.completedFuture(null);
           }
+          // When transfer status logging is enabled, a per-file listener shares the
+          // directory-scoped totalBytes counter; the OSS SDK drives it as the put stream is
+          // consumed. When disabled, no listener is attached (mirrors AWS) — null.
+          boolean loggingEnabled =
+              directoryUploadRequest.isTransferStatusLoggingEnabled();
           List<CompletableFuture<Void>> futures = fileSizes.entrySet().stream()
               .map(entry -> {
                 Path filePath = entry.getKey();
@@ -685,14 +782,21 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
                   uploadBuilder.withObjectLock(objectLock);
                 }
                 UploadRequest uploadRequest = uploadBuilder.build();
-                return doUpload(uploadRequest, filePath)
+                OssLoggingTransferListener listener = loggingEnabled
+                    ? OssLoggingTransferListener.create(
+                        OssLoggingTransferListener.Direction.UPLOAD,
+                        key, totalBytes, true)
+                    : null;
+                return doUploadFromPath(uploadRequest, filePath, listener)
                     .thenAccept(response -> {
-                      if (directoryUploadRequest
-                          .isTransferStatusLoggingEnabled()) {
-                        totalBytes.addAndGet(fileSize);
-                      }
+                      // For uploads the OSS SDK is the sole driver of onProgress/onFinish as it
+                      // consumes the put stream (mirrors how downloads are self-driven by our
+                      // copy loop). Driving onFinish() here too would double-log completion.
                     })
                     .exceptionally(ex -> {
+                      if (listener != null) {
+                        listener.transferFailed(ex);
+                      }
                       failures.add(FailedBlobUpload.builder()
                           .source(filePath)
                           .exception(ex)

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/OssLoggingTransferListener.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/OssLoggingTransferListener.java
@@ -1,0 +1,112 @@
+package com.salesforce.multicloudj.blob.ali.async;
+
+import com.aliyun.sdk.service.oss2.progress.ProgressListener;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Per-file transfer progress listener for Ali OSS async directory operations.
+ *
+ * <p>Implements the OSS v2 SDK's {@link ProgressListener}. For uploads, the SDK drives
+ * {@code onProgress}/{@code onFinish} directly (a {@code ProgressObserver} is wired into the
+ * upload stream). For downloads the SDK does not drive the listener, so the directory download
+ * copy loop invokes {@code onProgress}/{@code onFinish} itself — the same idiom the SDK's own
+ * {@code transfermanager.Downloader} uses internally.
+ *
+ * <p>The {@code onProgress} arguments follow the SDK convention
+ * {@code onProgress(increment, cumulativeTransferred, total)}; this listener accumulates the
+ * per-call {@code increment} into a directory-scoped shared {@link AtomicLong} so the running
+ * total spans every file in the operation.
+ *
+ * <p>Byte accumulation into the shared counter is always performed (cheap, drives the response's
+ * {@code totalBytesTransferred}). Log emission is gated on {@code loggingEnabled}, which is set
+ * from the request's {@code transferStatusLoggingEnabled} flag.
+ */
+final class OssLoggingTransferListener implements ProgressListener {
+
+  private static final Logger DEFAULT_LOGGER =
+      LoggerFactory.getLogger(OssLoggingTransferListener.class);
+
+  /** Transfer direction, used only for log context. */
+  enum Direction {
+    UPLOAD,
+    DOWNLOAD
+  }
+
+  private final Logger logger;
+  private final Direction direction;
+  private final String key;
+  private final AtomicLong cumulativeTotal;
+  private final boolean loggingEnabled;
+  private final Instant startTime;
+  // Per-file byte count for this listener instance, distinct from the directory-wide
+  // cumulativeTotal. Single-writer per instance (downloads: our copy loop; uploads: the
+  // SDK's per-stream observer), so a plain long is sufficient.
+  private long bytesThisFile;
+
+  static OssLoggingTransferListener create(
+      Direction direction, String key, AtomicLong cumulativeTotal, boolean loggingEnabled) {
+    return new OssLoggingTransferListener(
+        DEFAULT_LOGGER, direction, key, cumulativeTotal, loggingEnabled);
+  }
+
+  // Package-private: production constructs via create() with the default logger; the
+  // same-package unit test constructs directly with a logger to verify emission/gating.
+  OssLoggingTransferListener(
+      Logger logger, Direction direction, String key,
+      AtomicLong cumulativeTotal, boolean loggingEnabled) {
+    this.logger = logger;
+    this.direction = direction;
+    this.key = key;
+    this.cumulativeTotal = cumulativeTotal;
+    this.loggingEnabled = loggingEnabled;
+    // Instant.now() is timezone-agnostic; used only for elapsed-duration calculation.
+    this.startTime = Instant.now();
+    if (loggingEnabled) {
+      logger.debug(
+          "substrate SDK transferListener: direction={}, key={}. transfer initiated.",
+          direction, key);
+    }
+  }
+
+  @Override
+  public void onProgress(long increment, long transferred, long total) {
+    bytesThisFile += increment;
+    cumulativeTotal.addAndGet(increment);
+    if (loggingEnabled) {
+      logger.trace(
+          "substrate SDK transferListener: direction={}, key={}, increment={},"
+              + " transferred={}, total={}. bytes transferred.",
+          direction, key, increment, transferred, total);
+    }
+  }
+
+  @Override
+  public void onFinish() {
+    if (loggingEnabled) {
+      Duration elapsed = Duration.between(startTime, Instant.now());
+      logger.info(
+          "substrate SDK transferListener: direction={}, key={}, fileBytes={},"
+              + " directoryCumulativeBytes={}, elapsed={}. transfer complete.",
+          direction, key, bytesThisFile, cumulativeTotal.get(), elapsed);
+    }
+  }
+
+  /**
+   * Records a failed transfer. Mirrors AWS's gated {@code transferFailed}: emitted only when
+   * logging is enabled. The response's {@code failedTransfers} list remains the always-on failure
+   * surface and is populated independently by the directory operation.
+   */
+  void transferFailed(Throwable ex) {
+    if (loggingEnabled) {
+      Duration elapsed = Duration.between(startTime, Instant.now());
+      logger.error(
+          "substrate SDK transferListener: direction={}, key={}, fileBytes={},"
+              + " directoryCumulativeBytes={}, elapsed={}. transfer failed.",
+          direction, key, bytesThisFile, cumulativeTotal.get(), elapsed, ex);
+    }
+  }
+}

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -3,6 +3,7 @@ package com.salesforce.multicloudj.blob.ali.async;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -55,6 +56,7 @@ import com.aliyun.sdk.service.oss2.models.TagSet;
 import com.aliyun.sdk.service.oss2.models.Tagging;
 import com.aliyun.sdk.service.oss2.models.UploadPartRequest;
 import com.aliyun.sdk.service.oss2.models.UploadPartResult;
+import com.aliyun.sdk.service.oss2.progress.ProgressListener;
 import com.aliyun.sdk.service.oss2.transfermanager.DownloadError;
 import com.aliyun.sdk.service.oss2.transfermanager.DownloadResult;
 import com.aliyun.sdk.service.oss2.transfermanager.Downloader;
@@ -1088,6 +1090,88 @@ public class AliAsyncBlobStoreTest {
   }
 
   @Test
+  void testUploadDirectoryWithLoggingCountsSdkReportedBytes(
+      @TempDir Path tempDir) throws Exception {
+    // "alpha" = 5 bytes, "bravo!" = 6 bytes -> expect 11 cumulative.
+    Files.writeString(tempDir.resolve("a.txt"), "alpha");
+    Files.writeString(tempDir.resolve("b.txt"), "bravo!");
+
+    PutObjectResult mockResult = mock(PutObjectResult.class);
+    when(mockResult.versionId()).thenReturn(null);
+    when(mockResult.eTag()).thenReturn("\"etag\"");
+
+    // Simulate the OSS SDK driving the request's ProgressListener: the real
+    // putObjectAsync wires a ProgressObserver into the upload stream that calls
+    // onProgress(increment, transferred, total) as bytes are sent, then onFinish().
+    // Here we read the listener off the captured request and drive it the same way,
+    // reporting the file's byte count in two chunks to exercise accumulation.
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenAnswer(invocation -> {
+          PutObjectRequest req = invocation.getArgument(0);
+          ProgressListener listener = req.progressListener();
+          if (listener != null) {
+            long total = req.body() != null && req.body().getLength() != null
+                ? req.body().getLength() : 0L;
+            // Report in two increments that sum to the full object size.
+            long first = total / 2;
+            long second = total - first;
+            listener.onProgress(first, first, total);
+            listener.onProgress(second, total, total);
+            listener.onFinish();
+          }
+          return CompletableFuture.completedFuture(mockResult);
+        });
+
+    DirectoryUploadRequest request = DirectoryUploadRequest.builder()
+        .localSourceDirectory(tempDir.toString())
+        .prefix("pfx")
+        .includeSubFolders(true)
+        .transferStatusLoggingEnabled(true)
+        .build();
+    DirectoryUploadResponse response =
+        store.uploadDirectory(request).get();
+
+    assertNotNull(response);
+    assertEquals(0, response.getFailedTransfers().size());
+    // Byte total is driven entirely by the SDK-reported onProgress increments,
+    // accumulated into the directory-scoped shared counter across both files.
+    assertEquals(11L, response.getTotalBytesTransferred());
+  }
+
+  @Test
+  void testUploadDirectoryLoggingDisabledReturnsNullTotal(
+      @TempDir Path tempDir) throws Exception {
+    Files.writeString(tempDir.resolve("a.txt"), "alpha");
+
+    PutObjectResult mockResult = mock(PutObjectResult.class);
+    when(mockResult.versionId()).thenReturn(null);
+    when(mockResult.eTag()).thenReturn("\"etag\"");
+    // No listener should be attached when logging is disabled; assert that and
+    // ensure we never drive progress so the counter stays at zero / null.
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenAnswer(invocation -> {
+          PutObjectRequest req = invocation.getArgument(0);
+          assertNull(req.progressListener());
+          return CompletableFuture.completedFuture(mockResult);
+        });
+
+    // transferStatusLoggingEnabled defaults to false.
+    DirectoryUploadRequest request = DirectoryUploadRequest.builder()
+        .localSourceDirectory(tempDir.toString())
+        .prefix("pfx")
+        .includeSubFolders(true)
+        .build();
+    DirectoryUploadResponse response =
+        store.uploadDirectory(request).get();
+
+    assertNotNull(response);
+    assertEquals(0, response.getFailedTransfers().size());
+    assertNull(response.getTotalBytesTransferred());
+  }
+
+  @Test
   void testUploadDirectoryWithSubFolders(@TempDir Path tempDir)
       throws Exception {
     Files.writeString(tempDir.resolve("root.txt"), "root");
@@ -1313,6 +1397,89 @@ public class AliAsyncBlobStoreTest {
     assertNotNull(response);
     assertEquals(0, response.getFailedTransfers().size());
     assertEquals(1024L, response.getTotalBytesTransferred());
+  }
+
+  @Test
+  void testDownloadDirectoryLoggingDisabledReturnsNullTotal(
+      @TempDir Path tempDir) throws Exception {
+    ObjectSummary obj = mock(ObjectSummary.class);
+    when(obj.key()).thenReturn("log/data.bin");
+    when(obj.size()).thenReturn(2048L);
+
+    ListObjectsV2Result listResult = mock(ListObjectsV2Result.class);
+    when(listResult.contents()).thenReturn(List.of(obj));
+    when(listResult.commonPrefixes()).thenReturn(null);
+    when(listResult.isTruncated()).thenReturn(false);
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(listResult));
+
+    byte[] content = new byte[2048];
+    GetObjectResult getResult = mock(GetObjectResult.class);
+    when(getResult.body()).thenReturn(new ByteArrayInputStream(content));
+    when(getResult.contentLength()).thenReturn(2048L);
+    when(getResult.eTag()).thenReturn("\"e\"");
+    when(mockAsyncClient.getObjectAsync(
+        any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(getResult));
+
+    // transferStatusLoggingEnabled defaults to false — no listener attached, null total.
+    DirectoryDownloadRequest request = DirectoryDownloadRequest.builder()
+        .prefixToDownload("log")
+        .localDestinationDirectory(tempDir.toString())
+        .build();
+    DirectoryDownloadResponse response =
+        store.downloadDirectory(request).get();
+
+    assertNotNull(response);
+    assertEquals(0, response.getFailedTransfers().size());
+    assertNull(response.getTotalBytesTransferred());
+    // The file is still downloaded correctly even with no listener.
+    assertTrue(Files.exists(tempDir.resolve("data.bin")));
+  }
+
+  @Test
+  void testDownloadDirectoryWithLoggingAccumulatesAcrossFiles(
+      @TempDir Path tempDir) throws Exception {
+    ObjectSummary obj1 = mock(ObjectSummary.class);
+    when(obj1.key()).thenReturn("data/a.bin");
+    when(obj1.size()).thenReturn(100L);
+    ObjectSummary obj2 = mock(ObjectSummary.class);
+    when(obj2.key()).thenReturn("data/b.bin");
+    when(obj2.size()).thenReturn(200L);
+
+    ListObjectsV2Result listResult = mock(ListObjectsV2Result.class);
+    when(listResult.contents()).thenReturn(List.of(obj1, obj2));
+    when(listResult.commonPrefixes()).thenReturn(null);
+    when(listResult.isTruncated()).thenReturn(false);
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(listResult));
+
+    when(mockAsyncClient.getObjectAsync(
+        any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenAnswer(invocation -> {
+          GetObjectRequest req = invocation.getArgument(0);
+          int size = req.key().endsWith("a.bin") ? 100 : 200;
+          GetObjectResult result = mock(GetObjectResult.class);
+          when(result.body()).thenReturn(new ByteArrayInputStream(new byte[size]));
+          when(result.contentLength()).thenReturn((long) size);
+          when(result.eTag()).thenReturn("\"e\"");
+          return CompletableFuture.completedFuture(result);
+        });
+
+    DirectoryDownloadRequest request = DirectoryDownloadRequest.builder()
+        .prefixToDownload("data")
+        .localDestinationDirectory(tempDir.toString())
+        .transferStatusLoggingEnabled(true)
+        .build();
+    DirectoryDownloadResponse response =
+        store.downloadDirectory(request).get();
+
+    assertNotNull(response);
+    assertEquals(0, response.getFailedTransfers().size());
+    // Shared counter spans both files: 100 + 200, counted via the self-driven copy loop.
+    assertEquals(300L, response.getTotalBytesTransferred());
   }
 
   @Test

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/OssLoggingTransferListenerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/OssLoggingTransferListenerTest.java
@@ -1,0 +1,191 @@
+package com.salesforce.multicloudj.blob.ali.async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.salesforce.multicloudj.blob.ali.async.OssLoggingTransferListener.Direction;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.Logger;
+
+class OssLoggingTransferListenerTest {
+
+  @Test
+  void onProgressAccumulatesIncrementIntoSharedCounter() {
+    AtomicLong cumulative = new AtomicLong(0L);
+    OssLoggingTransferListener listener =
+        OssLoggingTransferListener.create(Direction.UPLOAD, "key1", cumulative, true);
+
+    // onProgress(increment, cumulativeWritten, total) — the listener accumulates arg1.
+    listener.onProgress(100L, 100L, 500L);
+    listener.onProgress(150L, 250L, 500L);
+
+    assertEquals(250L, cumulative.get());
+  }
+
+  @Test
+  void onProgressAccumulatesEvenWhenLoggingDisabled() {
+    // Byte accounting must always run so totalBytesTransferred is populated
+    // regardless of the transferStatusLoggingEnabled flag.
+    AtomicLong cumulative = new AtomicLong(0L);
+    OssLoggingTransferListener listener =
+        OssLoggingTransferListener.create(Direction.DOWNLOAD, "key2", cumulative, false);
+
+    listener.onProgress(1024L, 1024L, 1024L);
+    listener.onFinish();
+
+    assertEquals(1024L, cumulative.get());
+  }
+
+  @Test
+  void transferFailedDoesNotAlterCounter() {
+    AtomicLong cumulative = new AtomicLong(42L);
+    OssLoggingTransferListener listener =
+        OssLoggingTransferListener.create(Direction.UPLOAD, "key3", cumulative, true);
+
+    listener.transferFailed(new RuntimeException("boom"));
+
+    assertEquals(42L, cumulative.get());
+  }
+
+  @Test
+  void multipleListenersShareTheSameDirectoryScopedCounter() {
+    // Mirrors AWS's shared totalBytesTransferred across all files in a directory op.
+    AtomicLong cumulative = new AtomicLong(0L);
+    OssLoggingTransferListener fileA =
+        OssLoggingTransferListener.create(Direction.UPLOAD, "a.txt", cumulative, true);
+    OssLoggingTransferListener fileB =
+        OssLoggingTransferListener.create(Direction.UPLOAD, "b.txt", cumulative, true);
+
+    fileA.onProgress(300L, 300L, 300L);
+    fileB.onProgress(700L, 700L, 700L);
+
+    assertEquals(1000L, cumulative.get());
+  }
+
+  @Test
+  void concurrentOnProgressAccumulatesAtomically() throws Exception {
+    AtomicLong cumulative = new AtomicLong(0L);
+    int threads = 16;
+    int incrementsPerThread = 1000;
+    long incrementSize = 8L;
+
+    List<CompletableFuture<Void>> futures = IntStream.range(0, threads)
+        .mapToObj(t -> CompletableFuture.runAsync(() -> {
+          OssLoggingTransferListener listener = OssLoggingTransferListener.create(
+              Direction.DOWNLOAD, "key-" + t, cumulative, false);
+          for (int i = 0; i < incrementsPerThread; i++) {
+            listener.onProgress(incrementSize, incrementSize * (i + 1), 0L);
+          }
+        }))
+        .collect(Collectors.toList());
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+
+    assertEquals((long) threads * incrementsPerThread * incrementSize, cumulative.get());
+  }
+
+  @Test
+  void onFinishIsSafeToCallWithoutPriorProgress() {
+    AtomicLong cumulative = new AtomicLong(0L);
+    OssLoggingTransferListener listener =
+        OssLoggingTransferListener.create(Direction.DOWNLOAD, "empty", cumulative, true);
+
+    // Should not throw and should leave the counter untouched.
+    listener.onFinish();
+
+    assertEquals(0L, cumulative.get());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Logging emission / gating (logger injected via the package-private constructor)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void loggingEnabledEmitsExpectedLevelsPerLifecycleEvent() {
+    Logger logger = mock(Logger.class);
+    AtomicLong cumulative = new AtomicLong(0L);
+
+    // Construction with logging enabled emits the "transfer initiated" DEBUG line.
+    OssLoggingTransferListener listener = new OssLoggingTransferListener(
+        logger, Direction.UPLOAD, "key", cumulative, true);
+    verify(logger).debug(anyString(), any(), any());
+
+    // onProgress -> TRACE (direction, key, increment, transferred, total)
+    listener.onProgress(100L, 100L, 200L);
+    verify(logger).trace(anyString(), any(), any(), any(), any(), any());
+
+    // onFinish -> INFO (direction, key, fileBytes, directoryCumulativeBytes, elapsed)
+    listener.onFinish();
+    verify(logger).info(anyString(), any(), any(), any(), any(), any());
+
+    // transferFailed -> ERROR (direction, key, fileBytes, directoryCumulativeBytes, elapsed, ex)
+    RuntimeException ex = new RuntimeException("boom");
+    listener.transferFailed(ex);
+    verify(logger).error(anyString(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void loggingDisabledNeverTouchesLogger() {
+    Logger logger = mock(Logger.class);
+    AtomicLong cumulative = new AtomicLong(0L);
+
+    OssLoggingTransferListener listener = new OssLoggingTransferListener(
+        logger, Direction.DOWNLOAD, "key", cumulative, false);
+    listener.onProgress(100L, 100L, 200L);
+    listener.onFinish();
+    listener.transferFailed(new RuntimeException("boom"));
+
+    // No log line at any level when the flag is off — but byte accounting still ran.
+    verifyNoInteractions(logger);
+    assertEquals(100L, cumulative.get());
+  }
+
+  @Test
+  void loggingDisabledStillAccumulatesButDebugInitiatedSuppressed() {
+    Logger logger = mock(Logger.class);
+    AtomicLong cumulative = new AtomicLong(0L);
+
+    // Construction with logging disabled must NOT emit the initiated DEBUG line.
+    new OssLoggingTransferListener(
+        logger, Direction.UPLOAD, "key", cumulative, false);
+
+    verify(logger, never()).debug(anyString(), any(), any());
+  }
+
+  @Test
+  void onFinishLogsPerFileBytesDistinctFromDirectoryCumulative() {
+    // Shared directory counter already holds another file's bytes; this listener should
+    // log its OWN per-file total separately from the directory-wide cumulative.
+    Logger logger = mock(Logger.class);
+    AtomicLong cumulative = new AtomicLong(500L); // pretend file B already transferred 500
+
+    OssLoggingTransferListener listener = new OssLoggingTransferListener(
+        logger, Direction.DOWNLOAD, "fileA", cumulative, true);
+    listener.onProgress(100L, 100L, 300L);
+    listener.onProgress(200L, 300L, 300L);
+    listener.onFinish();
+
+    // Directory cumulative = 500 (pre-existing) + 300 (this file) = 800.
+    assertEquals(800L, cumulative.get());
+
+    // The INFO completion log records fileBytes=300 and directoryCumulativeBytes=800 as
+    // distinct positional args, so operators don't misread the running total as per-file.
+    ArgumentCaptor<Object> args = ArgumentCaptor.forClass(Object.class);
+    verify(logger).info(anyString(), args.capture(), args.capture(),
+        args.capture(), args.capture(), args.capture());
+    List<Object> captured = args.getAllValues();
+    // positional: direction, key, fileBytes, directoryCumulativeBytes, elapsed
+    assertEquals(300L, captured.get(2), "fileBytes should be this file's own total");
+    assertEquals(800L, captured.get(3), "directoryCumulativeBytes should be the shared total");
+  }
+}


### PR DESCRIPTION
## Summary

Adds per-file transfer progress logging and byte-count accounting to the Ali OSS async **directory** upload/download operations, honoring the existing `transferStatusLoggingEnabled` flag on `DirectoryUploadRequest` / `DirectoryDownloadRequest`. Previously Ali emitted no transfer logging and the flag had no effect.

Scope is limited to async directory operations. Single-file upload/download behavior is intentionally unchanged.

## Changes

- **New `OssLoggingTransferListener`** implementing the OSS v2 `ProgressListener`. Accumulates per-call byte increments into a directory-scoped shared `AtomicLong` (always, so the response's `totalBytesTransferred` is populated), and emits gated lifecycle logs: DEBUG initiated / TRACE progress / INFO complete / ERROR failed.
- **Upload:** the OSS SDK drives `onProgress`/`onFinish` as it consumes the put stream (listener attached to `PutObjectRequest`).
- **Download:** the OSS SDK does not invoke the listener on the download path, so a counting copy loop self-drives `onProgress`/`onFinish` — the same idiom the SDK's own `transfermanager.Downloader` uses internally.
- **Wiring via a nullable-listener overload** on the shared upload/download internals. Single-file codepaths pass `null` and are completely uninstrumented (behavior frozen until separately requested). When the flag is off, no listener is attached at all.
- **Single `onFinish` driver per direction** to avoid double-logging completion (SDK for uploads, our copy loop for downloads).

## Testing

- `OssLoggingTransferListenerTest` — byte accumulation, gating, `transferFailed`, concurrency, and **log emission/level assertions** (DEBUG/TRACE/INFO/ERROR) via an injected logger.
- `AliAsyncBlobStoreTest` — directory upload/download cases, including a mock that simulates the SDK driving the listener to cover SDK-metrics-driven upload byte counting deterministically, plus flag-off → `null` total assertions for both directions.
- `mvn test -pl blob/blob-ali` — all unit tests pass; checkstyle clean.

No `-client` (cloud-agnostic) changes — `transferStatusLoggingEnabled` / `totalBytesTransferred` / `failedTransfers` already exist on the shared request and response objects.

Mapping to aws logging listener: 
transferInitiated - create() which is called from inside AliAsyncBlobStore.doDownloadDirectory()
transferComplete - onFinish()
bytesTransferred - onProgress()
transferFailed - transferFailed() which is called from inside AliAsyncBlobStore