### PR TITLE
blobstore: populate lastModified timestamp in BlobInfo for Ali list API

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -607,6 +607,7 @@ public class AliTransformer {
         .map(obj -> new BlobInfo.Builder()
             .withKey(obj.key())
             .withObjectSize(obj.size() != null ? obj.size() : 0L)
+            .withLastModified(obj.lastModified())
             .build())
         .collect(Collectors.toList());
 

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/BlobInfoIterator.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/BlobInfoIterator.java
@@ -44,6 +44,7 @@ public class BlobInfoIterator implements Iterator<BlobInfo> {
                 new BlobInfo.Builder()
                     .withKey(objSum.key())
                     .withObjectSize(objSum.size() != null ? objSum.size() : 0L)
+                    .withLastModified(objSum.lastModified())
                     .build())
         .collect(toList());
   }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -533,8 +533,16 @@ public class AliBlobStoreTest {
       int current = count++;
       assertEquals("key-" + current, blobInfo.getKey());
       assertEquals(current, blobInfo.getObjectSize());
+      assertEquals(
+          BASE_LAST_MODIFIED.plusSeconds(current), blobInfo.getLastModified(),
+          "doList should propagate the OSS ObjectSummary lastModified timestamp");
     }
   }
+
+  // Base instant for deterministic lastModified values in the object-summary fixtures;
+  // each summary i gets BASE_LAST_MODIFIED + i seconds so tests can assert exact timestamps.
+  private static final java.time.Instant BASE_LAST_MODIFIED =
+      java.time.Instant.parse("2026-01-01T00:00:00Z");
 
   private List<com.aliyun.sdk.service.oss2.models.ObjectSummary> getObjectSummaryList() {
     List<com.aliyun.sdk.service.oss2.models.ObjectSummary> list = new ArrayList<>();
@@ -545,6 +553,7 @@ public class AliBlobStoreTest {
                   com.aliyun.sdk.service.oss2.models.ObjectSummary.newBuilder()
                       .key("key-" + i)
                       .size((long) i)
+                      .lastModified(BASE_LAST_MODIFIED.plusSeconds(i))
                       .build();
               list.add(summary);
             });
@@ -597,8 +606,10 @@ public class AliBlobStoreTest {
     // Verify first and last blob
     assertEquals("key-1", response.getBlobs().get(0).getKey());
     assertEquals(1, response.getBlobs().get(0).getObjectSize());
+    assertEquals(BASE_LAST_MODIFIED.plusSeconds(1), response.getBlobs().get(0).getLastModified());
     assertEquals("key-99", response.getBlobs().get(98).getKey());
     assertEquals(99, response.getBlobs().get(98).getObjectSize());
+    assertEquals(BASE_LAST_MODIFIED.plusSeconds(99), response.getBlobs().get(98).getLastModified());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Populates the `lastModified` timestamp on `BlobInfo` returned by the Ali OSS list APIs. The Ali list paths previously built `BlobInfo` with only `key` and `objectSize`, omitting the timestamp that the AWS and GCP implementations already populate. `BlobInfo` has supported an `Instant lastModified` field all along, and the OSS v2 `ObjectSummary` exposes `lastModified()` directly, so the data was available but never mapped — this closes that gap for cross-provider parity.

## Changes

- `AliTransformer.toListBlobsBatch` now sets `.withLastModified(obj.lastModified())`. This covers the sync `doListPage` and both async list paths, since they all route through this transformer.
- `BlobInfoIterator.nextBatch` does the same for the sync streaming `list()` path.

## Testing

- `AliBlobStoreTest` list fixtures now carry deterministic per-object timestamps, and `testDoList` / `testDoListPage` assert the propagated `lastModified` value for both the streaming-iterator and page-list paths.
- `mvn test -pl blob/blob-ali` — all unit tests pass; checkstyle clean.

No `-client` (cloud-agnostic) changes — the `lastModified` field and `withLastModified(...)` builder method already exist on `BlobInfo`.
