### PR TITLE
blobstore: honor contentDisposition on Ali OSS presigned download URLs

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -642,10 +642,18 @@ public class AliTransformer {
 
   public GetObjectRequest toPresignedGetObjectRequest(
       PresignedUrlRequest request) {
-    return GetObjectRequest.newBuilder()
-        .bucket(bucket)
-        .key(request.getKey())
-        .build();
+    GetObjectRequest.Builder builder =
+        GetObjectRequest.newBuilder()
+            .bucket(bucket)
+            .key(request.getKey());
+
+    // OSS treats responseContentDisposition as a response-header override that is folded into the
+    // signed presigned URL; on download OSS returns it as the Content-Disposition response header.
+    if (StringUtils.isNotEmpty(request.getContentDisposition())) {
+      builder.responseContentDisposition(request.getContentDisposition());
+    }
+
+    return builder.build();
   }
 
   public PresignOptions toPresignOptions(

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -589,6 +589,42 @@ public class AliTransformerTest {
 
     assertEquals(BUCKET, actual.bucket());
     assertEquals("object-1", actual.key());
+    assertNull(actual.responseContentDisposition());
+  }
+
+  @Test
+  void testToPresignedGetObjectRequest_withContentDisposition() {
+    PresignedUrlRequest presignedDownloadRequest =
+        PresignedUrlRequest.builder()
+            .type(PresignedOperation.DOWNLOAD)
+            .key("object-1")
+            .duration(Duration.ofHours(12))
+            .contentDisposition("attachment; filename=\"report.pdf\"")
+            .build();
+
+    var actual = transformer.toPresignedGetObjectRequest(presignedDownloadRequest);
+
+    assertEquals(BUCKET, actual.bucket());
+    assertEquals("object-1", actual.key());
+    assertEquals(
+        "attachment; filename=\"report.pdf\"", actual.responseContentDisposition());
+  }
+
+  @Test
+  void testToPresignedPutObjectRequest_ignoresContentDisposition() {
+    PresignedUrlRequest presignedUploadRequest =
+        PresignedUrlRequest.builder()
+            .type(PresignedOperation.UPLOAD)
+            .key("object-1")
+            .duration(Duration.ofHours(12))
+            .contentDisposition("attachment; filename=\"report.pdf\"")
+            .build();
+
+    var actual = transformer.toPresignedPutObjectRequest(presignedUploadRequest);
+
+    assertEquals(BUCKET, actual.bucket());
+    assertEquals("object-1", actual.key());
+    assertNull(actual.contentDisposition());
   }
 
   @Test


### PR DESCRIPTION
## Summary
The Ali OSS blob driver ignored a caller-supplied `Content-Disposition` override on
presigned download URLs. `AliTransformer.toPresignedGetObjectRequest` set only bucket
and key, so the `contentDisposition` carried on `PresignedUrlRequest` was silently
dropped — while AWS and GCP both honor it.

## Changes
- `AliTransformer.toPresignedGetObjectRequest` now wires `request.getContentDisposition()`
  to the OSS SDK's `GetObjectRequest.Builder.responseContentDisposition(...)`, which the
  SDK folds into the signed presigned URL; OSS returns it as the `Content-Disposition`
  response header on download.
- Added `AliTransformerTest` coverage: the GET presign path sets the override, and the
  PUT presign path ignores it.

## Testing
- `mvn test -pl blob/blob-ali` — all unit tests pass; `AliBlobStoreIT` passes in replay mode.
- No new conformance test / WireMock recordings: this capability is covered at the
  provider transformer-unit level (matching the existing AWS/GCP unit-test coverage), so
  the change stays scoped to the Ali module with no cross-provider recording impact.

## Cross-Cloud Compatibility
- AWS: already wires `responseContentDisposition` on the presign GET request.
- GCP: already signs `response-content-disposition` as a query parameter (download only).
- Alibaba: now at parity via the OSS SDK's native `responseContentDisposition`.