### PR TITLE
blobstore: honor useKmsManagedKey on Ali OSS upload

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -127,6 +127,9 @@ public class AliTransformer {
     if (StringUtils.isNotEmpty(uploadRequest.getKmsKeyId())) {
       builder.serverSideEncryption(SERVER_SIDE_ENCRYPTION_KMS);
       builder.serverSideEncryptionKeyId(uploadRequest.getKmsKeyId());
+    } else if (uploadRequest.isUseKmsManagedKey()) {
+      // SSE-KMS with no caller-supplied CMK: OSS encrypts with its default managed CMK.
+      builder.serverSideEncryption(SERVER_SIDE_ENCRYPTION_KMS);
     }
 
     if (StringUtils.isNotEmpty(uploadRequest.getChecksumValue())) {
@@ -469,6 +472,9 @@ public class AliTransformer {
     if (StringUtils.isNotEmpty(request.getKmsKeyId())) {
       builder.serverSideEncryption(SERVER_SIDE_ENCRYPTION_KMS);
       builder.serverSideEncryptionKeyId(request.getKmsKeyId());
+    } else if (request.isUseKmsManagedKey()) {
+      // SSE-KMS with no caller-supplied CMK: OSS encrypts with its default managed CMK.
+      builder.serverSideEncryption(SERVER_SIDE_ENCRYPTION_KMS);
     }
 
     if (StringUtils.isNotEmpty(request.getContentType())) {

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -99,6 +99,37 @@ public class AliTransformerTest {
   }
 
   @Test
+  void testToPutObjectRequest_useKmsManagedKey_setsKmsWithoutKeyId() {
+    var request =
+        UploadRequest.builder().withKey("some-key").withUseKmsManagedKey(true).build();
+    com.aliyun.sdk.service.oss2.transport.BinaryData body =
+        com.aliyun.sdk.service.oss2.transport.BinaryData.fromBytes("data".getBytes());
+
+    var actual = transformer.toPutObjectRequest(request, body);
+
+    assertEquals("KMS", actual.serverSideEncryption());
+    assertNull(actual.serverSideEncryptionKeyId());
+  }
+
+  @Test
+  void testToPutObjectRequest_explicitKmsKeyIdTakesPrecedenceOverManagedKey() {
+    var kmsKeyId = "alias/my-kms-key";
+    var request =
+        UploadRequest.builder()
+            .withKey("some-key")
+            .withKmsKeyId(kmsKeyId)
+            .withUseKmsManagedKey(true)
+            .build();
+    com.aliyun.sdk.service.oss2.transport.BinaryData body =
+        com.aliyun.sdk.service.oss2.transport.BinaryData.fromBytes("data".getBytes());
+
+    var actual = transformer.toPutObjectRequest(request, body);
+
+    assertEquals("KMS", actual.serverSideEncryption());
+    assertEquals(kmsKeyId, actual.serverSideEncryptionKeyId());
+  }
+
+  @Test
   void testToUploadResponse() {
     UploadRequest request =
         UploadRequest.builder()
@@ -215,6 +246,33 @@ public class AliTransformerTest {
     assertEquals(BUCKET, actual.bucket());
     assertEquals("key", actual.key());
     assertEquals(metadata, actual.metadata());
+  }
+
+  @Test
+  void testToInitiateMultipartUploadRequest_useKmsManagedKey_setsKmsWithoutKeyId() {
+    MultipartUploadRequest request =
+        new MultipartUploadRequest.Builder().withKey("key").withUseKmsManagedKey(true).build();
+
+    var actual = transformer.toInitiateMultipartUploadRequest(request);
+
+    assertEquals("KMS", actual.serverSideEncryption());
+    assertNull(actual.serverSideEncryptionKeyId());
+  }
+
+  @Test
+  void testToInitiateMultipartUploadRequest_explicitKmsKeyIdTakesPrecedenceOverManagedKey() {
+    String kmsKeyId = "alias/my-kms-key";
+    MultipartUploadRequest request =
+        new MultipartUploadRequest.Builder()
+            .withKey("key")
+            .withKmsKeyId(kmsKeyId)
+            .withUseKmsManagedKey(true)
+            .build();
+
+    var actual = transformer.toInitiateMultipartUploadRequest(request);
+
+    assertEquals("KMS", actual.serverSideEncryption());
+    assertEquals(kmsKeyId, actual.serverSideEncryptionKeyId());
   }
 
   @Test


### PR DESCRIPTION
## Summary
When `useKmsManagedKey=true` is set without an explicit `kmsKeyId`, the Ali OSS
driver emitted no server-side-encryption headers, so the object was not
KMS-encrypted. AWS honors this flag (SSE-KMS with no key id). This wires the same
behavior into Ali.

## Changes
- `AliTransformer.toPutObjectRequest` and `toInitiateMultipartUploadRequest` now set
  `x-oss-server-side-encryption: KMS` with no key id when `useKmsManagedKey=true`
  and no explicit `kmsKeyId` is given, so OSS encrypts with its default managed CMK.
  An explicit `kmsKeyId` still takes precedence.
- Added `AliTransformerTest` coverage for single-PUT and multipart-init.

## Testing
- `mvn test -pl blob/blob-ali` — all unit tests pass; `AliBlobStoreIT` passes in replay mode.
- OSS's default-managed-CMK behavior for `SSE=KMS` with no key id was verified
  empirically (PUT returns 200; HEAD shows an OSS-assigned CMK on the object).
- No new conformance tests / WireMock recordings: covered at the transformer-unit
  level (matching the existing AWS/GCP unit-test coverage), keeping the change
  scoped to the Ali module.

## Cross-Cloud Compatibility
- AWS: honors `useKmsManagedKey` (SSE-KMS with no key id).
- GCP: N/A — GCS uses bucket-level default KMS, no per-request managed-key flag.
- Alibaba: now at parity via the OSS SDK (SSE-KMS with default managed CMK).

## Note
- Correlation-ID-on-upload (originally part of this branch) has been split out to a
  separate change while pending work in that area settles.