### PR TITLE
blobstore: throw typed exception for unsupported Ali object lock retention mode upgrade

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -66,6 +66,7 @@ import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.ali.AliConstants;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.common.provider.Provider;
 import java.io.ByteArrayOutputStream;
@@ -731,6 +732,19 @@ public class AliBlobStore extends AbstractBlobStore {
 
     RetentionMode resolvedMode = ObjectRetentionRules.resolveAndValidate(
         currentMode, currentRetainUntil, config);
+
+    // OSS does not support changing an object's retention mode once set. A
+    // GOVERNANCE -> COMPLIANCE upgrade (which AWS/GCP allow with a bypass) is rejected
+    // server-side with HTTP 409 FileImmutable. Detect it here and fail with a clear,
+    // typed exception rather than leaking the provider-specific HTTP error. The shared
+    // ObjectRetentionRules has already allowed this transition for bypass-capable
+    // providers; this is the OSS-specific platform limitation.
+    if (currentMode == RetentionMode.GOVERNANCE
+        && resolvedMode == RetentionMode.COMPLIANCE) {
+      throw new UnSupportedOperationException(
+          "Alibaba OSS does not support upgrading an object's retention mode from "
+              + "GOVERNANCE to COMPLIANCE; the mode is immutable once set.");
+    }
 
     ossClient.putObjectRetention(
         transformer.toPutObjectRetentionRequest(

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -1256,6 +1256,70 @@ public class AliBlobStoreTest {
   }
 
   @Test
+  void testDoUpdateObjectRetention_governanceSameModeExtend_isUnaffectedByUpgradeGuard() {
+    // Regression safeguard: the GOVERNANCE -> COMPLIANCE upgrade guard must NOT interfere with a
+    // same-mode GOVERNANCE update (extending the retain-until date). This path should proceed
+    // normally and issue the PutObjectRetention call.
+    String key = "test-key";
+    String versionId = "version-1";
+
+    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult currentResult =
+        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
+            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
+                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.GOVERNANCE)
+                .retainUntilDate("2030-01-01T00:00:00Z")
+                .build())
+            .build();
+    when(mockOssClient.getObjectRetention(any(), any())).thenReturn(currentResult);
+    when(mockOssClient.putObjectRetention(any(), any()))
+        .thenReturn(
+            com.aliyun.sdk.service.oss2.models.PutObjectRetentionResult.newBuilder().build());
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(Instant.parse("2031-01-01T00:00:00Z"))
+            .build();
+
+    ali.updateObjectRetention(key, versionId, config);
+
+    // Guard does not fire for same-mode updates; the retention update is issued to OSS.
+    verify(mockOssClient).putObjectRetention(any(), any());
+  }
+
+  @Test
+  void testDoUpdateObjectRetention_complianceToGovernanceDowngrade_isUnaffectedByUpgradeGuard() {
+    // Regression safeguard: a COMPLIANCE -> GOVERNANCE downgrade is rejected by the shared
+    // ObjectRetentionRules (FailedPreconditionException), NOT by the OSS upgrade guard, and must
+    // never reach OSS. Documents that the upgrade guard is scoped to the opposite direction only.
+    String key = "test-key";
+    String versionId = "version-1";
+
+    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult currentResult =
+        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
+            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
+                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.COMPLIANCE)
+                .retainUntilDate("2030-01-01T00:00:00Z")
+                .build())
+            .build();
+    when(mockOssClient.getObjectRetention(any(), any())).thenReturn(currentResult);
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+            .retainUntilDate(Instant.parse("2031-01-01T00:00:00Z"))
+            .bypassGovernanceRetention(true)
+            .build();
+
+    assertThrows(
+        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        () -> ali.updateObjectRetention(key, versionId, config));
+
+    // Rejected by the shared rules before reaching OSS — not via the upgrade guard.
+    verify(mockOssClient, never()).putObjectRetention(any(), any());
+  }
+
+  @Test
   void testGetObjectLock_nonexistentKey_throws() {
     String key = "no-such-key";
     String versionId = null;

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,6 +46,7 @@ import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.ali.AliConstants;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.CredentialsType;
@@ -1219,6 +1221,38 @@ public class AliBlobStoreTest {
     ali.updateObjectRetention(key, versionId, config);
 
     verify(mockOssClient).putObjectRetention(any(), any());
+  }
+
+  @Test
+  void testDoUpdateObjectRetention_governanceToComplianceUpgrade_throwsUnsupported() {
+    // OSS cannot upgrade an object's retention mode GOVERNANCE -> COMPLIANCE. Even with
+    // bypass=true (which the shared ObjectRetentionRules allows for AWS/GCP), the Ali driver
+    // must fail fast with a typed UnSupportedOperationException instead of issuing the
+    // PutObjectRetention call and leaking OSS's 409 FileImmutable.
+    String key = "test-key";
+    String versionId = "version-1";
+
+    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult currentResult =
+        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
+            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
+                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.GOVERNANCE)
+                .retainUntilDate("2030-01-01T00:00:00Z")
+                .build())
+            .build();
+    when(mockOssClient.getObjectRetention(any(), any())).thenReturn(currentResult);
+
+    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
+        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
+            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.COMPLIANCE)
+            .retainUntilDate(Instant.parse("2031-01-01T00:00:00Z"))
+            .bypassGovernanceRetention(true)
+            .build();
+
+    assertThrows(UnSupportedOperationException.class,
+        () -> ali.updateObjectRetention(key, versionId, config));
+
+    // The upgrade is rejected before any PutObjectRetention call is made.
+    verify(mockOssClient, never()).putObjectRetention(any(), any());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Alibaba OSS does not support changing an object's retention mode once set. A GOVERNANCE → COMPLIANCE upgrade (which AWS and GCP allow with a bypass flag) is rejected server-side with HTTP 409, even when the bypass header is supplied. Previously that raw provider HTTP error leaked to callers.

This change makes the Ali sync driver detect a GOVERNANCE → COMPLIANCE mode-upgrade attempt and fail fast with a clear, typed exception instead.

## Changes

- `AliBlobStore.doUpdateObjectRetention` now detects a GOVERNANCE → COMPLIANCE transition (after the shared `ObjectRetentionRules` validation) and throws `UnSupportedOperationException` with an explanatory message, rather than issuing the `PutObjectRetention` call and surfacing OSS's 409.
- The guard is narrowly scoped to exactly that transition; same-mode GOVERNANCE updates (e.g. extending the retain-until date) and the existing negative cases are unaffected.

## Why

OSS treats an object version's retention mode as immutable once set — there is no SDK parameter, header, or alternate API that expresses the upgrade, and the bypass header (which is correctly sent) does not authorize it. The cross-cloud `ObjectRetentionRules` already permits the transition for bypass-capable providers (AWS/GCP); this provider-specific guard handles the OSS platform limitation by giving callers a predictable, documented failure consistent with the SDK exception hierarchy (`UnSupportedOperationException extends SubstrateSdkException`).

## Testing

- `AliBlobStoreTest` — new case asserts a GOVERNANCE → COMPLIANCE update with `bypassGovernanceRetention=true` throws `UnSupportedOperationException` and never calls `putObjectRetention`.
- `mvn test -pl blob/blob-ali` — all unit tests pass; checkstyle clean.

## Notes

The cross-cloud conformance test `testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds` remains skipped for Ali (it asserts the upgrade succeeds, which OSS does not support). No `-client` (cloud-agnostic) changes.
