### PR TITLE
blobstore: populate objectLockInfo in BlobMetadata for Ali

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -336,7 +336,69 @@ public class AliTransformer {
         .createdTime(lastModified)
         .md5(HexUtil.convertToBytes(result.contentMd5()))
         .contentType(result.contentType())
+        .objectLockInfo(extractObjectLockInfo(result.headers()))
         .build();
+  }
+
+  /**
+   * OSS exposes per-object WORM (retention + legal hold) state on HeadObject as response headers
+   * (verified live against a versioned + WORM-enabled bucket): {@code x-oss-object-worm-mode},
+   * {@code x-oss-object-worm-retain-until-date} (ISO-8601), and
+   * {@code x-oss-object-worm-legal-hold} (value <code>"ON"</code>/absent). This single-call read
+   * avoids the latency of a follow-up {@code GetObjectRetention} + {@code GetObjectLegalHold}
+   * round-trip pair.
+   *
+   * @return an {@link ObjectLockInfo} when any of the three worm headers is present; otherwise
+   *     {@code null} so {@code BlobMetadata.objectLockInfo} stays unset on objects without lock
+   *     state.
+   */
+  private static ObjectLockInfo extractObjectLockInfo(Map<String, String> headers) {
+    if (headers == null || headers.isEmpty()) {
+      return null;
+    }
+    String wormMode = caseInsensitiveGet(headers, "x-oss-object-worm-mode");
+    String wormRetainUntil = caseInsensitiveGet(headers, "x-oss-object-worm-retain-until-date");
+    String wormLegalHold = caseInsensitiveGet(headers, "x-oss-object-worm-legal-hold");
+    if (wormMode == null && wormRetainUntil == null && wormLegalHold == null) {
+      return null;
+    }
+    RetentionMode mode = null;
+    if (wormMode != null) {
+      try {
+        mode = RetentionMode.valueOf(wormMode.toUpperCase(java.util.Locale.ROOT));
+      } catch (IllegalArgumentException ignored) {
+        // Unknown OSS worm-mode value — leave mode null rather than fail the metadata read.
+        mode = null;
+      }
+    }
+    Instant retainUntil = null;
+    if (wormRetainUntil != null) {
+      try {
+        retainUntil = Instant.parse(wormRetainUntil);
+      } catch (java.time.format.DateTimeParseException ignored) {
+        retainUntil = null;
+      }
+    }
+    boolean legalHold = "ON".equalsIgnoreCase(wormLegalHold);
+    return ObjectLockInfo.builder()
+        .mode(mode)
+        .retainUntilDate(retainUntil)
+        .legalHold(legalHold)
+        // useEventBasedHold left null — OSS has no event-based-hold concept.
+        .build();
+  }
+
+  private static String caseInsensitiveGet(Map<String, String> headers, String name) {
+    String exact = headers.get(name);
+    if (exact != null) {
+      return exact;
+    }
+    for (Map.Entry<String, String> e : headers.entrySet()) {
+      if (e.getKey() != null && e.getKey().equalsIgnoreCase(name)) {
+        return e.getValue();
+      }
+    }
+    return null;
   }
 
   private String stripQuotes(String value) {

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -853,4 +853,56 @@ public class AliTransformerTest {
     assertTrue(info.isLegalHold(),
         "legal-hold value comparison should be case-insensitive (\"on\" -> true)");
   }
+
+  @Test
+  void testToBlobMetadata_unknownWormMode_leavesModeNullBestEffort() {
+    // OSS returns a worm-mode value the SDK enum does not recognize. The read is best-effort and
+    // must not throw: objectLockInfo is still populated (the other worm headers are present),
+    // mode falls back to null, and the remaining fields are unaffected.
+    Map<String, String> headers =
+        Map.of(
+            "x-oss-object-worm-mode", "UNKNOWN_MODE",
+            "x-oss-object-worm-retain-until-date", "2026-06-10T23:49:51.000Z",
+            "x-oss-object-worm-legal-hold", "ON");
+    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
+        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+            .headers(headers)
+            .build();
+
+    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+        transformer.toBlobMetadata("k", result).getObjectLockInfo();
+
+    assertNotNull(info,
+        "objectLockInfo should still be populated when other worm headers are present");
+    assertNull(info.getMode(),
+        "an unrecognized worm-mode must fall back to null rather than throw");
+    assertEquals(Instant.parse("2026-06-10T23:49:51.000Z"), info.getRetainUntilDate());
+    assertTrue(info.isLegalHold());
+  }
+
+  @Test
+  void testToBlobMetadata_malformedRetainUntilDate_leavesRetainUntilNullBestEffort() {
+    // OSS returns a retain-until-date that is not valid ISO-8601. The read is best-effort and must
+    // not throw: objectLockInfo is still populated, retainUntilDate falls back to null, and the
+    // mode/legal-hold fields parse normally.
+    Map<String, String> headers =
+        Map.of(
+            "x-oss-object-worm-mode", "GOVERNANCE",
+            "x-oss-object-worm-retain-until-date", "not-a-valid-date",
+            "x-oss-object-worm-legal-hold", "ON");
+    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
+        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+            .headers(headers)
+            .build();
+
+    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+        transformer.toBlobMetadata("k", result).getObjectLockInfo();
+
+    assertNotNull(info);
+    assertEquals(
+        com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE, info.getMode());
+    assertNull(info.getRetainUntilDate(),
+        "an unparseable retain-until-date must fall back to null rather than throw");
+    assertTrue(info.isLegalHold());
+  }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -1,6 +1,7 @@
 package com.salesforce.multicloudj.blob.ali;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -736,5 +737,120 @@ public class AliTransformerTest {
     assertEquals(
         "RetryConfig.fixedDelayMillis must be greater than 0 for FIXED mode, got: 0",
         ex.getMessage());
+  }
+
+  // ---- toBlobMetadata: objectLockInfo extraction from x-oss-object-worm-* headers ----
+
+  @Test
+  void testToBlobMetadata_locked_populatesObjectLockInfoFromHeaders() {
+    // OSS surfaces object-lock state on HeadObject as response headers (verified live against
+    // a versioned + WORM-enabled bucket). The transformer must read those headers and build an
+    // ObjectLockInfo.
+    Map<String, String> headers =
+        Map.of(
+            "x-oss-object-worm-mode", "GOVERNANCE",
+            "x-oss-object-worm-retain-until-date", "2026-06-10T23:49:51.000Z",
+            "x-oss-object-worm-legal-hold", "ON");
+    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
+        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+            .headers(headers)
+            .build();
+
+    BlobMetadata metadata = transformer.toBlobMetadata("k", result);
+
+    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info = metadata.getObjectLockInfo();
+    assertNotNull(info, "objectLockInfo should be populated when worm headers are present");
+    assertEquals(
+        com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE, info.getMode());
+    assertEquals(Instant.parse("2026-06-10T23:49:51.000Z"), info.getRetainUntilDate());
+    assertTrue(info.isLegalHold());
+    // OSS has no event-based-hold concept; AWS leaves it null too.
+    assertNull(info.getUseEventBasedHold());
+  }
+
+  @Test
+  void testToBlobMetadata_complianceModeWithoutLegalHold_populatesPartial() {
+    // COMPLIANCE retention with no legal hold: legalHold should be false, mode COMPLIANCE.
+    Map<String, String> headers =
+        Map.of(
+            "x-oss-object-worm-mode", "COMPLIANCE",
+            "x-oss-object-worm-retain-until-date", "2030-01-01T00:00:00.000Z");
+    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
+        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+            .headers(headers)
+            .build();
+
+    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+        transformer.toBlobMetadata("k", result).getObjectLockInfo();
+
+    assertNotNull(info);
+    assertEquals(
+        com.salesforce.multicloudj.blob.driver.RetentionMode.COMPLIANCE, info.getMode());
+    assertEquals(Instant.parse("2030-01-01T00:00:00.000Z"), info.getRetainUntilDate());
+    assertFalse(info.isLegalHold());
+  }
+
+  @Test
+  void testToBlobMetadata_legalHoldOnlyWithoutRetention_populatesObjectLockInfo() {
+    // OSS allows legal hold without retention. The transformer must still surface
+    // objectLockInfo with mode=null and legalHold=true so callers can act on the hold.
+    Map<String, String> headers = Map.of("x-oss-object-worm-legal-hold", "ON");
+    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
+        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+            .headers(headers)
+            .build();
+
+    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+        transformer.toBlobMetadata("k", result).getObjectLockInfo();
+
+    assertNotNull(info,
+        "objectLockInfo should be populated even when only legal hold is set");
+    assertNull(info.getMode());
+    assertNull(info.getRetainUntilDate());
+    assertTrue(info.isLegalHold());
+  }
+
+  @Test
+  void testToBlobMetadata_noWormHeaders_objectLockInfoIsNull() {
+    // No worm-related headers on the response — objectLockInfo should remain null, matching
+    // the AWS guard ("extract object lock info if present").
+    Map<String, String> headers =
+        Map.of(
+            "Content-Type", "application/octet-stream",
+            "ETag", "\"abc\"",
+            "x-oss-storage-class", "Standard");
+    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
+        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+            .headers(headers)
+            .build();
+
+    BlobMetadata metadata = transformer.toBlobMetadata("k", result);
+
+    assertNull(metadata.getObjectLockInfo(),
+        "objectLockInfo should be null when no x-oss-object-worm-* headers are present");
+  }
+
+  @Test
+  void testToBlobMetadata_caseInsensitiveHeaderLookup() {
+    // OSS header casing is conventionally lowercase, but the SDK headers Map should not
+    // dictate behavior here. Use mixed casing to verify the lookup is case-insensitive.
+    Map<String, String> headers =
+        Map.of(
+            "X-OSS-Object-Worm-Mode", "GOVERNANCE",
+            "X-OSS-Object-Worm-Retain-Until-Date", "2026-06-10T23:49:51.000Z",
+            "X-OSS-Object-Worm-Legal-Hold", "on");
+    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
+        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+            .headers(headers)
+            .build();
+
+    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+        transformer.toBlobMetadata("k", result).getObjectLockInfo();
+
+    assertNotNull(info);
+    assertEquals(
+        com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE, info.getMode());
+    assertTrue(info.isLegalHold(),
+        "legal-hold value comparison should be case-insensitive (\"on\" -> true)");
   }
 }


### PR DESCRIPTION
## Summary

Populates `BlobMetadata.objectLockInfo` for the Ali OSS blob driver's `getMetadata()` path, bringing Ali to parity with AWS and GCP. Single-call read — no follow-up `GetObjectRetention` / `GetObjectLegalHold` round trips needed.

## Background

Alibaba OSS surfaces per-object WORM (retention + legal hold) state directly on `HeadObject` response headers. Verified live against a versioned + WORM-enabled bucket holding a GOVERNANCE-locked object with legal hold ON:

```
x-oss-object-worm-mode: GOVERNANCE
x-oss-object-worm-retain-until-date: 2026-06-10T23:49:51.000Z
x-oss-object-worm-legal-hold: ON
```

The cloud-agnostic `ObjectLockInfo` slot on `BlobMetadata` already exists and is populated by AWS (from typed `HeadObject` accessors) and GCP (from `Blob.getRetention()` + `getTemporaryHold()`/`getEventBasedHold()`). The Ali transformer was leaving it null.

## Changes

- `AliTransformer.toBlobMetadata(String, HeadObjectResult)` now reads the three `x-oss-object-worm-*` response headers (case-insensitive) and builds an `ObjectLockInfo` when any of them is present:
  - `mode` — `RetentionMode.valueOf(worm-mode)` (GOVERNANCE / COMPLIANCE)
  - `retainUntilDate` — `Instant.parse(worm-retain-until-date)` (the value is already ISO-8601)
  - `legalHold` — `"ON".equalsIgnoreCase(worm-legal-hold)`
  - `useEventBasedHold` is left null (OSS has no event-based-hold concept)
- New private helpers `extractObjectLockInfo(...)` and `caseInsensitiveGet(...)`. Returns silently (null `ObjectLockInfo`) when no worm headers are present, matching the "extract object lock info if present" guard used by the other providers.

## Testing

- `AliTransformerTest` — five new `toBlobMetadata` cases:
  - Full GOVERNANCE retention + legal hold → mode, retainUntilDate, and legalHold all populated; `useEventBasedHold` null.
  - COMPLIANCE retention without legal hold → mode COMPLIANCE, legalHold false.
  - Legal-hold-only without retention → `objectLockInfo` populated with `mode=null`, `retainUntilDate=null`, `legalHold=true`.
  - No worm headers → `objectLockInfo` stays null.
  - Case-insensitive header lookup (mixed casing on header keys + `"on"` value).
- `mvn test -pl blob/blob-ali` — full Ali unit suite passes (193/193); checkstyle clean.

## Notes

Sync only (matches AWS/GCP, which only populate `objectLockInfo` on the sync metadata path). No `-client` (cloud-agnostic) changes — the `ObjectLockInfo` type and the `BlobMetadata.objectLockInfo` slot already exist.
