### PR TITLE
blobstore: wire socketTimeout into the Ali OSS sync client builder

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -75,6 +75,7 @@ import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.common.provider.Provider;
+import com.salesforce.multicloudj.common.retries.RetryConfig;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -998,13 +999,28 @@ public class AliBlobStore extends AbstractBlobStore {
         if (retryer != null) {
           clientBuilder.retryer(retryer);
         }
-        if (builder.getRetryConfig().getAttemptTimeout() != null) {
-          clientBuilder.readWriteTimeout(
-              Duration.ofMillis(builder.getRetryConfig().getAttemptTimeout()));
-        }
+      }
+
+      Duration readWriteTimeout =
+          resolveReadWriteTimeout(builder.getRetryConfig(), builder.getSocketTimeout());
+      if (readWriteTimeout != null) {
+        clientBuilder.readWriteTimeout(readWriteTimeout);
       }
 
       return clientBuilder.build();
+    }
+
+    /**
+     * Resolves the value for the Ali SDK's single {@code readWriteTimeout} setting from the two
+     * MultiCloudJ inputs that map onto it. {@code RetryConfig.attemptTimeout} (the more specific
+     * per-attempt deadline) takes precedence over the transport-level {@code socketTimeout}; if
+     * neither is set, returns {@code null} so the SDK default is left in place.
+     */
+    static Duration resolveReadWriteTimeout(RetryConfig retryConfig, Duration socketTimeout) {
+      if (retryConfig != null && retryConfig.getAttemptTimeout() != null) {
+        return Duration.ofMillis(retryConfig.getAttemptTimeout());
+      }
+      return socketTimeout;
     }
 
     @Override

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -49,6 +49,7 @@ import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
 import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
+import com.salesforce.multicloudj.common.retries.RetryConfig;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.CredentialsType;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
@@ -1961,5 +1962,43 @@ public class AliBlobStoreTest {
     assertNotNull(info);
     assertTrue(info.isArchived());
     assertEquals(priorVersionId, info.getVersionId());
+  }
+
+  @Test
+  void testResolveReadWriteTimeout_socketTimeoutOnly() {
+    Duration socketTimeout = Duration.ofSeconds(30);
+    assertEquals(
+        socketTimeout, AliBlobStore.Builder.resolveReadWriteTimeout(null, socketTimeout));
+  }
+
+  @Test
+  void testResolveReadWriteTimeout_attemptTimeoutTakesPrecedence() {
+    RetryConfig retryConfig = RetryConfig.builder().attemptTimeout(3000L).build();
+    Duration socketTimeout = Duration.ofSeconds(30);
+    assertEquals(
+        Duration.ofMillis(3000L),
+        AliBlobStore.Builder.resolveReadWriteTimeout(retryConfig, socketTimeout));
+  }
+
+  @Test
+  void testResolveReadWriteTimeout_attemptTimeoutOnly() {
+    RetryConfig retryConfig = RetryConfig.builder().attemptTimeout(3000L).build();
+    assertEquals(
+        Duration.ofMillis(3000L),
+        AliBlobStore.Builder.resolveReadWriteTimeout(retryConfig, null));
+  }
+
+  @Test
+  void testResolveReadWriteTimeout_neitherSet_returnsNull() {
+    assertNull(AliBlobStore.Builder.resolveReadWriteTimeout(null, null));
+  }
+
+  @Test
+  void testResolveReadWriteTimeout_retryConfigWithoutAttemptTimeout_fallsBackToSocketTimeout() {
+    RetryConfig retryConfig = RetryConfig.builder().maxAttempts(5).build();
+    Duration socketTimeout = Duration.ofSeconds(30);
+    assertEquals(
+        socketTimeout,
+        AliBlobStore.Builder.resolveReadWriteTimeout(retryConfig, socketTimeout));
   }
 }


### PR DESCRIPTION
## Summary
The Ali OSS sync client builder only set the SDK's `readWriteTimeout` from `RetryConfig.attemptTimeout`, so a caller-supplied `socketTimeout` was dropped on the sync path. The async store already honors it, and AWS and GCP wire `socketTimeout` on both their sync and async clients — only the Ali sync builder was missing it.

## Changes
- Extracted the timeout resolution into a testable helper `resolveReadWriteTimeout(retryConfig, socketTimeout)`: `attemptTimeout` (the more specific per-attempt deadline) takes precedence, else fall back to `socketTimeout`, else leave the SDK default.
- `buildOSSClient` now applies the resolved value, so `socketTimeout` reaches the sync client — matching the async store and AWS/GCP behavior.
- Added `AliBlobStoreTest` coverage for the resolution helper.

## Note
OSS exposes a single `readWriteTimeout` setting onto which both `socketTimeout` and `attemptTimeout` map, so the two cannot be honored independently the way AWS/GCP can (which have a dedicated socket timeout separate from the API-call/attempt timeout). Precedence resolves the conflict.

## Testing
- `mvn test -pl blob/blob-ali` — all unit tests pass; `AliBlobStoreIT` passes in replay mode.
- No new conformance tests / WireMock recordings: the resolution logic is covered by unit tests on the extracted helper (the built OSS client is opaque and the builder path is credential-gated), keeping the change scoped to the Ali module.

## Cross-Cloud Compatibility
- AWS: wires `socketTimeout` on both sync and async clients.
- GCP: wires `socketTimeout` on both sync and async clients.
- Alibaba: sync client now honors `socketTimeout` (async already did).