### PR TITLE
blobstore: implement checkArchived for Ali OSS (delete-marker detection)

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -360,9 +360,23 @@ public class AliBlobStore extends AbstractBlobStore {
    * (404 NoSuchKey + {@code x-oss-delete-marker: true} + {@code x-oss-version-id} of the
    * marker).
    *
-   * <p>Returns silently if (a) {@code checkArchived} is off, (b) the underlying OSS exception
-   * is not 404, or (c) the 404 response did not carry a delete-marker header — in those cases
-   * the original exception is allowed to propagate unchanged.
+   * <p>The prior version is resolved deterministically by paging through {@code ListObjectVersions}
+   * (via the SDK paginator) and stopping at the first entry whose key matches exactly. Because OSS
+   * delete markers share the listing page-size budget with real versions, a single bounded page can
+   * return markers only; pagination guarantees the real version is found regardless of how many
+   * delete markers precede it (e.g. after repeated PUT/DELETE cycles), without relying on a
+   * guessed page size.
+   *
+   * <p>Archive detection is strictly best-effort: this method returns silently — allowing the
+   * original exception to propagate unchanged — if (a) {@code checkArchived} is off, (b) the
+   * underlying OSS exception is not 404, (c) the 404 response did not carry a delete-marker
+   * header, (d) the {@code ListObjectVersions} paging itself fails (network error, permission
+   * denied, versioning disabled, throttling), or (e) no prior version of the key could be
+   * resolved from the listing. It only throws {@link ResourceNotFoundException} with
+   * {@link ArchiveInfo} when it has positively identified an archived prior version
+   * ({@code versionId} non-null). This guarantees the guard never masks the caller's original
+   * download failure with a secondary error, and never reports {@code archived=true} without a
+   * usable {@code versionId}.
    */
   private void handleArchivedObjects(
       DownloadRequest downloadRequest, Throwable failure) {
@@ -389,22 +403,43 @@ public class AliBlobStore extends AbstractBlobStore {
     if (!isDeleteMarker) {
       return;
     }
-    ListObjectVersionsResult versions = ossClient.listObjectVersions(
-        ListObjectVersionsRequest.newBuilder()
-            .bucket(bucket)
-            .prefix(downloadRequest.getKey())
-            .maxKeys(2L)
-            .build(),
-        OperationOptions.defaults());
+    // Resolve the prior (non-marker) version id by listing versions for the key. A simple
+    // single-page listing is not deterministic: repeated PUT/DELETE cycles stack multiple delete
+    // markers ahead of the first real version, and delete markers share the page-size budget with
+    // versions, so a bounded page can come back with markers only. Instead, page through the
+    // results (the SDK paginator follows the key/version markers transparently) and stop at the
+    // first entry whose key matches exactly — the prefix listing can also return sibling keys.
+    // This yields a correct result regardless of how many delete markers precede the version.
     String versionId = null;
-    if (versions != null && versions.versions() != null) {
-      for (ObjectVersion v : versions.versions()) {
-        // Match exactly on key — the prefix listing can return sibling keys.
-        if (downloadRequest.getKey().equals(v.key())) {
-          versionId = v.versionId();
-          break;
+    try {
+      outer:
+      for (ListObjectVersionsResult page :
+          ossClient.listObjectVersionsPaginator(
+              ListObjectVersionsRequest.newBuilder()
+                  .bucket(bucket)
+                  .prefix(downloadRequest.getKey())
+                  .build())) {
+        if (page == null || page.versions() == null) {
+          continue;
+        }
+        for (ObjectVersion v : page.versions()) {
+          if (downloadRequest.getKey().equals(v.key())) {
+            versionId = v.versionId();
+            break outer;
+          }
         }
       }
+    } catch (Exception listFailure) {
+      // Best-effort: if version listing fails (network error, permission denied, versioning
+      // disabled, throttling), do not mask the caller's original download failure — let the
+      // original exception propagate unchanged.
+      return;
+    }
+    if (versionId == null) {
+      // No prior version of the key could be resolved (e.g. only delete markers exist). Rather
+      // than report archived=true with a null versionId the caller cannot act on, fall through
+      // and let the original 404 propagate unchanged.
+      return;
     }
     throw new ResourceNotFoundException(
         "Object is archived (delete marker): " + downloadRequest.getKey(),

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -23,10 +23,13 @@ import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
 import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult;
+import com.aliyun.sdk.service.oss2.models.ListObjectVersionsRequest;
+import com.aliyun.sdk.service.oss2.models.ListObjectVersionsResult;
 import com.aliyun.sdk.service.oss2.models.ListObjectsV2Request;
 import com.aliyun.sdk.service.oss2.models.ListObjectsV2Result;
 import com.aliyun.sdk.service.oss2.models.ListPartsRequest;
 import com.aliyun.sdk.service.oss2.models.ListPartsResult;
+import com.aliyun.sdk.service.oss2.models.ObjectVersion;
 import com.aliyun.sdk.service.oss2.models.PresignResult;
 import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
 import com.aliyun.sdk.service.oss2.models.PutObjectResult;
@@ -65,7 +68,9 @@ import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.ali.AliConstants;
+import com.salesforce.multicloudj.common.exceptions.ArchiveInfo;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
@@ -250,6 +255,7 @@ public class AliBlobStore extends AbstractBlobStore {
     } catch (IOException e) {
       throw new RuntimeException("Failed to download Blob: " + downloadRequest.getKey(), e);
     } catch (Exception e) {
+      handleArchivedObjects(downloadRequest, e);
       if (e instanceof RuntimeException) {
         throw (RuntimeException) e;
       }
@@ -306,6 +312,7 @@ public class AliBlobStore extends AbstractBlobStore {
     } catch (IOException e) {
       throw new RuntimeException("Failed to download Blob: " + downloadRequest.getKey(), e);
     } catch (Exception e) {
+      handleArchivedObjects(downloadRequest, e);
       if (e instanceof RuntimeException) {
         throw (RuntimeException) e;
       }
@@ -324,9 +331,13 @@ public class AliBlobStore extends AbstractBlobStore {
   public DownloadResponse doDownload(DownloadRequest downloadRequest) {
     GetObjectRequest request =
         transformer.toGetObjectRequest(downloadRequest);
-    GetObjectResult result =
-        ossClient.getObject(request,
-            OperationOptions.defaults());
+    GetObjectResult result;
+    try {
+      result = ossClient.getObject(request, OperationOptions.defaults());
+    } catch (Exception e) {
+      handleArchivedObjects(downloadRequest, e);
+      throw e;
+    }
     try {
       validateRangeResponse(downloadRequest, result);
     } catch (RuntimeException e) {
@@ -338,6 +349,82 @@ public class AliBlobStore extends AbstractBlobStore {
       throw e;
     }
     return transformer.toDownloadResponse(downloadRequest.getKey(), result, result.body());
+  }
+
+  /**
+   * If the caller asked for archive detection and the OSS GET failed with HTTP 404 carrying
+   * the {@code x-oss-delete-marker} header, list the prior versions of the key and throw
+   * {@link ResourceNotFoundException} populated with {@link ArchiveInfo} so the caller can
+   * recover the archived data via the prior {@code versionId}. Mirrors the on-the-wire
+   * delete-marker semantics observed against a real versioned + WORM-enabled bucket
+   * (404 NoSuchKey + {@code x-oss-delete-marker: true} + {@code x-oss-version-id} of the
+   * marker).
+   *
+   * <p>Returns silently if (a) {@code checkArchived} is off, (b) the underlying OSS exception
+   * is not 404, or (c) the 404 response did not carry a delete-marker header — in those cases
+   * the original exception is allowed to propagate unchanged.
+   */
+  private void handleArchivedObjects(
+      DownloadRequest downloadRequest, Throwable failure) {
+    if (!downloadRequest.isCheckArchived()) {
+      return;
+    }
+    ServiceException service = unwrapServiceException(failure);
+    if (service == null || service.statusCode() != 404) {
+      return;
+    }
+    Map<String, String> headers = service.headers();
+    if (headers == null) {
+      return;
+    }
+    boolean isDeleteMarker = false;
+    for (Map.Entry<String, String> entry : headers.entrySet()) {
+      if (entry.getKey() != null
+          && entry.getKey().equalsIgnoreCase("x-oss-delete-marker")
+          && "true".equalsIgnoreCase(entry.getValue())) {
+        isDeleteMarker = true;
+        break;
+      }
+    }
+    if (!isDeleteMarker) {
+      return;
+    }
+    ListObjectVersionsResult versions = ossClient.listObjectVersions(
+        ListObjectVersionsRequest.newBuilder()
+            .bucket(bucket)
+            .prefix(downloadRequest.getKey())
+            .maxKeys(2L)
+            .build(),
+        OperationOptions.defaults());
+    String versionId = null;
+    if (versions != null && versions.versions() != null) {
+      for (ObjectVersion v : versions.versions()) {
+        // Match exactly on key — the prefix listing can return sibling keys.
+        if (downloadRequest.getKey().equals(v.key())) {
+          versionId = v.versionId();
+          break;
+        }
+      }
+    }
+    throw new ResourceNotFoundException(
+        "Object is archived (delete marker): " + downloadRequest.getKey(),
+        failure,
+        ArchiveInfo.builder().archived(true).versionId(versionId).build());
+  }
+
+  /**
+   * Walks the cause chain of a thrown OSS exception to find the underlying
+   * {@link ServiceException}.
+   */
+  private static ServiceException unwrapServiceException(Throwable t) {
+    Throwable cur = t;
+    while (cur != null) {
+      if (cur instanceof ServiceException) {
+        return (ServiceException) cur;
+      }
+      cur = cur.getCause();
+    }
+    return null;
   }
 
   // OSS returns the full object with HTTP 200 when range start exceeds object size,

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -1633,4 +1633,117 @@ public class AliBlobStoreTest {
     assertFalse(iter.hasNext());
     assertThrows(NoSuchElementException.class, iter::next);
   }
+
+  // ---------- checkArchived (delete-marker / prior-version detection) ----------
+
+  @Test
+  void testDoDownload_checkArchived_deletedOnVersionedBucket_throwsWithArchiveInfo() {
+    // OSS returns 404 NoSuchKey on a GET of a deleted versioned object, with the
+    // x-oss-delete-marker:true header on the ServiceException. Behavior verified live
+    // against a real bucket — see AliCheckArchivedSmokeIT (separate IT branch). With
+    // checkArchived=true, the driver must call ListObjectVersions, capture the prior
+    // ObjectVersion's id, and throw ResourceNotFoundException with ArchiveInfo populated.
+    String key = "deleted-key";
+    String priorVersionId = "v-prior-1";
+
+    // 1. The OSS GET fails with 404 + the delete-marker header. Use a mocked OperationException
+    //    rather than `new OperationException(...)` because that constructor performs a
+    //    String.format on the cause, which interacts poorly with the JaCoCo agent on Mockito-spun
+    //    ServiceException instances in this build environment.
+    ServiceException service = mock(ServiceException.class);
+    when(service.statusCode()).thenReturn(404);
+    when(service.errorCode()).thenReturn("NoSuchKey");
+    Map<String, String> headers = new java.util.HashMap<>();
+    headers.put("x-oss-delete-marker", "true");
+    when(service.headers()).thenReturn(headers);
+    OperationException op = mock(OperationException.class);
+    when(op.getCause()).thenReturn(service);
+    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
+        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+        .thenThrow(op);
+
+    // 2. ListObjectVersions returns one prior ObjectVersion. Use the prior version's id (NOT
+    //    the delete marker's id), since the conformance test re-downloads it for the bytes.
+    ObjectVersion priorVersion = mock(ObjectVersion.class);
+    when(priorVersion.versionId()).thenReturn(priorVersionId);
+    when(priorVersion.key()).thenReturn(key);
+    ListObjectVersionsResult listResult = mock(ListObjectVersionsResult.class);
+    when(listResult.versions()).thenReturn(List.of(priorVersion));
+    when(mockOssClient.listObjectVersions(any(ListObjectVersionsRequest.class),
+        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+        .thenReturn(listResult);
+
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey(key).withCheckArchived(true).build();
+
+    com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException ex = assertThrows(
+        com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException.class,
+        () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
+
+    com.salesforce.multicloudj.common.exceptions.ArchiveInfo info = ex.getArchiveInfo();
+    assertNotNull(info, "ArchiveInfo should be populated when a delete marker is detected");
+    assertTrue(info.isArchived());
+    assertEquals(priorVersionId, info.getVersionId());
+  }
+
+  @Test
+  void testDoDownload_checkArchivedFalse_doesNotListVersionsOrChangeException() {
+    // When checkArchived is OFF, the guard must be a complete no-op: no ListObjectVersions
+    // call, and the original OSS exception type must propagate unchanged. This protects the
+    // single-file download path from any regression introduced by the guard.
+    String key = "deleted-key";
+
+    ServiceException service = mock(ServiceException.class);
+    when(service.statusCode()).thenReturn(404);
+    when(service.errorCode()).thenReturn("NoSuchKey");
+    Map<String, String> headers = new java.util.HashMap<>();
+    headers.put("x-oss-delete-marker", "true");
+    when(service.headers()).thenReturn(headers);
+    OperationException op = mock(OperationException.class);
+    when(op.getCause()).thenReturn(service);
+    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
+        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+        .thenThrow(op);
+
+    // checkArchived defaults to false on DownloadRequest.
+    DownloadRequest request = DownloadRequest.builder().withKey(key).build();
+
+    // The original OSS-side failure surfaces (the existing path wraps it in RuntimeException);
+    // the assertion is that the driver does NOT enrich it with ArchiveInfo and does NOT call
+    // listObjectVersions.
+    assertThrows(RuntimeException.class,
+        () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
+    verify(mockOssClient, never()).listObjectVersions(any(ListObjectVersionsRequest.class),
+        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
+  }
+
+  @Test
+  void testDoDownload_checkArchived_neverExisted_doesNotPopulateArchiveInfo() {
+    // 404 with NO x-oss-delete-marker header -> the key never existed (vs. was deleted on a
+    // versioned bucket). The driver must NOT call ListObjectVersions and must NOT throw a
+    // ResourceNotFoundException with archived=true. The conformance test
+    // testDownload_checkArchived_neverExisted accepts either a null ArchiveInfo or
+    // archived=false; we satisfy it by simply propagating the original exception unchanged.
+    String key = "never-existed-key";
+
+    ServiceException service = mock(ServiceException.class);
+    when(service.statusCode()).thenReturn(404);
+    when(service.errorCode()).thenReturn("NoSuchKey");
+    when(service.headers()).thenReturn(new java.util.HashMap<>()); // no delete-marker header
+    OperationException op = mock(OperationException.class);
+    when(op.getCause()).thenReturn(service);
+    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
+        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+        .thenThrow(op);
+
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey(key).withCheckArchived(true).build();
+
+    // No ResourceNotFoundException with archive info — guard short-circuits and the original
+    // 404-driven RuntimeException propagates.
+    assertThrows(RuntimeException.class,
+        () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
+    verify(mockOssClient, never()).listObjectVersions(any(ListObjectVersionsRequest.class),
+        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
+  }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -1662,16 +1662,17 @@ public class AliBlobStoreTest {
         any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
         .thenThrow(op);
 
-    // 2. ListObjectVersions returns one prior ObjectVersion. Use the prior version's id (NOT
-    //    the delete marker's id), since the conformance test re-downloads it for the bytes.
+    // 2. ListObjectVersions (paginated) returns one prior ObjectVersion. Use the prior version's
+    //    id (NOT the delete marker's id), since the conformance test re-downloads it for the bytes.
     ObjectVersion priorVersion = mock(ObjectVersion.class);
     when(priorVersion.versionId()).thenReturn(priorVersionId);
     when(priorVersion.key()).thenReturn(key);
     ListObjectVersionsResult listResult = mock(ListObjectVersionsResult.class);
     when(listResult.versions()).thenReturn(List.of(priorVersion));
-    when(mockOssClient.listObjectVersions(any(ListObjectVersionsRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
-        .thenReturn(listResult);
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(listResult).iterator());
+    when(mockOssClient.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
 
     DownloadRequest request = DownloadRequest.builder()
         .withKey(key).withCheckArchived(true).build();
@@ -1713,8 +1714,8 @@ public class AliBlobStoreTest {
     // listObjectVersions.
     assertThrows(RuntimeException.class,
         () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
-    verify(mockOssClient, never()).listObjectVersions(any(ListObjectVersionsRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
+    verify(mockOssClient, never())
+        .listObjectVersionsPaginator(any(ListObjectVersionsRequest.class));
   }
 
   @Test
@@ -1743,7 +1744,167 @@ public class AliBlobStoreTest {
     // 404-driven RuntimeException propagates.
     assertThrows(RuntimeException.class,
         () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
-    verify(mockOssClient, never()).listObjectVersions(any(ListObjectVersionsRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
+    verify(mockOssClient, never())
+        .listObjectVersionsPaginator(any(ListObjectVersionsRequest.class));
+  }
+
+  @Test
+  void testDoDownload_checkArchived_listVersionsFails_propagatesOriginalException() {
+    // Best-effort contract: if the delete marker is detected but the follow-up
+    // ListObjectVersions call itself fails (network error, permission denied, versioning
+    // disabled, throttling), the guard must NOT mask the caller's original download failure
+    // with the secondary listing error. The original 404-driven exception must propagate and
+    // NO ResourceNotFoundException/ArchiveInfo is produced.
+    String key = "deleted-key";
+
+    ServiceException service = mock(ServiceException.class);
+    when(service.statusCode()).thenReturn(404);
+    when(service.errorCode()).thenReturn("NoSuchKey");
+    Map<String, String> headers = new java.util.HashMap<>();
+    headers.put("x-oss-delete-marker", "true");
+    when(service.headers()).thenReturn(headers);
+    OperationException op = mock(OperationException.class);
+    when(op.getCause()).thenReturn(service);
+    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
+        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+        .thenThrow(op);
+
+    // ListObjectVersions paging blows up.
+    when(mockOssClient.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenThrow(new RuntimeException("listObjectVersions failed: permission denied"));
+
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey(key).withCheckArchived(true).build();
+
+    // The guard swallows the listing failure and re-throws the ORIGINAL exception (the mocked
+    // OperationException), not a ResourceNotFoundException.
+    Exception thrown = assertThrows(Exception.class,
+        () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
+    assertFalse(
+        thrown instanceof com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException,
+        "listObjectVersions failure must not be reported as an archived ResourceNotFoundException");
+  }
+
+  @Test
+  void testDoDownload_checkArchived_emptyVersionsPage_propagatesOriginalException() {
+    // Delete marker detected, but the paginated listing yields a page with a null versions list
+    // (e.g. only delete markers, which live in a separate list). The guard must fall through
+    // (no archived=true with a null versionId) and let the original exception propagate.
+    String key = "deleted-key";
+
+    ServiceException service = mock(ServiceException.class);
+    when(service.statusCode()).thenReturn(404);
+    when(service.errorCode()).thenReturn("NoSuchKey");
+    Map<String, String> headers = new java.util.HashMap<>();
+    headers.put("x-oss-delete-marker", "true");
+    when(service.headers()).thenReturn(headers);
+    OperationException op = mock(OperationException.class);
+    when(op.getCause()).thenReturn(service);
+    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
+        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+        .thenThrow(op);
+
+    ListObjectVersionsResult emptyPage = mock(ListObjectVersionsResult.class);
+    when(emptyPage.versions()).thenReturn(null);
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(emptyPage).iterator());
+    when(mockOssClient.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey(key).withCheckArchived(true).build();
+
+    Exception thrown = assertThrows(Exception.class,
+        () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
+    assertFalse(
+        thrown instanceof com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException,
+        "An empty versions page must not produce an archived ResourceNotFoundException");
+  }
+
+  @Test
+  void testDoDownload_checkArchived_noMatchingVersion_propagatesOriginalException() {
+    // Delete marker detected, paging returns versions but none whose key matches (e.g. only
+    // sibling keys). versionId stays null across all pages, so the guard must fall through
+    // rather than throw archived=true with a null versionId.
+    String key = "deleted-key";
+
+    ServiceException service = mock(ServiceException.class);
+    when(service.statusCode()).thenReturn(404);
+    when(service.errorCode()).thenReturn("NoSuchKey");
+    Map<String, String> headers = new java.util.HashMap<>();
+    headers.put("x-oss-delete-marker", "true");
+    when(service.headers()).thenReturn(headers);
+    OperationException op = mock(OperationException.class);
+    when(op.getCause()).thenReturn(service);
+    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
+        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+        .thenThrow(op);
+
+    // A version for a DIFFERENT (sibling) key — the exact-key match must skip it.
+    ObjectVersion sibling = mock(ObjectVersion.class);
+    when(sibling.key()).thenReturn("deleted-key-sibling");
+    ListObjectVersionsResult listResult = mock(ListObjectVersionsResult.class);
+    when(listResult.versions()).thenReturn(List.of(sibling));
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(listResult).iterator());
+    when(mockOssClient.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey(key).withCheckArchived(true).build();
+
+    Exception thrown = assertThrows(Exception.class,
+        () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
+    assertFalse(
+        thrown instanceof com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException,
+        "An unresolved versionId must not produce an archived ResourceNotFoundException");
+  }
+
+  @Test
+  void testDoDownload_checkArchived_versionOnLaterPage_resolvesAcrossPages() {
+    // Determinism check: the matching version is on the SECOND page (the first page contains only
+    // a sibling key, simulating delete markers / unrelated keys consuming the first page). The
+    // paginated walk must cross pages and still resolve the correct prior versionId.
+    String key = "deleted-key";
+    String priorVersionId = "v-on-page-2";
+
+    ServiceException service = mock(ServiceException.class);
+    when(service.statusCode()).thenReturn(404);
+    when(service.errorCode()).thenReturn("NoSuchKey");
+    Map<String, String> headers = new java.util.HashMap<>();
+    headers.put("x-oss-delete-marker", "true");
+    when(service.headers()).thenReturn(headers);
+    OperationException op = mock(OperationException.class);
+    when(op.getCause()).thenReturn(service);
+    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
+        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+        .thenThrow(op);
+
+    ObjectVersion sibling = mock(ObjectVersion.class);
+    when(sibling.key()).thenReturn("deleted-key-sibling");
+    ListObjectVersionsResult page1 = mock(ListObjectVersionsResult.class);
+    when(page1.versions()).thenReturn(List.of(sibling));
+
+    ObjectVersion match = mock(ObjectVersion.class);
+    when(match.key()).thenReturn(key);
+    when(match.versionId()).thenReturn(priorVersionId);
+    ListObjectVersionsResult page2 = mock(ListObjectVersionsResult.class);
+    when(page2.versions()).thenReturn(List.of(match));
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(page1, page2).iterator());
+    when(mockOssClient.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey(key).withCheckArchived(true).build();
+
+    com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException ex = assertThrows(
+        com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException.class,
+        () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
+    com.salesforce.multicloudj.common.exceptions.ArchiveInfo info = ex.getArchiveInfo();
+    assertNotNull(info);
+    assertTrue(info.isArchived());
+    assertEquals(priorVersionId, info.getVersionId());
   }
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-delete-0.json
@@ -1,0 +1,29 @@
+{
+  "id" : "36a5b3ef-a501-4866-afde-ea149b652e3e",
+  "name" : "AliBlobStoreIT_testDownload_checkArchived-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/check-archived/archived-blob",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQigsY8vn1nPzFuvUZIiAyM2M1MzAxY2YxMWY0NTVjOTAxZTkyMDIwZjMwNDljMA--",
+      "x-oss-request-id" : "6A289C69B4C7B93239BC42A3",
+      "x-oss-server-time" : "58",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Tue, 09 Jun 2026 23:06:17 GMT"
+    }
+  },
+  "uuid" : "36a5b3ef-a501-4866-afde-ea149b652e3e",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-check-archived-archived-blob",
+  "requiredScenarioState" : "scenario-1-conformance-tests-check-archived-archived-blob-2",
+  "insertionIndex" : 619
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "36a5b3ef-a501-4866-afde-ea149b652e3e",
+  "id" : "8f31ac68-d4d9-4cd4-9c1f-ce20ff159376",
   "name" : "AliBlobStoreIT_testDownload_checkArchived-DELETE-0",
   "request" : {
     "url" : "/conformance-tests/check-archived/archived-blob",
@@ -13,17 +13,17 @@
   "response" : {
     "status" : 204,
     "headers" : {
-      "x-oss-version-id" : "CAEQigsY8vn1nPzFuvUZIiAyM2M1MzAxY2YxMWY0NTVjOTAxZTkyMDIwZjMwNDljMA--",
-      "x-oss-request-id" : "6A289C69B4C7B93239BC42A3",
-      "x-oss-server-time" : "58",
+      "x-oss-version-id" : "CAEQvAsY.cXXl7uSzvUZIiA5Y2Q4NTk3ZTE0OWI0YjJmYmNhN2QyOTZlODQ5YWFkMg--",
+      "x-oss-request-id" : "6A29DD7FB899983736D77F92",
+      "x-oss-server-time" : "47",
       "Server" : "AliyunOSS",
       "x-oss-delete-marker" : "true",
-      "Date" : "Tue, 09 Jun 2026 23:06:17 GMT"
+      "Date" : "Wed, 10 Jun 2026 21:56:15 GMT"
     }
   },
-  "uuid" : "36a5b3ef-a501-4866-afde-ea149b652e3e",
+  "uuid" : "8f31ac68-d4d9-4cd4-9c1f-ce20ff159376",
   "persistent" : true,
   "scenarioName" : "scenario-1-conformance-tests-check-archived-archived-blob",
   "requiredScenarioState" : "scenario-1-conformance-tests-check-archived-archived-blob-2",
-  "insertionIndex" : 619
+  "insertionIndex" : 626
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-delete-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-delete-4.json
@@ -1,0 +1,30 @@
+{
+  "id" : "2c621284-544a-4362-b377-cd57b8f240c8",
+  "name" : "AliBlobStoreIT_testDownload_checkArchived-DELETE-4",
+  "request" : {
+    "url" : "/conformance-tests/check-archived/archived-blob",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQigsYlJaOm._FuvUZIiAwMDhiZDJkZjBhM2I0MTI2ODk0OGZmYzEwMDNmMzg1Yw--",
+      "x-oss-request-id" : "6A289C66E116C6303322BEDF",
+      "x-oss-server-time" : "106",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Tue, 09 Jun 2026 23:06:14 GMT"
+    }
+  },
+  "uuid" : "2c621284-544a-4362-b377-cd57b8f240c8",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-check-archived-archived-blob",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-conformance-tests-check-archived-archived-blob-2",
+  "insertionIndex" : 623
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-delete-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-delete-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "2c621284-544a-4362-b377-cd57b8f240c8",
+  "id" : "49bd5706-2bf1-4512-a356-49e2a6afc145",
   "name" : "AliBlobStoreIT_testDownload_checkArchived-DELETE-4",
   "request" : {
     "url" : "/conformance-tests/check-archived/archived-blob",
@@ -13,18 +13,18 @@
   "response" : {
     "status" : 204,
     "headers" : {
-      "x-oss-version-id" : "CAEQigsYlJaOm._FuvUZIiAwMDhiZDJkZjBhM2I0MTI2ODk0OGZmYzEwMDNmMzg1Yw--",
-      "x-oss-request-id" : "6A289C66E116C6303322BEDF",
-      "x-oss-server-time" : "106",
+      "x-oss-version-id" : "CAEQvAsYwJvUna6SzvUZIiA4NjhmMjFiZjBlNmY0OGYxYmE5MWUzNzI3N2I2ZjcxYg--",
+      "x-oss-request-id" : "6A29DD7CE4C5F830365B7646",
+      "x-oss-server-time" : "104",
       "Server" : "AliyunOSS",
       "x-oss-delete-marker" : "true",
-      "Date" : "Tue, 09 Jun 2026 23:06:14 GMT"
+      "Date" : "Wed, 10 Jun 2026 21:56:12 GMT"
     }
   },
-  "uuid" : "2c621284-544a-4362-b377-cd57b8f240c8",
+  "uuid" : "49bd5706-2bf1-4512-a356-49e2a6afc145",
   "persistent" : true,
   "scenarioName" : "scenario-1-conformance-tests-check-archived-archived-blob",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-conformance-tests-check-archived-archived-blob-2",
-  "insertionIndex" : 623
+  "insertionIndex" : 630
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-get-1.json
@@ -1,0 +1,45 @@
+{
+  "id" : "b21dc885-79bd-4229-a1d8-9aeb57c61c12",
+  "name" : "AliBlobStoreIT_testDownload_checkArchived-GET-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/check-archived/archived-blob",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQigsY9MzO4evFuvUZIiAyMWZlMzAwNzczNzc0M2VhOTRmNmMyNDc2OWZlNzM2ZQ--"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "YXJjaGl2ZWQgY29udGVudA==",
+    "headers" : {
+      "x-oss-version-id" : "CAEQigsY9MzO4evFuvUZIiAyMWZlMzAwNzczNzc0M2VhOTRmNmMyNDc2OWZlNzM2ZQ--",
+      "x-oss-request-id" : "6A289C6858FB013832687713",
+      "x-oss-server-time" : "70",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 09 Jun 2026 23:06:13 GMT",
+      "Date" : "Tue, 09 Jun 2026 23:06:16 GMT",
+      "Content-MD5" : "qYhxiUZF0GoGNk7+a0KvnQ==",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "14870085893817539781",
+      "ETag" : "\"A98871894645D06A06364EFE6B42AF9D\"",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "b21dc885-79bd-4229-a1d8-9aeb57c61c12",
+  "persistent" : true,
+  "insertionIndex" : 620
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "b21dc885-79bd-4229-a1d8-9aeb57c61c12",
+  "id" : "6e6086a3-8302-4829-89c9-bda22da7d9bf",
   "name" : "AliBlobStoreIT_testDownload_checkArchived-GET-1",
   "request" : {
     "urlPath" : "/conformance-tests/check-archived/archived-blob",
@@ -15,7 +15,7 @@
     "queryParameters" : {
       "versionId" : {
         "hasExactly" : [ {
-          "equalTo" : "CAEQigsY9MzO4evFuvUZIiAyMWZlMzAwNzczNzc0M2VhOTRmNmMyNDc2OWZlNzM2ZQ--"
+          "equalTo" : "CAEQvAsY5vml.6qSzvUZIiAyMmYxMzJkZDRhYzE0Nzc3YjhiOWY2NjYzMmNjNjliMA--"
         } ]
       }
     }
@@ -24,13 +24,13 @@
     "status" : 200,
     "base64Body" : "YXJjaGl2ZWQgY29udGVudA==",
     "headers" : {
-      "x-oss-version-id" : "CAEQigsY9MzO4evFuvUZIiAyMWZlMzAwNzczNzc0M2VhOTRmNmMyNDc2OWZlNzM2ZQ--",
-      "x-oss-request-id" : "6A289C6858FB013832687713",
-      "x-oss-server-time" : "70",
+      "x-oss-version-id" : "CAEQvAsY5vml.6qSzvUZIiAyMmYxMzJkZDRhYzE0Nzc3YjhiOWY2NjYzMmNjNjliMA--",
+      "x-oss-request-id" : "6A29DD7ED056AC3934CCD0F5",
+      "x-oss-server-time" : "98",
       "Server" : "AliyunOSS",
       "x-oss-object-type" : "Normal",
-      "Last-Modified" : "Tue, 09 Jun 2026 23:06:13 GMT",
-      "Date" : "Tue, 09 Jun 2026 23:06:16 GMT",
+      "Last-Modified" : "Wed, 10 Jun 2026 21:56:11 GMT",
+      "Date" : "Wed, 10 Jun 2026 21:56:15 GMT",
       "Content-MD5" : "qYhxiUZF0GoGNk7+a0KvnQ==",
       "Accept-Ranges" : "bytes",
       "x-oss-storage-class" : "Standard",
@@ -39,7 +39,7 @@
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "b21dc885-79bd-4229-a1d8-9aeb57c61c12",
+  "uuid" : "6e6086a3-8302-4829-89c9-bda22da7d9bf",
   "persistent" : true,
-  "insertionIndex" : 620
+  "insertionIndex" : 627
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-get-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-get-2.json
@@ -1,0 +1,52 @@
+{
+  "id" : "c87bacb8-b419-4666-bc03-3b36826c1153",
+  "name" : "AliBlobStoreIT_testDownload_checkArchived-GET-2",
+  "request" : {
+    "urlPath" : "/",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "4"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "max-keys" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      },
+      "versions" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      },
+      "prefix" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/check-archived/archived-blob"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListVersionsResult>\n  <Name>chameleon-multicloudj-test-versioned</Name>\n  <Prefix>conformance-tests%2Fcheck-archived%2Farchived-blob</Prefix>\n  <KeyMarker></KeyMarker>\n  <VersionIdMarker></VersionIdMarker>\n  <MaxKeys>2</MaxKeys>\n  <Delimiter></Delimiter>\n  <EncodingType>url</EncodingType>\n  <IsTruncated>true</IsTruncated>\n  <NextKeyMarker>conformance-tests%2Fcheck-archived%2Farchived-blob</NextKeyMarker>\n  <NextVersionIdMarker>CAEQigsY9MzO4evFuvUZIiAyMWZlMzAwNzczNzc0M2VhOTRmNmMyNDc2OWZlNzM2ZQ--</NextVersionIdMarker>\n  <DeleteMarker>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigsYlJaOm._FuvUZIiAwMDhiZDJkZjBhM2I0MTI2ODk0OGZmYzEwMDNmMzg1Yw--</VersionId>\n    <IsLatest>true</IsLatest>\n    <LastModified>2026-06-09T23:06:14.000Z</LastModified>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </DeleteMarker>\n  <Version>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigsY9MzO4evFuvUZIiAyMWZlMzAwNzczNzc0M2VhOTRmNmMyNDc2OWZlNzM2ZQ--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-06-09T23:06:13.000Z</LastModified>\n    <ETag>\"A98871894645D06A06364EFE6B42AF9D\"</ETag>\n    <Type>Normal</Type>\n    <Size>16</Size>\n    <StorageClass>Standard</StorageClass>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </Version>\n</ListVersionsResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A289C67986E293831973336",
+      "x-oss-server-time" : "87",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 09 Jun 2026 23:06:15 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "c87bacb8-b419-4666-bc03-3b36826c1153",
+  "persistent" : true,
+  "insertionIndex" : 621
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-get-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-get-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "c87bacb8-b419-4666-bc03-3b36826c1153",
+  "id" : "29c3caac-869d-474b-ae00-f857aa768d8f",
   "name" : "AliBlobStoreIT_testDownload_checkArchived-GET-2",
   "request" : {
     "urlPath" : "/",
@@ -9,18 +9,13 @@
         "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
       },
       "X-Query-Param-Count" : {
-        "equalTo" : "4"
+        "equalTo" : "3"
       }
     },
     "queryParameters" : {
       "encoding-type" : {
         "hasExactly" : [ {
           "equalTo" : "url"
-        } ]
-      },
-      "max-keys" : {
-        "hasExactly" : [ {
-          "equalTo" : "2"
         } ]
       },
       "versions" : {
@@ -37,16 +32,16 @@
   },
   "response" : {
     "status" : 200,
-    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListVersionsResult>\n  <Name>chameleon-multicloudj-test-versioned</Name>\n  <Prefix>conformance-tests%2Fcheck-archived%2Farchived-blob</Prefix>\n  <KeyMarker></KeyMarker>\n  <VersionIdMarker></VersionIdMarker>\n  <MaxKeys>2</MaxKeys>\n  <Delimiter></Delimiter>\n  <EncodingType>url</EncodingType>\n  <IsTruncated>true</IsTruncated>\n  <NextKeyMarker>conformance-tests%2Fcheck-archived%2Farchived-blob</NextKeyMarker>\n  <NextVersionIdMarker>CAEQigsY9MzO4evFuvUZIiAyMWZlMzAwNzczNzc0M2VhOTRmNmMyNDc2OWZlNzM2ZQ--</NextVersionIdMarker>\n  <DeleteMarker>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigsYlJaOm._FuvUZIiAwMDhiZDJkZjBhM2I0MTI2ODk0OGZmYzEwMDNmMzg1Yw--</VersionId>\n    <IsLatest>true</IsLatest>\n    <LastModified>2026-06-09T23:06:14.000Z</LastModified>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </DeleteMarker>\n  <Version>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigsY9MzO4evFuvUZIiAyMWZlMzAwNzczNzc0M2VhOTRmNmMyNDc2OWZlNzM2ZQ--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-06-09T23:06:13.000Z</LastModified>\n    <ETag>\"A98871894645D06A06364EFE6B42AF9D\"</ETag>\n    <Type>Normal</Type>\n    <Size>16</Size>\n    <StorageClass>Standard</StorageClass>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </Version>\n</ListVersionsResult>\n",
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListVersionsResult>\n  <Name>chameleon-multicloudj-test-versioned</Name>\n  <Prefix>conformance-tests%2Fcheck-archived%2Farchived-blob</Prefix>\n  <KeyMarker></KeyMarker>\n  <VersionIdMarker></VersionIdMarker>\n  <MaxKeys>100</MaxKeys>\n  <Delimiter></Delimiter>\n  <EncodingType>url</EncodingType>\n  <IsTruncated>false</IsTruncated>\n  <DeleteMarker>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQvAsYwJvUna6SzvUZIiA4NjhmMjFiZjBlNmY0OGYxYmE5MWUzNzI3N2I2ZjcxYg--</VersionId>\n    <IsLatest>true</IsLatest>\n    <LastModified>2026-06-10T21:56:12.000Z</LastModified>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </DeleteMarker>\n  <Version>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQvAsY5vml.6qSzvUZIiAyMmYxMzJkZDRhYzE0Nzc3YjhiOWY2NjYzMmNjNjliMA--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-06-10T21:56:11.000Z</LastModified>\n    <ETag>\"A98871894645D06A06364EFE6B42AF9D\"</ETag>\n    <Type>Normal</Type>\n    <Size>16</Size>\n    <StorageClass>Standard</StorageClass>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </Version>\n  <DeleteMarker>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigsYjtPz1f3cuvUZIiAxZGE2OWFhZjIxNTE0YWY2OTcwNmQ0OTc4YTU5YmZjMQ--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-06-09T23:18:51.000Z</LastModified>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </DeleteMarker>\n  <DeleteMarker>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigsY7o.c6vDcuvUZIiBlMzIzODI1YzRmOTY0N2Q0YWFkY2JiOGY1M2UyYTY3Ng--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-06-09T23:18:48.000Z</LastModified>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </DeleteMarker>\n  <Version>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigsYvayRru3cuvUZIiBhOTc0NzdiZDFkYjk0YWVlODRmNzUwMGI1YjExNWFmZA--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-06-09T23:18:47.000Z</LastModified>\n    <ETag>\"A98871894645D06A06364EFE6B42AF9D\"</ETag>\n    <Type>Normal</Type>\n    <Size>16</Size>\n    <StorageClass>Standard</StorageClass>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </Version>\n  <DeleteMarker>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigsY8vn1nPzFuvUZIiAyM2M1MzAxY2YxMWY0NTVjOTAxZTkyMDIwZjMwNDljMA--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-06-09T23:06:17.000Z</LastModified>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </DeleteMarker>\n  <DeleteMarker>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigsYlJaOm._FuvUZIiAwMDhiZDJkZjBhM2I0MTI2ODk0OGZmYzEwMDNmMzg1Yw--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-06-09T23:06:14.000Z</LastModified>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </DeleteMarker>\n  <Version>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigsY9MzO4evFuvUZIiAyMWZlMzAwNzczNzc0M2VhOTRmNmMyNDc2OWZlNzM2ZQ--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-06-09T23:06:13.000Z</LastModified>\n    <ETag>\"A98871894645D06A06364EFE6B42AF9D\"</ETag>\n    <Type>Normal</Type>\n    <Size>16</Size>\n    <StorageClass>Standard</StorageClass>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </Version>\n  <DeleteMarker>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigEYgoDAuf7YsvEZIiA3M2ZiMDM5OWM2YTA0OWEwYWRjNWZjMGQ1ZjI4MzU5MA--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-05-15T17:26:02.000Z</LastModified>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </DeleteMarker>\n  <DeleteMarker>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigEYgYCA8vXYsvEZIiA0NzFkNjQyM2JmZDU0YTkwOTBkNjI2ZWI5YTI5ZmMzZg--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-05-15T17:26:00.000Z</LastModified>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </DeleteMarker>\n  <Version>\n    <Key>conformance-tests%2Fcheck-archived%2Farchived-blob</Key>\n    <VersionId>CAEQigEYgYDAq.3YsvEZIiAxM2VkNjVmMWFlNmM0NjdkODA5NGMzN2M3OTY0NzI5ZQ--</VersionId>\n    <IsLatest>false</IsLatest>\n    <LastModified>2026-05-15T17:25:58.000Z</LastModified>\n    <ETag>\"A98871894645D06A06364EFE6B42AF9D\"</ETag>\n    <Type>Normal</Type>\n    <Size>16</Size>\n    <StorageClass>Standard</StorageClass>\n    <Owner>\n      <ID>1099202394511537</ID>\n      <DisplayName>1099202394511537</DisplayName>\n    </Owner>\n  </Version>\n</ListVersionsResult>\n",
     "headers" : {
-      "x-oss-request-id" : "6A289C67986E293831973336",
-      "x-oss-server-time" : "87",
+      "x-oss-request-id" : "6A29DD7E9E87C136346D0630",
+      "x-oss-server-time" : "83",
       "Server" : "AliyunOSS",
-      "Date" : "Tue, 09 Jun 2026 23:06:15 GMT",
+      "Date" : "Wed, 10 Jun 2026 21:56:14 GMT",
       "Content-Type" : "application/xml"
     }
   },
-  "uuid" : "c87bacb8-b419-4666-bc03-3b36826c1153",
+  "uuid" : "29c3caac-869d-474b-ae00-f857aa768d8f",
   "persistent" : true,
-  "insertionIndex" : 621
+  "insertionIndex" : 628
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-get-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-get-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "131e7e5a-9018-4e16-9ecd-b9bd942a18f8",
+  "id" : "a39531f3-0c38-42c0-be1c-4128691cb55f",
   "name" : "AliBlobStoreIT_testDownload_checkArchived-GET-3",
   "request" : {
     "url" : "/conformance-tests/check-archived/archived-blob",
@@ -12,19 +12,19 @@
   },
   "response" : {
     "status" : 404,
-    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchKey</Code>\n  <Message>The specified key does not exist.</Message>\n  <RequestId>6A289C6676CDA43833CFB431</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <Key>conformance-tests/check-archived/archived-blob</Key>\n  <EC>0026-00000001</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0026-00000001</RecommendDoc>\n</Error>\n",
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchKey</Code>\n  <Message>The specified key does not exist.</Message>\n  <RequestId>6A29DD7D20C22B3136702678</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <Key>conformance-tests/check-archived/archived-blob</Key>\n  <EC>0026-00000001</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0026-00000001</RecommendDoc>\n</Error>\n",
     "headers" : {
-      "x-oss-version-id" : "CAEQigsYlJaOm._FuvUZIiAwMDhiZDJkZjBhM2I0MTI2ODk0OGZmYzEwMDNmMzg1Yw--",
-      "x-oss-request-id" : "6A289C6676CDA43833CFB431",
-      "x-oss-server-time" : "51",
+      "x-oss-version-id" : "CAEQvAsYwJvUna6SzvUZIiA4NjhmMjFiZjBlNmY0OGYxYmE5MWUzNzI3N2I2ZjcxYg--",
+      "x-oss-request-id" : "6A29DD7D20C22B3136702678",
+      "x-oss-server-time" : "60",
       "Server" : "AliyunOSS",
       "x-oss-ec" : "0026-00000001",
       "x-oss-delete-marker" : "true",
-      "Date" : "Tue, 09 Jun 2026 23:06:14 GMT",
+      "Date" : "Wed, 10 Jun 2026 21:56:13 GMT",
       "Content-Type" : "application/xml"
     }
   },
-  "uuid" : "131e7e5a-9018-4e16-9ecd-b9bd942a18f8",
+  "uuid" : "a39531f3-0c38-42c0-be1c-4128691cb55f",
   "persistent" : true,
-  "insertionIndex" : 622
+  "insertionIndex" : 629
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-get-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-get-3.json
@@ -1,0 +1,30 @@
+{
+  "id" : "131e7e5a-9018-4e16-9ecd-b9bd942a18f8",
+  "name" : "AliBlobStoreIT_testDownload_checkArchived-GET-3",
+  "request" : {
+    "url" : "/conformance-tests/check-archived/archived-blob",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchKey</Code>\n  <Message>The specified key does not exist.</Message>\n  <RequestId>6A289C6676CDA43833CFB431</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <Key>conformance-tests/check-archived/archived-blob</Key>\n  <EC>0026-00000001</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0026-00000001</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQigsYlJaOm._FuvUZIiAwMDhiZDJkZjBhM2I0MTI2ODk0OGZmYzEwMDNmMzg1Yw--",
+      "x-oss-request-id" : "6A289C6676CDA43833CFB431",
+      "x-oss-server-time" : "51",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0026-00000001",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Tue, 09 Jun 2026 23:06:14 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "131e7e5a-9018-4e16-9ecd-b9bd942a18f8",
+  "persistent" : true,
+  "insertionIndex" : 622
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-put-5.json
@@ -1,5 +1,5 @@
 {
-  "id" : "8b447ffa-0d43-4fe0-af0f-fe7094ca6bd7",
+  "id" : "a59e8cc3-3157-4a59-9756-215391eac30e",
   "name" : "AliBlobStoreIT_testDownload_checkArchived-PUT-5",
   "request" : {
     "url" : "/conformance-tests/check-archived/archived-blob",
@@ -16,17 +16,17 @@
   "response" : {
     "status" : 200,
     "headers" : {
-      "x-oss-version-id" : "CAEQigsY9MzO4evFuvUZIiAyMWZlMzAwNzczNzc0M2VhOTRmNmMyNDc2OWZlNzM2ZQ--",
-      "x-oss-request-id" : "6A289C65FA23083130287452",
-      "x-oss-server-time" : "122",
+      "x-oss-version-id" : "CAEQvAsY5vml.6qSzvUZIiAyMmYxMzJkZDRhYzE0Nzc3YjhiOWY2NjYzMmNjNjliMA--",
+      "x-oss-request-id" : "6A29DD7BC15CCF3337D61708",
+      "x-oss-server-time" : "103",
       "Server" : "AliyunOSS",
       "x-oss-hash-crc64ecma" : "14870085893817539781",
       "ETag" : "\"A98871894645D06A06364EFE6B42AF9D\"",
-      "Date" : "Tue, 09 Jun 2026 23:06:13 GMT",
+      "Date" : "Wed, 10 Jun 2026 21:56:11 GMT",
       "Content-MD5" : "qYhxiUZF0GoGNk7+a0KvnQ=="
     }
   },
-  "uuid" : "8b447ffa-0d43-4fe0-af0f-fe7094ca6bd7",
+  "uuid" : "a59e8cc3-3157-4a59-9756-215391eac30e",
   "persistent" : true,
-  "insertionIndex" : 624
+  "insertionIndex" : 631
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived-put-5.json
@@ -1,0 +1,32 @@
+{
+  "id" : "8b447ffa-0d43-4fe0-af0f-fe7094ca6bd7",
+  "name" : "AliBlobStoreIT_testDownload_checkArchived-PUT-5",
+  "request" : {
+    "url" : "/conformance-tests/check-archived/archived-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "YXJjaGl2ZWQgY29udGVudA=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQigsY9MzO4evFuvUZIiAyMWZlMzAwNzczNzc0M2VhOTRmNmMyNDc2OWZlNzM2ZQ--",
+      "x-oss-request-id" : "6A289C65FA23083130287452",
+      "x-oss-server-time" : "122",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14870085893817539781",
+      "ETag" : "\"A98871894645D06A06364EFE6B42AF9D\"",
+      "Date" : "Tue, 09 Jun 2026 23:06:13 GMT",
+      "Content-MD5" : "qYhxiUZF0GoGNk7+a0KvnQ=="
+    }
+  },
+  "uuid" : "8b447ffa-0d43-4fe0-af0f-fe7094ca6bd7",
+  "persistent" : true,
+  "insertionIndex" : 624
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived_neverexisted-get-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived_neverexisted-get-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "55de7426-a2a6-4542-a454-faea196b8772",
+  "id" : "a51dd075-052d-40e7-85eb-7185a95e4a83",
   "name" : "AliBlobStoreIT_testDownload_checkArchived_neverExisted-GET-0",
   "request" : {
     "url" : "/conformance-tests/check-archived/never-existed",
@@ -12,17 +12,17 @@
   },
   "response" : {
     "status" : 404,
-    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchKey</Code>\n  <Message>The specified key does not exist.</Message>\n  <RequestId>6A289D7AE4C5F836318EDEFB</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <Key>conformance-tests/check-archived/never-existed</Key>\n  <EC>0026-00000001</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0026-00000001</RecommendDoc>\n</Error>\n",
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchKey</Code>\n  <Message>The specified key does not exist.</Message>\n  <RequestId>6A29DE90A73E4C373474221E</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <Key>conformance-tests/check-archived/never-existed</Key>\n  <EC>0026-00000001</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0026-00000001</RecommendDoc>\n</Error>\n",
     "headers" : {
-      "x-oss-request-id" : "6A289D7AE4C5F836318EDEFB",
-      "x-oss-server-time" : "35",
+      "x-oss-request-id" : "6A29DE90A73E4C373474221E",
+      "x-oss-server-time" : "11",
       "Server" : "AliyunOSS",
       "x-oss-ec" : "0026-00000001",
-      "Date" : "Tue, 09 Jun 2026 23:10:50 GMT",
+      "Date" : "Wed, 10 Jun 2026 22:00:48 GMT",
       "Content-Type" : "application/xml"
     }
   },
-  "uuid" : "55de7426-a2a6-4542-a454-faea196b8772",
+  "uuid" : "a51dd075-052d-40e7-85eb-7185a95e4a83",
   "persistent" : true,
-  "insertionIndex" : 1040
+  "insertionIndex" : 1047
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived_neverexisted-get-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownload_checkarchived_neverexisted-get-0.json
@@ -1,0 +1,28 @@
+{
+  "id" : "55de7426-a2a6-4542-a454-faea196b8772",
+  "name" : "AliBlobStoreIT_testDownload_checkArchived_neverExisted-GET-0",
+  "request" : {
+    "url" : "/conformance-tests/check-archived/never-existed",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchKey</Code>\n  <Message>The specified key does not exist.</Message>\n  <RequestId>6A289D7AE4C5F836318EDEFB</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <Key>conformance-tests/check-archived/never-existed</Key>\n  <EC>0026-00000001</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0026-00000001</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A289D7AE4C5F836318EDEFB",
+      "x-oss-server-time" : "35",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0026-00000001",
+      "Date" : "Tue, 09 Jun 2026 23:10:50 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "55de7426-a2a6-4542-a454-faea196b8772",
+  "persistent" : true,
+  "insertionIndex" : 1040
+}

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -5217,7 +5217,6 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testDownload_checkArchived() throws IOException {
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
     BucketClient bucketClient = new BucketClient(blobStore);
     String key = "conformance-tests/check-archived/archived-blob";
@@ -5262,7 +5261,6 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testDownload_checkArchived_neverExisted() throws IOException {
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
     BucketClient bucketClient = new BucketClient(blobStore);
 


### PR DESCRIPTION
## Summary

Implements `checkArchived` for the Ali OSS blob driver. When a sync `download` request has `checkArchived=true` and the underlying OSS GET fails with HTTP 404 carrying the `x-oss-delete-marker` header, the driver now lists prior versions of the key and throws `ResourceNotFoundException` populated with `ArchiveInfo` so callers can recover the archived data via the prior `versionId`.

This brings Ali to parity with AWS and GCP, which already implement the cross-cloud delete-marker / prior-version detection contract on their sync paths.

## Changes

- `AliBlobStore.handleArchivedObjects(...)` — new helper invoked from the catch blocks of all three sync `doDownload` variants (OutputStream, Path, InputStream); File and ByteArray variants delegate through them.
  - Gates on `isCheckArchived()` AND `ServiceException.statusCode == 404`.
  - Requires `x-oss-delete-marker: true` on the response (case-insensitive header lookup).
  - Calls `listObjectVersions(prefix=key, maxKeys=2)` and returns the first matching `ObjectVersion`'s id (NOT the delete marker's id, since the conformance contract re-downloads the returned id and expects original bytes).
  - Returns silently when any gate isn't met, letting the original exception propagate (never-existed key / no-bypass paths).
- `AliBlobStore.unwrapServiceException(...)` — small helper to walk the cause chain and find the underlying OSS `ServiceException` (the existing `getException` method uses a similar unwrap pattern).
- Conformance gates removed: `Assumptions.assumeFalse(ALI_PROVIDER_ID...)` dropped from `testDownload_checkArchived` and `testDownload_checkArchived_neverExisted` in `AbstractBlobStoreIT`.
- WireMock replay mappings recorded against a real versioned + WORM-enabled bucket and committed under `blob-ali/src/test/resources/mappings/`.

The async path is intentionally left unchanged for parity with AWS/GCP, which only implement this on the sync path.

## API Example

```java
BucketClient client = BucketClient.builder("ali")
    .withRegion("cn-shanghai")
    .withBucket("my-versioned-bucket")
    // ...
    .build();

try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
    client.download(
        new DownloadRequest.Builder()
            .withKey("my-key")
            .withCheckArchived(true)
            .build(),
        out);
} catch (ResourceNotFoundException e) {
    ArchiveInfo info = e.getArchiveInfo();
    if (info != null && info.isArchived()) {
        // Recover prior bytes via the version id OSS returned.
        String priorVersionId = info.getVersionId();
        // download(...) by versionId returns the original content.
    }
}
```

## Testing

- New unit tests in `AliBlobStoreTest`:
  - `testDoDownload_checkArchived_deletedOnVersionedBucket_throwsWithArchiveInfo` — positive case: delete-marker → `ArchiveInfo(archived=true, versionId=<prior>)`.
  - `testDoDownload_checkArchivedFalse_doesNotListVersionsOrChangeException` — guard is a complete no-op when the flag is off.
  - `testDoDownload_checkArchived_neverExisted_doesNotPopulateArchiveInfo` — 404 without the delete-marker header → original exception propagates, no `listObjectVersions` call.
- `mvn test -pl blob/blob-ali` — full Ali unit suite passes (191/191), checkstyle clean.
- Conformance tests `AliBlobStoreIT#testDownload_checkArchived` and `#testDownload_checkArchived_neverExisted` pass in replay mode against the recorded mappings.
