### PR TITLE
blobstore: add getBucketVersioning() API across all providers

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -12,6 +12,8 @@ import com.aliyun.sdk.service.oss2.models.CopyObjectRequest;
 import com.aliyun.sdk.service.oss2.models.CopyObjectResult;
 import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
 import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
+import com.aliyun.sdk.service.oss2.models.GetBucketVersioningRequest;
+import com.aliyun.sdk.service.oss2.models.GetBucketVersioningResult;
 import com.aliyun.sdk.service.oss2.models.GetObjectLegalHoldResult;
 import com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest;
 import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
@@ -810,6 +812,29 @@ public class AliBlobStore extends AbstractBlobStore {
   @Override
   protected boolean doDoesBucketExist() {
     return ossClient.doesBucketExist(bucket);
+  }
+
+  @Override
+  protected com.salesforce.multicloudj.blob.driver.BucketVersioningStatus doGetBucketVersioning() {
+    GetBucketVersioningRequest request =
+        GetBucketVersioningRequest.newBuilder().bucket(bucket).build();
+    GetBucketVersioningResult result =
+        ossClient.getBucketVersioning(request, OperationOptions.defaults());
+    String status =
+        result.versioningConfiguration() != null
+            ? result.versioningConfiguration().status()
+            : null;
+    if (status == null || status.isEmpty()) {
+      return com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.UNSET;
+    }
+    switch (status) {
+      case "Enabled":
+        return com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.ENABLED;
+      case "Suspended":
+        return com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.SUSPENDED;
+      default:
+        return com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.UNSET;
+    }
   }
 
   @Override

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
@@ -64,6 +64,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.BucketVersioningStatus;
 import software.amazon.awssdk.services.s3.model.CommonPrefix;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
@@ -71,6 +72,7 @@ import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.GetBucketVersioningResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectLegalHoldResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
@@ -598,6 +600,24 @@ public class AwsBlobStore extends AbstractBlobStore {
         return false;
       }
       throw e;
+    }
+  }
+
+  @Override
+  protected com.salesforce.multicloudj.blob.driver.BucketVersioningStatus doGetBucketVersioning() {
+    GetBucketVersioningResponse response =
+        s3Client.getBucketVersioning(builder -> builder.bucket(bucket));
+    BucketVersioningStatus status = response.status();
+    if (status == null) {
+      return com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.UNSET;
+    }
+    switch (status) {
+      case ENABLED:
+        return com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.ENABLED;
+      case SUSPENDED:
+        return com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.SUSPENDED;
+      default:
+        return com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.UNSET;
     }
   }
 

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreTest.java
@@ -107,6 +107,7 @@ import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketVersioningResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectLegalHoldRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectLegalHoldResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -1440,6 +1441,50 @@ public class AwsBlobStoreTest {
 
     result = aws.doDoesBucketExist();
     assertFalse(result);
+  }
+
+  @Test
+  void testDoGetBucketVersioningEnabled() {
+    GetBucketVersioningResponse mockResponse = mock(GetBucketVersioningResponse.class);
+    when(mockResponse.status())
+        .thenReturn(software.amazon.awssdk.services.s3.model.BucketVersioningStatus.ENABLED);
+    when(mockS3Client.getBucketVersioning(
+            ArgumentMatchers.<Consumer<software.amazon.awssdk.services.s3.model
+                .GetBucketVersioningRequest.Builder>>any()))
+        .thenReturn(mockResponse);
+
+    com.salesforce.multicloudj.blob.driver.BucketVersioningStatus result =
+        aws.doGetBucketVersioning();
+    assertEquals(com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.ENABLED, result);
+  }
+
+  @Test
+  void testDoGetBucketVersioningSuspended() {
+    GetBucketVersioningResponse mockResponse = mock(GetBucketVersioningResponse.class);
+    when(mockResponse.status())
+        .thenReturn(software.amazon.awssdk.services.s3.model.BucketVersioningStatus.SUSPENDED);
+    when(mockS3Client.getBucketVersioning(
+            ArgumentMatchers.<Consumer<software.amazon.awssdk.services.s3.model
+                .GetBucketVersioningRequest.Builder>>any()))
+        .thenReturn(mockResponse);
+
+    com.salesforce.multicloudj.blob.driver.BucketVersioningStatus result =
+        aws.doGetBucketVersioning();
+    assertEquals(com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.SUSPENDED, result);
+  }
+
+  @Test
+  void testDoGetBucketVersioningUnset() {
+    GetBucketVersioningResponse mockResponse = mock(GetBucketVersioningResponse.class);
+    when(mockResponse.status()).thenReturn(null);
+    when(mockS3Client.getBucketVersioning(
+            ArgumentMatchers.<Consumer<software.amazon.awssdk.services.s3.model
+                .GetBucketVersioningRequest.Builder>>any()))
+        .thenReturn(mockResponse);
+
+    com.salesforce.multicloudj.blob.driver.BucketVersioningStatus result =
+        aws.doGetBucketVersioning();
+    assertEquals(com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.UNSET, result);
   }
 
   private S3Object mockObject(int index) {

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetbucketversioning-get-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetbucketversioning-get-0.json
@@ -1,0 +1,33 @@
+{
+  "id" : "4762477b-3f16-492d-ad4d-9e6bc88e8da2",
+  "name" : "AwsBlobStoreIT_testGetBucketVersioning-GET-0",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "versioning" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZlcnNpb25pbmdDb25maWd1cmF0aW9uIHhtbG5zPSJodHRwOi8vczMuYW1hem9uYXdzLmNvbS9kb2MvMjAwNi0wMy0wMS8iLz4=",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "FQ9R26RZXXAMWPJG",
+      "x-amz-id-2" : "QLaMDCT0Q9z1pRpqJmKBILUU1uQpT+3Bspi4uMvTaqoa3awAAH1eF4Qjw8kX1g33+hQJt1Q3asHVB+CmBGcDbZFdMq7+ksVX",
+      "Date" : "Wed, 10 Jun 2026 00:00:42 GMT"
+    }
+  },
+  "uuid" : "4762477b-3f16-492d-ad4d-9e6bc88e8da2",
+  "persistent" : true,
+  "insertionIndex" : 753
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetbucketversioning_versionedbucket-get-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetbucketversioning_versionedbucket-get-0.json
@@ -1,0 +1,33 @@
+{
+  "id" : "005070bf-ec73-411b-b195-5947977d5027",
+  "name" : "AwsBlobStoreIT_testGetBucketVersioning_VersionedBucket-GET-0",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "versioning" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPFZlcnNpb25pbmdDb25maWd1cmF0aW9uIHhtbG5zPSJodHRwOi8vczMuYW1hem9uYXdzLmNvbS9kb2MvMjAwNi0wMy0wMS8iPjxTdGF0dXM+RW5hYmxlZDwvU3RhdHVzPjwvVmVyc2lvbmluZ0NvbmZpZ3VyYXRpb24+",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "76JQTZB6KHVE4EXY",
+      "x-amz-id-2" : "tb1r+E350u0nb4OBPirK/HSM40pPssYh5dfHofNlQ3+XlF2CXdgM1CiFEEF718cLp6KRy/S5/Dt2wEEDxVjrQBwvc+4bYL1n",
+      "Date" : "Wed, 10 Jun 2026 00:00:45 GMT"
+    }
+  },
+  "uuid" : "005070bf-ec73-411b-b195-5947977d5027",
+  "persistent" : true,
+  "insertionIndex" : 755
+}

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
@@ -5,6 +5,7 @@ import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.BlobSpanNames;
+import com.salesforce.multicloudj.blob.driver.BucketVersioningStatus;
 import com.salesforce.multicloudj.blob.driver.ByteArray;
 import com.salesforce.multicloudj.blob.driver.CopyFromRequest;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
@@ -690,6 +691,30 @@ public class BucketClient implements AutoCloseable {
               }
             });
     return Boolean.TRUE.equals(result);
+  }
+
+  /**
+   * Retrieves the versioning configuration status of the bucket.
+   *
+   * @return the current {@link com.salesforce.multicloudj.blob.driver.BucketVersioningStatus} of
+   *     the bucket
+   * @throws SubstrateSdkException Thrown if the operation fails
+   * @throws UnsupportedOperationException Thrown when the configured provider does not support this
+   *     operation
+   */
+  public BucketVersioningStatus getBucketVersioning() {
+    return multiCloudJLogger.traceOperation(
+        BlobSpanNames.GET_BUCKET_VERSIONING,
+        bucketAttrs(),
+        null,
+        ctx -> {
+          try {
+            return blobStore.getBucketVersioning();
+          } catch (Throwable t) {
+            propagate(t);
+            return null;
+          }
+        });
   }
 
   /**

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStore.java
@@ -240,6 +240,12 @@ public abstract class AbstractBlobStore implements BlobStore, AutoCloseable {
 
   /** {@inheritDoc} */
   @Override
+  public BucketVersioningStatus getBucketVersioning() {
+    return doGetBucketVersioning();
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public DirectoryDownloadResponse downloadDirectory(
       DirectoryDownloadRequest directoryDownloadRequest) {
     validator.validate(directoryDownloadRequest);
@@ -357,6 +363,17 @@ public abstract class AbstractBlobStore implements BlobStore, AutoCloseable {
   protected abstract boolean doDoesObjectExist(String key, String versionId);
 
   protected abstract boolean doDoesBucketExist();
+
+  /**
+   * Provider hook for retrieving bucket versioning configuration.
+   *
+   * <p>Default implementation throws {@link UnsupportedOperationException}; providers opt in by
+   * overriding this method.
+   */
+  protected BucketVersioningStatus doGetBucketVersioning() {
+    throw new UnsupportedOperationException(
+        "Bucket versioning status retrieval is not supported by this substrate implementation");
+  }
 
   /**
    * Provider hook for {@link #updateObjectRetention(String, String, ObjectRetentionConfig)}.

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobSpanNames.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobSpanNames.java
@@ -27,6 +27,7 @@ public final class BlobSpanNames {
   public static final String GENERATE_PRESIGNED_URL = "blob.generatePresignedUrl";
   public static final String DOES_OBJECT_EXIST = "blob.doesObjectExist";
   public static final String DOES_BUCKET_EXIST = "blob.doesBucketExist";
+  public static final String GET_BUCKET_VERSIONING = "blob.getBucketVersioning";
 
   // Multipart operations.
   public static final String INITIATE_MULTIPART_UPLOAD = "blob.initiateMultipartUpload";

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobStore.java
@@ -267,6 +267,14 @@ public interface BlobStore extends SdkService, Provider {
   boolean doesBucketExist();
 
   /**
+   * Retrieves the versioning configuration status of the bucket.
+   *
+   * @return the current {@link BucketVersioningStatus} of the bucket
+   * @throws UnsupportedOperationException if the provider does not support this operation
+   */
+  BucketVersioningStatus getBucketVersioning();
+
+  /**
    * Downloads a directory from the blob store
    *
    * @param directoryDownloadRequest the directory download request

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BucketVersioningStatus.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BucketVersioningStatus.java
@@ -1,0 +1,24 @@
+package com.salesforce.multicloudj.blob.driver;
+
+/**
+ * Represents the versioning configuration status of a bucket.
+ *
+ * <p>Bucket versioning can be in one of three states:
+ *
+ * <ul>
+ *   <li>{@link #ENABLED} - Versioning is active; new object writes create version entries.
+ *   <li>{@link #SUSPENDED} - Versioning was previously enabled but is now paused; existing versions
+ *       are preserved but new writes do not create version entries.
+ *   <li>{@link #UNSET} - Versioning has never been enabled on this bucket.
+ * </ul>
+ */
+public enum BucketVersioningStatus {
+  /** Versioning is active on the bucket. */
+  ENABLED,
+
+  /** Versioning was previously enabled but is now suspended. */
+  SUSPENDED,
+
+  /** Versioning has never been enabled on the bucket. */
+  UNSET
+}

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -4217,6 +4217,30 @@ public abstract class AbstractBlobStoreIT {
     Assertions.assertFalse(bucketClient.doesBucketExist());
   }
 
+  @Test
+  void testGetBucketVersioning() {
+    // Test with a valid bucket - should return a non-null versioning status
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    com.salesforce.multicloudj.blob.driver.BucketVersioningStatus status =
+        bucketClient.getBucketVersioning();
+    Assertions.assertNotNull(status);
+    // The unversioned test bucket should report either UNSET or SUSPENDED
+    Assertions.assertNotEquals(
+        com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.ENABLED, status);
+  }
+
+  @Test
+  void testGetBucketVersioning_VersionedBucket() {
+    // Test with a versioned bucket - should return ENABLED
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    com.salesforce.multicloudj.blob.driver.BucketVersioningStatus status =
+        bucketClient.getBucketVersioning();
+    Assertions.assertEquals(
+        com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.ENABLED, status);
+  }
+
   /**
    * Helper function for uploading to a presignedUrl
    */

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -4235,8 +4235,9 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   void testGetBucketVersioning_VersionedBucket() {
-    // Ali WireMock mappings not yet recorded — skip until cassettes are available
+    // Ali and GCP WireMock mappings not yet recorded — skip until cassettes are available
     Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
+    Assumptions.assumeFalse(GCP_PROVIDER_ID.equals(harness.getProviderId()));
     // Test with a versioned bucket - should return ENABLED
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
     BucketClient bucketClient = new BucketClient(blobStore);

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -4219,6 +4219,8 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   void testGetBucketVersioning() {
+    // Ali WireMock mappings not yet recorded — skip until cassettes are available
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     // Test with a valid bucket - should return a non-null versioning status
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
     BucketClient bucketClient = new BucketClient(blobStore);
@@ -4232,6 +4234,8 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   void testGetBucketVersioning_VersionedBucket() {
+    // Ali WireMock mappings not yet recorded — skip until cassettes are available
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     // Test with a versioned bucket - should return ENABLED
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
     BucketClient bucketClient = new BucketClient(blobStore);

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -968,6 +968,21 @@ public class GcpBlobStore extends AbstractBlobStore {
     }
   }
 
+  @Override
+  protected com.salesforce.multicloudj.blob.driver.BucketVersioningStatus doGetBucketVersioning() {
+    Bucket bucketObj = storage.get(bucket);
+    if (bucketObj == null) {
+      throw new SubstrateSdkException("Bucket not found: " + bucket);
+    }
+    Boolean versioningEnabled = bucketObj.versioningEnabled();
+    if (versioningEnabled == null) {
+      return com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.UNSET;
+    }
+    return versioningEnabled
+        ? com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.ENABLED
+        : com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.SUSPENDED;
+  }
+
   /**
    * Maximum number of objects that can be deleted in a single batch operation. GCP supports up to
    * 1000 objects per batch delete.

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -1538,6 +1538,67 @@ class GcpBlobStoreTest {
   }
 
   @Test
+  void testDoGetBucketVersioning_Enabled() {
+    // Given
+    Bucket mockBucket = mock(Bucket.class);
+    when(mockBucket.versioningEnabled()).thenReturn(Boolean.TRUE);
+    when(mockStorage.get(TEST_BUCKET)).thenReturn(mockBucket);
+
+    // When
+    com.salesforce.multicloudj.blob.driver.BucketVersioningStatus result =
+        gcpBlobStore.doGetBucketVersioning();
+
+    // Then
+    assertEquals(
+        com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.ENABLED, result);
+    verify(mockStorage).get(TEST_BUCKET);
+  }
+
+  @Test
+  void testDoGetBucketVersioning_Suspended() {
+    // Given
+    Bucket mockBucket = mock(Bucket.class);
+    when(mockBucket.versioningEnabled()).thenReturn(Boolean.FALSE);
+    when(mockStorage.get(TEST_BUCKET)).thenReturn(mockBucket);
+
+    // When
+    com.salesforce.multicloudj.blob.driver.BucketVersioningStatus result =
+        gcpBlobStore.doGetBucketVersioning();
+
+    // Then
+    assertEquals(
+        com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.SUSPENDED, result);
+    verify(mockStorage).get(TEST_BUCKET);
+  }
+
+  @Test
+  void testDoGetBucketVersioning_Unset() {
+    // Given
+    Bucket mockBucket = mock(Bucket.class);
+    when(mockBucket.versioningEnabled()).thenReturn(null);
+    when(mockStorage.get(TEST_BUCKET)).thenReturn(mockBucket);
+
+    // When
+    com.salesforce.multicloudj.blob.driver.BucketVersioningStatus result =
+        gcpBlobStore.doGetBucketVersioning();
+
+    // Then
+    assertEquals(
+        com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.UNSET, result);
+    verify(mockStorage).get(TEST_BUCKET);
+  }
+
+  @Test
+  void testDoGetBucketVersioning_BucketNotFound() {
+    // Given
+    when(mockStorage.get(TEST_BUCKET)).thenReturn(null);
+
+    // When/Then
+    assertThrows(SubstrateSdkException.class, () -> gcpBlobStore.doGetBucketVersioning());
+    verify(mockStorage).get(TEST_BUCKET);
+  }
+
+  @Test
   void testGetException_WithSubstrateSdkException() {
     // Given
     SubstrateSdkException testException = new SubstrateSdkException("Test");

--- a/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
+++ b/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
@@ -875,6 +875,12 @@ public class InMemoryBlobStore extends AbstractBlobStore {
   }
 
   @Override
+  protected com.salesforce.multicloudj.blob.driver.BucketVersioningStatus doGetBucketVersioning() {
+    // In-memory implementation always reports versioning as UNSET
+    return com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.UNSET;
+  }
+
+  @Override
   public void close() {
     // Nothing to close for in-memory implementation
   }

--- a/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
+++ b/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
@@ -895,7 +895,10 @@ public class InMemoryBlobStore extends AbstractBlobStore {
 
   @Override
   protected com.salesforce.multicloudj.blob.driver.BucketVersioningStatus doGetBucketVersioning() {
-    // In-memory implementation always reports versioning as UNSET
+    BucketMetadata metadata = BUCKETS.get(bucket);
+    if (metadata != null && metadata.isVersioningEnabled()) {
+      return com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.ENABLED;
+    }
     return com.salesforce.multicloudj.blob.driver.BucketVersioningStatus.UNSET;
   }
 
@@ -1146,9 +1149,15 @@ public class InMemoryBlobStore extends AbstractBlobStore {
   @Getter
   static class BucketMetadata {
     private final Instant creationDate;
+    private final boolean versioningEnabled;
 
     public BucketMetadata(Instant creationDate) {
+      this(creationDate, false);
+    }
+
+    public BucketMetadata(Instant creationDate, boolean versioningEnabled) {
       this.creationDate = creationDate;
+      this.versioningEnabled = versioningEnabled;
     }
   }
 
@@ -1240,6 +1249,16 @@ public class InMemoryBlobStore extends AbstractBlobStore {
    */
   public static void createBucket(String bucketName) {
     BUCKETS.putIfAbsent(bucketName, new BucketMetadata(Instant.now()));
+  }
+
+  /**
+   * Creates a bucket for testing purposes with optional versioning.
+   *
+   * @param bucketName the name of the bucket to create
+   * @param versioningEnabled whether versioning should be enabled on the bucket
+   */
+  public static void createBucket(String bucketName, boolean versioningEnabled) {
+    BUCKETS.putIfAbsent(bucketName, new BucketMetadata(Instant.now(), versioningEnabled));
   }
 
   /** Clears all in-memory storage including buckets, blobs, tags, and multipart uploads. */

--- a/blob/blob-inmemory/src/test/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStoreIT.java
+++ b/blob/blob-inmemory/src/test/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStoreIT.java
@@ -51,7 +51,7 @@ public class InMemoryBlobStoreIT extends AbstractBlobStoreIT {
 
       // Create the bucket if it should exist
       if (useValidBucket) {
-        InMemoryBlobStore.createBucket(bucketNameToUse);
+        InMemoryBlobStore.createBucket(bucketNameToUse, useVersionedBucket);
       }
 
       return new InMemoryBlobStore.Builder().withBucket(bucketNameToUse).withRegion(region).build();


### PR DESCRIPTION
## Summary
- Adds `getBucketVersioning()` API to `BucketClient`, returning a `BucketVersioningStatus` enum (`ENABLED`, `SUSPENDED`, `UNSET`)
- Implemented across all providers: AWS (S3), GCP (GCS), Alibaba Cloud (OSS), and InMemory
- Follows existing template method pattern (`doGetBucketVersioning()` with default `UnsupportedOperationException`)

## Motivation
Closes TD: https://gus.lightning.force.com/lightning/r/ADM_Team_Dependency__c/a0nEE000001HJbxYAG/view

The seas-s3 team needs to port FIT tests from raw AWS S3 SDK to multicloudj for cross-cloud portability (W-22392014). Their versioning assertion—verifying buckets have versioning disabled as an infra/compliance invariant—cannot currently be expressed through the SDK, leaving a GCP coverage gap.

## Changes
| Layer | File | Change |
|-------|------|--------|
| Enum | `BucketVersioningStatus.java` | New: `ENABLED`, `SUSPENDED`, `UNSET` |
| Interface | `BlobStore.java` | Added `getBucketVersioning()` |
| Abstract | `AbstractBlobStore.java` | Added `doGetBucketVersioning()` with opt-in default |
| Tracing | `BlobSpanNames.java` | Added `GET_BUCKET_VERSIONING` constant |
| Client | `BucketClient.java` | Added public API with tracing wrapper |
| AWS | `AwsBlobStore.java` | `s3Client.getBucketVersioning()` → status mapping |
| GCP | `GcpBlobStore.java` | `storage.get(bucket).versioningEnabled()` → status mapping |
| Ali | `AliBlobStore.java` | `ossClient.getBucketVersioning()` → status mapping |
| InMemory | `InMemoryBlobStore.java` | Returns `UNSET` |

## API Example
```java
BucketClient client = BucketClient.builder("aws")
    .withBucket("my-bucket")
    .withRegion("us-west-2")
    .build();

BucketVersioningStatus status = client.getBucketVersioning();
assertNotEquals(BucketVersioningStatus.ENABLED, status); // compliance check
```

## Cross-Provider Semantic Mapping
| SDK Enum | AWS | GCP | Ali |
|----------|-----|-----|-----|
| `ENABLED` | `Status.ENABLED` | `true` | `"Enabled"` |
| `SUSPENDED` | `Status.SUSPENDED` | `false` | `"Suspended"` |
| `UNSET` | `null` | `null` | `null/empty` |

## Testing
- **AWS unit tests**: 3 tests (ENABLED, SUSPENDED, UNSET) — ✅ passing
- **AWS conformance tests**: record + replay mode — ✅ passing
- **GCP unit tests**: 4 tests (ENABLED, SUSPENDED, UNSET, BucketNotFound) — written (pre-existing test compile issues in GCP module block execution; GCP main source compiles cleanly)
- **Conformance tests**: Added to `AbstractBlobStoreIT` for both versioned and unversioned buckets
- **GCP WireMock recordings**: Pending — pre-existing test compilation failures in `blob-gcp` module prevent running record mode (unrelated to this PR)

## Test plan
- [x] AWS unit tests pass locally
- [x] AWS conformance tests pass in record mode
- [x] AWS conformance tests pass in replay mode (no credentials)
- [x] No credentials leaked in WireMock recording files
- [x] Checkstyle passes for all modified modules
- [ ] GCP conformance test recording (blocked by pre-existing test compile failures in blob-gcp)
- [ ] Ali conformance test recording (done on dedicated machines)