### PR TITLE
blobstore: enable testCopy and testCopyFrom conformance tests for Ali

### DIFF
--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
@@ -31,6 +31,12 @@ public class AliBlobStoreIT extends AbstractBlobStoreIT {
   private static final String nonExistentBucketName = "java-bucket-does-not-exist";
   private static final String region = "cn-shanghai";
 
+  /**
+   * OSS sends this header only on copy operations (never on a plain upload PUT). Captured as a
+   * recording match header to disambiguate copy-PUT vs upload-PUT to the same key.
+   */
+  private static final String OSS_COPY_SOURCE_HEADER = "x-oss-copy-source";
+
   @Override
   protected Harness createHarness() {
     return new HarnessImpl();
@@ -167,11 +173,10 @@ public class AliBlobStoreIT extends AbstractBlobStoreIT {
 
     @Override
     public java.util.List<String> getRecordingCaptureHeaders() {
-      // x-oss-copy-source is sent only on copy operations (never on a plain upload PUT), so
-      // capturing it as a stub matcher disambiguates copy-PUT vs upload-PUT to the same key,
-      // and distinguishes multiple copies to the same key by their differing source value.
-      // Inert for non-copy requests (header absent -> no matcher added).
-      return java.util.List.of("Host", "x-oss-copy-source");
+      // OSS_COPY_SOURCE_HEADER disambiguates copy-PUT vs upload-PUT to the same key, and
+      // distinguishes multiple copies to the same key by their differing source value. Inert
+      // for non-copy requests (header absent -> no matcher added).
+      return java.util.List.of("Host", OSS_COPY_SOURCE_HEADER);
     }
 
     @Override

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
@@ -167,7 +167,11 @@ public class AliBlobStoreIT extends AbstractBlobStoreIT {
 
     @Override
     public java.util.List<String> getRecordingCaptureHeaders() {
-      return java.util.List.of("Host");
+      // x-oss-copy-source is sent only on copy operations (never on a plain upload PUT), so
+      // capturing it as a stub matcher disambiguates copy-PUT vs upload-PUT to the same key,
+      // and distinguishes multiple copies to the same key by their differing source value.
+      // Inert for non-copy requests (header absent -> no matcher added).
+      return java.util.List.of("Host", "x-oss-copy-source");
     }
 
     @Override

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "4084e211-5bd1-4ed6-83ff-8449a664bb5c",
+  "name" : "AliBlobStoreIT_testCopy-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/clobbered-blob",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA094A9D9839384AE65B",
+      "x-oss-server-time" : "52",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:03:05 GMT"
+    }
+  },
+  "uuid" : "4084e211-5bd1-4ed6-83ff-8449a664bb5c",
+  "persistent" : true,
+  "insertionIndex" : 44
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-delete-1.json
@@ -1,0 +1,25 @@
+{
+  "id" : "4132e139-26e0-4c8e-bcec-9e63816dcc74",
+  "name" : "AliBlobStoreIT_testCopy-DELETE-1",
+  "request" : {
+    "url" : "/conformance-tests/copied-blob",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA0802657933325B2D2A",
+      "x-oss-server-time" : "44",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:03:04 GMT"
+    }
+  },
+  "uuid" : "4132e139-26e0-4c8e-bcec-9e63816dcc74",
+  "persistent" : true,
+  "insertionIndex" : 45
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-delete-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-delete-2.json
@@ -1,0 +1,25 @@
+{
+  "id" : "5f33d2d9-2284-4c72-bfdd-61320179f8f5",
+  "name" : "AliBlobStoreIT_testCopy-DELETE-2",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-copying",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA07F40CB63439B46539",
+      "x-oss-server-time" : "57",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:03:03 GMT"
+    }
+  },
+  "uuid" : "5f33d2d9-2284-4c72-bfdd-61320179f8f5",
+  "persistent" : true,
+  "insertionIndex" : 46
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-get-12.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-get-12.json
@@ -1,0 +1,36 @@
+{
+  "id" : "5fd10803-6b00-499d-8f23-501c7b979dc6",
+  "name" : "AliBlobStoreIT_testCopy-GET-12",
+  "request" : {
+    "url" : "/conformance-tests/copied-blob",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "UGxlYXNlIGNvcHkgdGhpcyBkYXRhIQ==",
+    "headers" : {
+      "x-oss-request-id" : "6A31B9FF982AE93731D761A5",
+      "x-oss-server-time" : "54",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:02:52 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:02:55 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "5fd10803-6b00-499d-8f23-501c7b979dc6",
+  "persistent" : true,
+  "insertionIndex" : 56
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-get-13.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-get-13.json
@@ -1,0 +1,39 @@
+{
+  "id" : "3c4a969d-504e-436c-a5df-f0f371cfb4ac",
+  "name" : "AliBlobStoreIT_testCopy-GET-13",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-copying",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "UGxlYXNlIGNvcHkgdGhpcyBkYXRhIQ==",
+    "headers" : {
+      "x-oss-request-id" : "6A31B9FE9A6FD3383520A301",
+      "x-oss-server-time" : "47",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:02:52 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:02:54 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "3c4a969d-504e-436c-a5df-f0f371cfb4ac",
+  "persistent" : true,
+  "scenarioName" : "scenario-3-conformance-tests-blob-for-copying",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-3-conformance-tests-blob-for-copying-2",
+  "insertionIndex" : 57
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-get-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-get-5.json
@@ -1,0 +1,36 @@
+{
+  "id" : "da549cfc-8f98-4079-b40e-0cd5d83f006b",
+  "name" : "AliBlobStoreIT_testCopy-GET-5",
+  "request" : {
+    "url" : "/conformance-tests/clobbered-blob",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "UGxlYXNlIGNvcHkgdGhpcyBkYXRhIQ==",
+    "headers" : {
+      "x-oss-request-id" : "6A31BA0526F4193839A1FB0F",
+      "x-oss-server-time" : "3",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:02:58 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:01 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "da549cfc-8f98-4079-b40e-0cd5d83f006b",
+  "persistent" : true,
+  "insertionIndex" : 49
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-get-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-get-6.json
@@ -1,0 +1,38 @@
+{
+  "id" : "0a4d234b-d82b-4769-8fc4-51b70dc606ab",
+  "name" : "AliBlobStoreIT_testCopy-GET-6",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-copying",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "UGxlYXNlIGNvcHkgdGhpcyBkYXRhIQ==",
+    "headers" : {
+      "x-oss-request-id" : "6A31BA048D81BD37392ADDB9",
+      "x-oss-server-time" : "38",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:02:52 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:00 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "0a4d234b-d82b-4769-8fc4-51b70dc606ab",
+  "persistent" : true,
+  "scenarioName" : "scenario-3-conformance-tests-blob-for-copying",
+  "requiredScenarioState" : "scenario-3-conformance-tests-blob-for-copying-2",
+  "insertionIndex" : 50
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-head-10.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-head-10.json
@@ -1,0 +1,37 @@
+{
+  "id" : "3554f3f9-f5fb-45a0-bf1b-2e6b7f7f1bf2",
+  "name" : "AliBlobStoreIT_testCopy-HEAD-10",
+  "request" : {
+    "url" : "/conformance-tests/copied-blob",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA0126F419363104E80F",
+      "x-oss-server-time" : "37",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:02:52 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:02:57 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "3554f3f9-f5fb-45a0-bf1b-2e6b7f7f1bf2",
+  "persistent" : true,
+  "scenarioName" : "scenario-4-conformance-tests-copied-blob",
+  "requiredScenarioState" : "scenario-4-conformance-tests-copied-blob-2",
+  "insertionIndex" : 54
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-head-11.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-head-11.json
@@ -1,0 +1,38 @@
+{
+  "id" : "31eeba0b-fa4b-48cc-8493-61f48bb39217",
+  "name" : "AliBlobStoreIT_testCopy-HEAD-11",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-copying",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA00279F71343208D5B2",
+      "x-oss-server-time" : "36",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:02:52 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:02:56 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "31eeba0b-fa4b-48cc-8493-61f48bb39217",
+  "persistent" : true,
+  "scenarioName" : "scenario-2-conformance-tests-blob-for-copying",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-2-conformance-tests-blob-for-copying-2",
+  "insertionIndex" : 55
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-head-14.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-head-14.json
@@ -1,0 +1,38 @@
+{
+  "id" : "a5f029e3-b426-4e68-b401-fb4dc0e4950d",
+  "name" : "AliBlobStoreIT_testCopy-HEAD-14",
+  "request" : {
+    "url" : "/conformance-tests/copied-blob",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31B9FD6D612F31305CC738",
+      "x-oss-server-time" : "40",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:02:52 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:02:53 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "a5f029e3-b426-4e68-b401-fb4dc0e4950d",
+  "persistent" : true,
+  "scenarioName" : "scenario-4-conformance-tests-copied-blob",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-4-conformance-tests-copied-blob-2",
+  "insertionIndex" : 58
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-head-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-head-3.json
@@ -1,0 +1,37 @@
+{
+  "id" : "2ad40ca8-cd13-4506-9795-bd92ea2925b4",
+  "name" : "AliBlobStoreIT_testCopy-HEAD-3",
+  "request" : {
+    "url" : "/conformance-tests/clobbered-blob",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA06A8277C3532DED2AB",
+      "x-oss-server-time" : "30",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:02:58 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:02 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "2ad40ca8-cd13-4506-9795-bd92ea2925b4",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-clobbered-blob",
+  "requiredScenarioState" : "scenario-1-conformance-tests-clobbered-blob-2",
+  "insertionIndex" : 47
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-head-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-head-4.json
@@ -1,0 +1,37 @@
+{
+  "id" : "a72238df-7a66-48d5-8fc0-3d72872424d8",
+  "name" : "AliBlobStoreIT_testCopy-HEAD-4",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-copying",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA063AD86E3431507799",
+      "x-oss-server-time" : "37",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:02:52 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:02 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "a72238df-7a66-48d5-8fc0-3d72872424d8",
+  "persistent" : true,
+  "scenarioName" : "scenario-2-conformance-tests-blob-for-copying",
+  "requiredScenarioState" : "scenario-2-conformance-tests-blob-for-copying-2",
+  "insertionIndex" : 48
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-head-7.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-head-7.json
@@ -1,0 +1,38 @@
+{
+  "id" : "22200392-84e5-423c-bcc4-aa3d1be94c93",
+  "name" : "AliBlobStoreIT_testCopy-HEAD-7",
+  "request" : {
+    "url" : "/conformance-tests/clobbered-blob",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA036AC38838392B403B",
+      "x-oss-server-time" : "36",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:02:58 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:02:59 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "22200392-84e5-423c-bcc4-aa3d1be94c93",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-clobbered-blob",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-conformance-tests-clobbered-blob-2",
+  "insertionIndex" : 51
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-put-15.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-put-15.json
@@ -1,0 +1,34 @@
+{
+  "id" : "35a93136-d05e-4a68-9bfc-eefbdd4f1c78",
+  "name" : "AliBlobStoreIT_testCopy-PUT-15",
+  "request" : {
+    "url" : "/conformance-tests/copied-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "x-oss-copy-source" : {
+        "equalTo" : "/chameleon-multicloudj-test/conformance-tests%2Fblob-for-copying"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CopyObjectResult>\n  <ETag>\"70A2B8957D07AF666AAD6080C576A74D\"</ETag>\n  <LastModified>2026-06-16T21:02:52.000Z</LastModified>\n</CopyObjectResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31B9FC57D51439360ED81C",
+      "x-oss-server-time" : "68",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-copied-size" : "22",
+      "x-oss-ia-retrieve-flow-type" : "0",
+      "Date" : "Tue, 16 Jun 2026 21:02:52 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "35a93136-d05e-4a68-9bfc-eefbdd4f1c78",
+  "persistent" : true,
+  "insertionIndex" : 59
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-put-16.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-put-16.json
@@ -1,0 +1,31 @@
+{
+  "id" : "483f2022-110f-4687-aa04-fe16091cfdee",
+  "name" : "AliBlobStoreIT_testCopy-PUT-16",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-copying",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "UGxlYXNlIGNvcHkgdGhpcyBkYXRhIQ=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31B9FB58FB013435EB272D",
+      "x-oss-server-time" : "57",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "Date" : "Tue, 16 Jun 2026 21:02:52 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ=="
+    }
+  },
+  "uuid" : "483f2022-110f-4687-aa04-fe16091cfdee",
+  "persistent" : true,
+  "insertionIndex" : 60
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-put-17.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-put-17.json
@@ -1,0 +1,31 @@
+{
+  "id" : "74dbf2b7-7134-4028-9c12-50dd394ea976",
+  "name" : "AliBlobStoreIT_testCopy-PUT-17",
+  "request" : {
+    "url" : "/conformance-tests/copied-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "x-oss-copy-source" : {
+        "equalTo" : "/chameleon-multicloudj-test/blob-that-doesnt-exist"
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchKey</Code>\n  <Message>The specified key does not exist.</Message>\n  <RequestId>6A31B9FAEFD97E3130664288</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <Key>blob-that-doesnt-exist</Key>\n  <EC>0026-00000001</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0026-00000001</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31B9FAEFD97E3130664288",
+      "x-oss-server-time" : "51",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0026-00000001",
+      "Date" : "Tue, 16 Jun 2026 21:02:51 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "74dbf2b7-7134-4028-9c12-50dd394ea976",
+  "persistent" : true,
+  "insertionIndex" : 61
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-put-8.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-put-8.json
@@ -1,0 +1,34 @@
+{
+  "id" : "22989510-e665-4678-951b-8a581f962496",
+  "name" : "AliBlobStoreIT_testCopy-PUT-8",
+  "request" : {
+    "url" : "/conformance-tests/clobbered-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "x-oss-copy-source" : {
+        "equalTo" : "/chameleon-multicloudj-test/conformance-tests%2Fblob-for-copying"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CopyObjectResult>\n  <ETag>\"70A2B8957D07AF666AAD6080C576A74D\"</ETag>\n  <LastModified>2026-06-16T21:02:58.000Z</LastModified>\n</CopyObjectResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31BA0275B8B63934B4B865",
+      "x-oss-server-time" : "63",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-copied-size" : "22",
+      "x-oss-ia-retrieve-flow-type" : "0",
+      "Date" : "Tue, 16 Jun 2026 21:02:58 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "22989510-e665-4678-951b-8a581f962496",
+  "persistent" : true,
+  "insertionIndex" : 52
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-put-9.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopy-put-9.json
@@ -1,0 +1,31 @@
+{
+  "id" : "32e1ba38-85eb-4adf-a03f-3acb131f42df",
+  "name" : "AliBlobStoreIT_testCopy-PUT-9",
+  "request" : {
+    "url" : "/conformance-tests/clobbered-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "Q2xvYmJlciB0aGlzIGJsb2Ih"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA0199244C383392A725",
+      "x-oss-server-time" : "53",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "15363236680709416857",
+      "ETag" : "\"3C25DEC16B02717CC179EEB1FD368066\"",
+      "Date" : "Tue, 16 Jun 2026 21:02:57 GMT",
+      "Content-MD5" : "PCXewWsCcXzBee6x/TaAZg=="
+    }
+  },
+  "uuid" : "32e1ba38-85eb-4adf-a03f-3acb131f42df",
+  "persistent" : true,
+  "insertionIndex" : 53
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "82f2bf3c-c829-4867-8cd2-a9d5d284286d",
+  "name" : "AliBlobStoreIT_testCopyFrom-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/clobbered-from-blob",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA190710A8313691FDDF",
+      "x-oss-server-time" : "61",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:03:21 GMT"
+    }
+  },
+  "uuid" : "82f2bf3c-c829-4867-8cd2-a9d5d284286d",
+  "persistent" : true,
+  "insertionIndex" : 63
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-delete-1.json
@@ -1,0 +1,25 @@
+{
+  "id" : "ff4a5cb2-22c2-46f9-a6a1-1e4368711e6a",
+  "name" : "AliBlobStoreIT_testCopyFrom-DELETE-1",
+  "request" : {
+    "url" : "/conformance-tests/copied-from-blob",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA1882E54D32376F0D25",
+      "x-oss-server-time" : "45",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:03:20 GMT"
+    }
+  },
+  "uuid" : "ff4a5cb2-22c2-46f9-a6a1-1e4368711e6a",
+  "persistent" : true,
+  "insertionIndex" : 64
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-delete-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-delete-2.json
@@ -1,0 +1,25 @@
+{
+  "id" : "81723975-367d-4eea-ab01-b942d841c9c2",
+  "name" : "AliBlobStoreIT_testCopyFrom-DELETE-2",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-copyFrom",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA17C15CCF353514BFE0",
+      "x-oss-server-time" : "47",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:03:19 GMT"
+    }
+  },
+  "uuid" : "81723975-367d-4eea-ab01-b942d841c9c2",
+  "persistent" : true,
+  "insertionIndex" : 65
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-get-12.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-get-12.json
@@ -1,0 +1,36 @@
+{
+  "id" : "9c52efd7-3e03-4402-978f-3c7d34b2a429",
+  "name" : "AliBlobStoreIT_testCopyFrom-GET-12",
+  "request" : {
+    "url" : "/conformance-tests/copied-from-blob",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "UGxlYXNlIGNvcHkgdGhpcyBkYXRhIQ==",
+    "headers" : {
+      "x-oss-request-id" : "6A31BA0F986E293132BE2C6C",
+      "x-oss-server-time" : "28",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:03:08 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:11 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "9c52efd7-3e03-4402-978f-3c7d34b2a429",
+  "persistent" : true,
+  "insertionIndex" : 75
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-get-13.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-get-13.json
@@ -1,0 +1,39 @@
+{
+  "id" : "e8df7a9a-e28e-4951-933b-01bf737aae0b",
+  "name" : "AliBlobStoreIT_testCopyFrom-GET-13",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-copyFrom",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "UGxlYXNlIGNvcHkgdGhpcyBkYXRhIQ==",
+    "headers" : {
+      "x-oss-request-id" : "6A31BA0E10827E3832CEA419",
+      "x-oss-server-time" : "36",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:03:07 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:10 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "e8df7a9a-e28e-4951-933b-01bf737aae0b",
+  "persistent" : true,
+  "scenarioName" : "scenario-3-conformance-tests-blob-for-copyFrom",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-3-conformance-tests-blob-for-copyFrom-2",
+  "insertionIndex" : 76
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-get-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-get-5.json
@@ -1,0 +1,36 @@
+{
+  "id" : "6145d90a-d58a-4613-8a02-172dabed3844",
+  "name" : "AliBlobStoreIT_testCopyFrom-GET-5",
+  "request" : {
+    "url" : "/conformance-tests/clobbered-from-blob",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "UGxlYXNlIGNvcHkgdGhpcyBkYXRhIQ==",
+    "headers" : {
+      "x-oss-request-id" : "6A31BA143D204E37344FC60E",
+      "x-oss-server-time" : "44",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:03:14 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:16 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "6145d90a-d58a-4613-8a02-172dabed3844",
+  "persistent" : true,
+  "insertionIndex" : 68
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-get-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-get-6.json
@@ -1,0 +1,38 @@
+{
+  "id" : "44f1a77a-9cfc-4990-a04c-c9133f5d1c35",
+  "name" : "AliBlobStoreIT_testCopyFrom-GET-6",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-copyFrom",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "UGxlYXNlIGNvcHkgdGhpcyBkYXRhIQ==",
+    "headers" : {
+      "x-oss-request-id" : "6A31BA149670D23834FD2717",
+      "x-oss-server-time" : "36",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:03:07 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:16 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "44f1a77a-9cfc-4990-a04c-c9133f5d1c35",
+  "persistent" : true,
+  "scenarioName" : "scenario-3-conformance-tests-blob-for-copyFrom",
+  "requiredScenarioState" : "scenario-3-conformance-tests-blob-for-copyFrom-2",
+  "insertionIndex" : 69
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-head-10.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-head-10.json
@@ -1,0 +1,37 @@
+{
+  "id" : "21bc18bc-9c53-4735-8032-6e6504bf6fb6",
+  "name" : "AliBlobStoreIT_testCopyFrom-HEAD-10",
+  "request" : {
+    "url" : "/conformance-tests/copied-from-blob",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA103BC91B383881A0A8",
+      "x-oss-server-time" : "5",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:03:08 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:12 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "21bc18bc-9c53-4735-8032-6e6504bf6fb6",
+  "persistent" : true,
+  "scenarioName" : "scenario-4-conformance-tests-copied-from-blob",
+  "requiredScenarioState" : "scenario-4-conformance-tests-copied-from-blob-2",
+  "insertionIndex" : 73
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-head-11.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-head-11.json
@@ -1,0 +1,38 @@
+{
+  "id" : "391a2dfb-78a7-4dc4-a0e3-e676cf199640",
+  "name" : "AliBlobStoreIT_testCopyFrom-HEAD-11",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-copyFrom",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA103BC91B3935F89CA8",
+      "x-oss-server-time" : "28",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:03:07 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:12 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "391a2dfb-78a7-4dc4-a0e3-e676cf199640",
+  "persistent" : true,
+  "scenarioName" : "scenario-2-conformance-tests-blob-for-copyFrom",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-2-conformance-tests-blob-for-copyFrom-2",
+  "insertionIndex" : 74
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-head-14.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-head-14.json
@@ -1,0 +1,38 @@
+{
+  "id" : "bff647e6-0287-404a-984b-01d324fdec6e",
+  "name" : "AliBlobStoreIT_testCopyFrom-HEAD-14",
+  "request" : {
+    "url" : "/conformance-tests/copied-from-blob",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA0D9E5E0B3532A28312",
+      "x-oss-server-time" : "44",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:03:08 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:09 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "bff647e6-0287-404a-984b-01d324fdec6e",
+  "persistent" : true,
+  "scenarioName" : "scenario-4-conformance-tests-copied-from-blob",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-4-conformance-tests-copied-from-blob-2",
+  "insertionIndex" : 77
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-head-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-head-3.json
@@ -1,0 +1,37 @@
+{
+  "id" : "07d71776-7dfb-4814-a773-1bd73042c1d2",
+  "name" : "AliBlobStoreIT_testCopyFrom-HEAD-3",
+  "request" : {
+    "url" : "/conformance-tests/clobbered-from-blob",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA16B6DF4E3636C6BB95",
+      "x-oss-server-time" : "10",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:03:14 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:18 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "07d71776-7dfb-4814-a773-1bd73042c1d2",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-clobbered-from-blob",
+  "requiredScenarioState" : "scenario-1-conformance-tests-clobbered-from-blob-2",
+  "insertionIndex" : 66
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-head-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-head-4.json
@@ -1,0 +1,37 @@
+{
+  "id" : "76947188-bfd8-48cc-b167-4e89a5524fb9",
+  "name" : "AliBlobStoreIT_testCopyFrom-HEAD-4",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-copyFrom",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA1506B2B233359E7E0B",
+      "x-oss-server-time" : "26",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:03:07 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:17 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "76947188-bfd8-48cc-b167-4e89a5524fb9",
+  "persistent" : true,
+  "scenarioName" : "scenario-2-conformance-tests-blob-for-copyFrom",
+  "requiredScenarioState" : "scenario-2-conformance-tests-blob-for-copyFrom-2",
+  "insertionIndex" : 67
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-head-7.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-head-7.json
@@ -1,0 +1,38 @@
+{
+  "id" : "0654f9b7-d070-4a0d-b774-9b2d1ce2c890",
+  "name" : "AliBlobStoreIT_testCopyFrom-HEAD-7",
+  "request" : {
+    "url" : "/conformance-tests/clobbered-from-blob",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA1365B5FD383567020C",
+      "x-oss-server-time" : "46",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Normal",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:03:14 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:03:15 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ==",
+      "x-oss-meta-key1" : "value1",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-meta-key2" : "value2",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "0654f9b7-d070-4a0d-b774-9b2d1ce2c890",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-clobbered-from-blob",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-conformance-tests-clobbered-from-blob-2",
+  "insertionIndex" : 70
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-put-15.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-put-15.json
@@ -1,0 +1,34 @@
+{
+  "id" : "bbcf65f4-1d90-4b98-958a-f3934dcdd5bc",
+  "name" : "AliBlobStoreIT_testCopyFrom-PUT-15",
+  "request" : {
+    "url" : "/conformance-tests/copied-from-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "x-oss-copy-source" : {
+        "equalTo" : "/chameleon-multicloudj-test/conformance-tests%2Fblob-for-copyFrom"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CopyObjectResult>\n  <ETag>\"70A2B8957D07AF666AAD6080C576A74D\"</ETag>\n  <LastModified>2026-06-16T21:03:08.000Z</LastModified>\n</CopyObjectResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31BA0C3E95CC3233E9A438",
+      "x-oss-server-time" : "54",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-copied-size" : "22",
+      "x-oss-ia-retrieve-flow-type" : "0",
+      "Date" : "Tue, 16 Jun 2026 21:03:08 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "bbcf65f4-1d90-4b98-958a-f3934dcdd5bc",
+  "persistent" : true,
+  "insertionIndex" : 78
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-put-16.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-put-16.json
@@ -1,0 +1,31 @@
+{
+  "id" : "eb8737e2-3b0d-4134-9dfa-e4a68e2b3fb5",
+  "name" : "AliBlobStoreIT_testCopyFrom-PUT-16",
+  "request" : {
+    "url" : "/conformance-tests/copied-from-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "x-oss-copy-source" : {
+        "equalTo" : "/bucketThatDoesntExist/conformance-tests%2Fblob-for-copyFrom"
+      }
+    }
+  },
+  "response" : {
+    "status" : 400,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>InvalidBucketName</Code>\n  <Message>The specified bucket is not valid.</Message>\n  <RequestId>6A31BA0B7FD7C23433A2CE69</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <BucketName>bucketThatDoesntExist</BucketName>\n  <EC>0015-00000001</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0015-00000001</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31BA0B7FD7C23433A2CE69",
+      "x-oss-server-time" : "18",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0015-00000001",
+      "Date" : "Tue, 16 Jun 2026 21:03:07 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "eb8737e2-3b0d-4134-9dfa-e4a68e2b3fb5",
+  "persistent" : true,
+  "insertionIndex" : 79
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-put-17.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-put-17.json
@@ -1,0 +1,31 @@
+{
+  "id" : "19c43d43-37fd-43be-b680-e1f47c633521",
+  "name" : "AliBlobStoreIT_testCopyFrom-PUT-17",
+  "request" : {
+    "url" : "/conformance-tests/blob-for-copyFrom",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "UGxlYXNlIGNvcHkgdGhpcyBkYXRhIQ=="
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA0BB6DF4E3338B78C95",
+      "x-oss-server-time" : "44",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "Date" : "Tue, 16 Jun 2026 21:03:07 GMT",
+      "Content-MD5" : "cKK4lX0Hr2ZqrWCAxXanTQ=="
+    }
+  },
+  "uuid" : "19c43d43-37fd-43be-b680-e1f47c633521",
+  "persistent" : true,
+  "insertionIndex" : 80
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-put-18.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-put-18.json
@@ -1,0 +1,31 @@
+{
+  "id" : "65c0bf2f-6bd2-4d2d-a66e-307bb06d4651",
+  "name" : "AliBlobStoreIT_testCopyFrom-PUT-18",
+  "request" : {
+    "url" : "/conformance-tests/copied-from-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "x-oss-copy-source" : {
+        "equalTo" : "/chameleon-multicloudj-test/blob-that-doesnt-exist"
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchKey</Code>\n  <Message>The specified key does not exist.</Message>\n  <RequestId>6A31BA0A57D51438341C1A1D</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <Key>blob-that-doesnt-exist</Key>\n  <EC>0026-00000001</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0026-00000001</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31BA0A57D51438341C1A1D",
+      "x-oss-server-time" : "11",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0026-00000001",
+      "Date" : "Tue, 16 Jun 2026 21:03:06 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "65c0bf2f-6bd2-4d2d-a66e-307bb06d4651",
+  "persistent" : true,
+  "insertionIndex" : 81
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-put-8.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-put-8.json
@@ -1,0 +1,34 @@
+{
+  "id" : "b2888437-307d-4a96-8c83-5ceefd374550",
+  "name" : "AliBlobStoreIT_testCopyFrom-PUT-8",
+  "request" : {
+    "url" : "/conformance-tests/clobbered-from-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "x-oss-copy-source" : {
+        "equalTo" : "/chameleon-multicloudj-test/conformance-tests%2Fblob-for-copyFrom"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CopyObjectResult>\n  <ETag>\"70A2B8957D07AF666AAD6080C576A74D\"</ETag>\n  <LastModified>2026-06-16T21:03:14.000Z</LastModified>\n</CopyObjectResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31BA12A8277C3633D608AC",
+      "x-oss-server-time" : "21",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "456912294384585950",
+      "ETag" : "\"70A2B8957D07AF666AAD6080C576A74D\"",
+      "x-oss-copied-size" : "22",
+      "x-oss-ia-retrieve-flow-type" : "0",
+      "Date" : "Tue, 16 Jun 2026 21:03:14 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "b2888437-307d-4a96-8c83-5ceefd374550",
+  "persistent" : true,
+  "insertionIndex" : 71
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-put-9.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testcopyfrom-put-9.json
@@ -1,0 +1,31 @@
+{
+  "id" : "e1043fd2-e0a8-4815-9e2a-4809c7019a2a",
+  "name" : "AliBlobStoreIT_testCopyFrom-PUT-9",
+  "request" : {
+    "url" : "/conformance-tests/clobbered-from-blob",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    },
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "Q2xvYmJlciB0aGlzIGJsb2Ih"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31BA11FFEA073936E60D59",
+      "x-oss-server-time" : "40",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "15363236680709416857",
+      "ETag" : "\"3C25DEC16B02717CC179EEB1FD368066\"",
+      "Date" : "Tue, 16 Jun 2026 21:03:13 GMT",
+      "Content-MD5" : "PCXewWsCcXzBee6x/TaAZg=="
+    }
+  },
+  "uuid" : "e1043fd2-e0a8-4815-9e2a-4809c7019a2a",
+  "persistent" : true,
+  "insertionIndex" : 72
+}

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -1455,8 +1455,6 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testCopy() throws IOException {
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
-
     String key = "conformance-tests/blob-for-copying";
     String destKey = "conformance-tests/copied-blob";
     String blobToClobber = "conformance-tests/clobbered-blob";
@@ -1684,8 +1682,6 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testCopyFrom() throws IOException {
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
-
     String key = "conformance-tests/blob-for-copyFrom";
     String destKey = "conformance-tests/copied-from-blob";
     String blobToClobber = "conformance-tests/clobbered-from-blob";


### PR DESCRIPTION
## Summary
`testCopy` and `testCopyFrom` were skipped for Ali via `assumeFalse(ALI_PROVIDER_ID)` guards because their WireMock recordings did not replay deterministically after the v1→v2 SDK migration. This enables both tests for Ali.

## Root cause
Both tests reuse the same object key as both a copy target and an upload target, and issue multiple copies to one key. Copy PUTs and upload PUTs to the same URL were indistinguishable to WireMock (only `Host` was captured as a match header), so the wrong stub was served on replay — the OSS SDK's CRC64 response check then failed with `InconsistentException`.

## Fix
Capture `x-oss-copy-source` (a header OSS sends only on copy operations) as a recording match header. This disambiguates copy-PUT vs upload-PUT to the same key, and distinguishes multiple copies to one key by their differing source value. It is inert for non-copy requests (header absent → no matcher added), so other tests are unaffected.

- Add `x-oss-copy-source` to `AliBlobStoreIT.getRecordingCaptureHeaders()`
- Remove the `assumeFalse(ALI)` guards from `testCopy` and `testCopyFrom`
- Add the re-recorded Ali WireMock mappings for both tests

## Testing
- `mvn test -pl blob/blob-ali` — replay mode (no credentials): `AliBlobStoreIT` 119 run, 0 failures.
- `testCopy` and `testCopyFrom` now run and pass for Ali; `testVersionedCopy` (the other active copy test) is unaffected.
- No production code changes; conformance-test enablement only.

## Cross-Cloud Compatibility
- AWS / GCP: unaffected — the capture-header change is in the Ali IT harness only, and `x-oss-copy-source` is OSS-specific.
- Alibaba: `testCopy` / `testCopyFrom` now covered in CI.