### PR TITLE
blobstore: enable multipart upload conformance tests for Ali

### DIFF
--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
@@ -155,7 +155,10 @@ public class AliBlobStoreIT extends AbstractBlobStoreIT {
 
     @Override
     public boolean isSha256Supported() {
-      return true;
+      // Ali OSS's only native object checksum is CRC64-ECMA; it rejects SHA256 (and CRC32C) for
+      // caller-supplied checksums (see AliTransformer.rejectUnsupportedChecksum). SHA256-specific
+      // conformance tests are skipped via this capability flag rather than a provider guard.
+      return false;
     }
 
     @Override

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_completeanabortedupload-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_completeanabortedupload-delete-0.json
@@ -1,0 +1,40 @@
+{
+  "id" : "fdb80db4-ae70-4ab1-adf9-643afa34f21f",
+  "name" : "AliBlobStoreIT_testMultipartUpload_completeAnAbortedUpload-DELETE-0",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-completeAnAborted",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "50E34E39B0FD44F58794FE46A9CB22F2"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchUpload</Code>\n  <Message>The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.</Message>\n  <RequestId>6A31C2FA9670D23333B4BB3F</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <UploadId>50E34E39B0FD44F58794FE46A9CB22F2</UploadId>\n  <EC>0042-00000002</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0042-00000002</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31C2FA9670D23333B4BB3F",
+      "x-oss-server-time" : "36",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0042-00000002",
+      "Date" : "Tue, 16 Jun 2026 21:41:14 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "fdb80db4-ae70-4ab1-adf9-643afa34f21f",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-multipart-completeAnAborted",
+  "requiredScenarioState" : "scenario-1-conformance-tests-multipart-completeAnAborted-2",
+  "insertionIndex" : 63
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_completeanabortedupload-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_completeanabortedupload-delete-1.json
@@ -1,0 +1,25 @@
+{
+  "id" : "3bed9434-9995-4c9e-834b-9c18f5be773b",
+  "name" : "AliBlobStoreIT_testMultipartUpload_completeAnAbortedUpload-DELETE-1",
+  "request" : {
+    "url" : "/conformance-tests/multipart-completeAnAborted",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A31C2F995CBF1353205BFCF",
+      "x-oss-server-time" : "21",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:41:13 GMT"
+    }
+  },
+  "uuid" : "3bed9434-9995-4c9e-834b-9c18f5be773b",
+  "persistent" : true,
+  "insertionIndex" : 64
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_completeanabortedupload-delete-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_completeanabortedupload-delete-3.json
@@ -1,0 +1,38 @@
+{
+  "id" : "aee4092f-a4c1-446c-8e46-5c8be4398bca",
+  "name" : "AliBlobStoreIT_testMultipartUpload_completeAnAbortedUpload-DELETE-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-completeAnAborted",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "50E34E39B0FD44F58794FE46A9CB22F2"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A31C2F83D437D343992A386",
+      "x-oss-server-time" : "51",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:41:12 GMT"
+    }
+  },
+  "uuid" : "aee4092f-a4c1-446c-8e46-5c8be4398bca",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-multipart-completeAnAborted",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-conformance-tests-multipart-completeAnAborted-2",
+  "insertionIndex" : 66
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_completeanabortedupload-post-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_completeanabortedupload-post-2.json
@@ -1,0 +1,46 @@
+{
+  "id" : "63bcb053-d0ba-4a9d-86c0-fe7e2f18665e",
+  "name" : "AliBlobStoreIT_testMultipartUpload_completeAnAbortedUpload-POST-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-completeAnAborted",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "50E34E39B0FD44F58794FE46A9CB22F2"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>2B5C91AD399409EC9B409B66F5BB00FB</ETag></Part></CompleteMultipartUpload>"
+    } ]
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchUpload</Code>\n  <Message>The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.</Message>\n  <RequestId>6A31C2F8F7D6923133A30468</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <UploadId>50E34E39B0FD44F58794FE46A9CB22F2</UploadId>\n  <EC>0042-00000203</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0042-00000203</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31C2F8F7D6923133A30468",
+      "x-oss-server-time" : "35",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0042-00000203",
+      "Date" : "Tue, 16 Jun 2026 21:41:13 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "63bcb053-d0ba-4a9d-86c0-fe7e2f18665e",
+  "persistent" : true,
+  "insertionIndex" : 65
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_completeanabortedupload-post-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_completeanabortedupload-post-5.json
@@ -1,0 +1,42 @@
+{
+  "id" : "e90d1504-8bed-4fc7-ade7-883690d96bfe",
+  "name" : "AliBlobStoreIT_testMultipartUpload_completeAnAbortedUpload-POST-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-completeAnAborted",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-completeAnAborted</Key>\n  <UploadId>50E34E39B0FD44F58794FE46A9CB22F2</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31C2F4F5C7C435353EF72A",
+      "x-oss-server-time" : "46",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:41:08 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "e90d1504-8bed-4fc7-ade7-883690d96bfe",
+  "persistent" : true,
+  "insertionIndex" : 68
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_completeanabortedupload-put-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_completeanabortedupload-put-4.json
@@ -1,0 +1,44 @@
+{
+  "id" : "06daaf9a-08ed-4d05-b9e8-faf3cca6eb7b",
+  "name" : "AliBlobStoreIT_testMultipartUpload_completeAnAbortedUpload-PUT-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-completeAnAborted",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "50E34E39B0FD44F58794FE46A9CB22F2"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31C2F5A8277C3439B191D4",
+      "x-oss-server-time" : "105",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"2B5C91AD399409EC9B409B66F5BB00FB\"",
+      "Date" : "Tue, 16 Jun 2026 21:41:11 GMT",
+      "Content-MD5" : "K1yRrTmUCeybQJtm9bsA+w=="
+    }
+  },
+  "uuid" : "06daaf9a-08ed-4d05-b9e8-faf3cca6eb7b",
+  "persistent" : true,
+  "insertionIndex" : 67
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multiplemultipartuploadsforsamekey-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multiplemultipartuploadsforsamekey-delete-0.json
@@ -1,0 +1,35 @@
+{
+  "id" : "47a980ba-a5d9-4e61-b5e8-cd760fba5bd8",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleMultipartUploadsForSameKey-DELETE-0",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-multipleMPU",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CA606DA093E94E3E82C9D6C3E0C383FB"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A31C2FE27D2E9333866BF04",
+      "x-oss-server-time" : "31",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:41:18 GMT"
+    }
+  },
+  "uuid" : "47a980ba-a5d9-4e61-b5e8-cd760fba5bd8",
+  "persistent" : true,
+  "insertionIndex" : 70
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multiplemultipartuploadsforsamekey-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multiplemultipartuploadsforsamekey-delete-1.json
@@ -1,0 +1,35 @@
+{
+  "id" : "3a4a7ed0-76e6-4eb7-afee-e04a4e2c61a4",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleMultipartUploadsForSameKey-DELETE-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-multipleMPU",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "24F7F7151120435CA2878C2AC90BC059"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A31C2FD4896753235FE7C66",
+      "x-oss-server-time" : "45",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:41:18 GMT"
+    }
+  },
+  "uuid" : "3a4a7ed0-76e6-4eb7-afee-e04a4e2c61a4",
+  "persistent" : true,
+  "insertionIndex" : 71
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multiplemultipartuploadsforsamekey-delete-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multiplemultipartuploadsforsamekey-delete-2.json
@@ -1,0 +1,25 @@
+{
+  "id" : "e90ecc8f-7c36-447a-b848-9f01be6623d7",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleMultipartUploadsForSameKey-DELETE-2",
+  "request" : {
+    "url" : "/conformance-tests/multipart-multipleMPU",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A31C2FDDA12F93230805639",
+      "x-oss-server-time" : "9",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:41:17 GMT"
+    }
+  },
+  "uuid" : "e90ecc8f-7c36-447a-b848-9f01be6623d7",
+  "persistent" : true,
+  "insertionIndex" : 72
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multiplemultipartuploadsforsamekey-post-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multiplemultipartuploadsforsamekey-post-3.json
@@ -1,0 +1,44 @@
+{
+  "id" : "c56943b7-fa99-4b0b-a261-2d2025a45147",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleMultipartUploadsForSameKey-POST-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-multipleMPU",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-multipleMPU</Key>\n  <UploadId>CA606DA093E94E3E82C9D6C3E0C383FB</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31C2FC1FB8DD343492BC0B",
+      "x-oss-server-time" : "40",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:41:16 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "c56943b7-fa99-4b0b-a261-2d2025a45147",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-multipart-multipleMPU",
+  "requiredScenarioState" : "scenario-1-conformance-tests-multipart-multipleMPU-2",
+  "insertionIndex" : 73
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multiplemultipartuploadsforsamekey-post-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multiplemultipartuploadsforsamekey-post-4.json
@@ -1,0 +1,45 @@
+{
+  "id" : "42c4983d-5d3d-4f1d-b1a6-a5a358afdaba",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleMultipartUploadsForSameKey-POST-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-multipleMPU",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-multipleMPU</Key>\n  <UploadId>24F7F7151120435CA2878C2AC90BC059</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31C2FB20C22B3131F5C87D",
+      "x-oss-server-time" : "43",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:41:15 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "42c4983d-5d3d-4f1d-b1a6-a5a358afdaba",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-multipart-multipleMPU",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-conformance-tests-multipart-multipleMPU-2",
+  "insertionIndex" : 74
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withcontenttype-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withcontenttype-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "d5789ac6-cb8f-4053-83d7-14a6fccc719b",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withContentType-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/multipart-withContentType",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A31C2F3603E7D3730F35FDC",
+      "x-oss-server-time" : "52",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:41:07 GMT"
+    }
+  },
+  "uuid" : "d5789ac6-cb8f-4053-83d7-14a6fccc719b",
+  "persistent" : true,
+  "insertionIndex" : 53
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withcontenttype-head-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withcontenttype-head-1.json
@@ -1,0 +1,33 @@
+{
+  "id" : "7d601137-1afe-499a-a789-71ac8744542d",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withContentType-HEAD-1",
+  "request" : {
+    "url" : "/conformance-tests/multipart-withContentType",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31C2F2D056AC39314174F5",
+      "x-oss-server-time" : "40",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Multipart",
+      "Last-Modified" : "Tue, 16 Jun 2026 21:41:05 GMT",
+      "Date" : "Tue, 16 Jun 2026 21:41:06 GMT",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "16941702395769382088",
+      "ETag" : "\"8C11B624ED7D61A26D45D7A28FE98349-2\"",
+      "Vary" : "Accept-Encoding",
+      "Content-Type" : "text/plain"
+    }
+  },
+  "uuid" : "7d601137-1afe-499a-a789-71ac8744542d",
+  "persistent" : true,
+  "insertionIndex" : 54
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withcontenttype-post-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withcontenttype-post-2.json
@@ -1,0 +1,47 @@
+{
+  "id" : "77563a3c-c751-49e6-bf99-7f1db2f2f893",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withContentType-POST-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withContentType",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "979D91127A614F458B105FC9D05EC518"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>2B5C91AD399409EC9B409B66F5BB00FB</ETag></Part><Part><PartNumber>2</PartNumber><ETag>267C038CC2EC32FFD0EE2512FF5DA5A5</ETag></Part></CompleteMultipartUpload>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CompleteMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Location>https://chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com/conformance-tests/multipart-withContentType</Location>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-withContentType</Key>\n  <ETag>\"8C11B624ED7D61A26D45D7A28FE98349-2\"</ETag>\n</CompleteMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31C2F126AA8C353675E5F1",
+      "x-oss-server-time" : "77",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "16941702395769382088",
+      "ETag" : "\"8C11B624ED7D61A26D45D7A28FE98349-2\"",
+      "Date" : "Tue, 16 Jun 2026 21:41:05 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "77563a3c-c751-49e6-bf99-7f1db2f2f893",
+  "persistent" : true,
+  "insertionIndex" : 55
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withcontenttype-post-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withcontenttype-post-5.json
@@ -1,0 +1,42 @@
+{
+  "id" : "3730d407-f300-4bd9-a2cf-d9d05897c1a5",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withContentType-POST-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withContentType",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-withContentType</Key>\n  <UploadId>979D91127A614F458B105FC9D05EC518</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31C2EB3A503C3539CC1083",
+      "x-oss-server-time" : "46",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:40:59 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "3730d407-f300-4bd9-a2cf-d9d05897c1a5",
+  "persistent" : true,
+  "insertionIndex" : 58
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withcontenttype-put-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withcontenttype-put-3.json
@@ -1,0 +1,44 @@
+{
+  "id" : "b03ade8d-01fd-41b4-b0fa-9915b9e329e7",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withContentType-PUT-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withContentType",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "979D91127A614F458B105FC9D05EC518"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31C2EEA4C9F93037BD343E",
+      "x-oss-server-time" : "102",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "9618452871104087932",
+      "ETag" : "\"267C038CC2EC32FFD0EE2512FF5DA5A5\"",
+      "Date" : "Tue, 16 Jun 2026 21:41:04 GMT",
+      "Content-MD5" : "JnwDjMLsMv/Q7iUS/12lpQ=="
+    }
+  },
+  "uuid" : "b03ade8d-01fd-41b4-b0fa-9915b9e329e7",
+  "persistent" : true,
+  "insertionIndex" : 56
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withcontenttype-put-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withcontenttype-put-4.json
@@ -1,0 +1,44 @@
+{
+  "id" : "bc2e1dae-1bfb-4007-8a9a-a96fe1824d8e",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withContentType-PUT-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withContentType",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "979D91127A614F458B105FC9D05EC518"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31C2EC3AD86E3939C8FBC1",
+      "x-oss-server-time" : "113",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"2B5C91AD399409EC9B409B66F5BB00FB\"",
+      "Date" : "Tue, 16 Jun 2026 21:41:02 GMT",
+      "Content-MD5" : "K1yRrTmUCeybQJtm9bsA+w=="
+    }
+  },
+  "uuid" : "bc2e1dae-1bfb-4007-8a9a-a96fe1824d8e",
+  "persistent" : true,
+  "insertionIndex" : 57
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-delete-0.json
@@ -1,0 +1,27 @@
+{
+  "id" : "39b7fc5d-ae3e-4fbb-b463-5b4d47f80343",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withObjectLock-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/multipart-withObjectLock",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-version-id" : "CAEQ3w0Y86j8muTCyfYZIiA0NTM3ZDVlMjY4MTE0NTI1OWQxMTZkNjJjZTAyYmRmOA--",
+      "x-oss-request-id" : "6A31C2EAFB200F383931324D",
+      "x-oss-server-time" : "90",
+      "Server" : "AliyunOSS",
+      "x-oss-delete-marker" : "true",
+      "Date" : "Tue, 16 Jun 2026 21:40:58 GMT"
+    }
+  },
+  "uuid" : "39b7fc5d-ae3e-4fbb-b463-5b4d47f80343",
+  "persistent" : true,
+  "insertionIndex" : 44
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-get-1.json
@@ -1,0 +1,37 @@
+{
+  "id" : "d0cc7d3d-4fcd-49a6-819c-3a9b29a790f2",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withObjectLock-GET-1",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withObjectLock",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "legalHold" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchObjectLegalHoldConfiguration</Code>\n  <Message>The specified object does not have an object legal hold configuration.</Message>\n  <RequestId>6A31C2E9DF515537315F68F5</RequestId>\n  <HostId>chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com</HostId>\n  <ObjectName>conformance-tests/multipart-withObjectLock</ObjectName>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31C2E9DF515537315F68F5",
+      "x-oss-server-time" : "58",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:40:57 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "d0cc7d3d-4fcd-49a6-819c-3a9b29a790f2",
+  "persistent" : true,
+  "insertionIndex" : 45
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-get-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-get-2.json
@@ -1,0 +1,38 @@
+{
+  "id" : "d3eb2f15-388d-495e-a207-c3b5f7b45a75",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withObjectLock-GET-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withObjectLock",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Retention>\n  <Mode>GOVERNANCE</Mode>\n  <RetainUntilDate>2100-01-01T00:00:00.000Z</RetainUntilDate>\n</Retention>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQ3w0YnpXBrNbCyfYZIiA2NjM3NjhlNTdjMzU0OGJlOWQzY2YzMmYzZWU3OTk2ZA--",
+      "x-oss-request-id" : "6A31C2E88896FB3131128BAF",
+      "x-oss-server-time" : "72",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:40:56 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "d3eb2f15-388d-495e-a207-c3b5f7b45a75",
+  "persistent" : true,
+  "insertionIndex" : 46
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-post-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-post-4.json
@@ -1,0 +1,48 @@
+{
+  "id" : "c1b829d0-9d70-4eba-a246-2fc2440b1da8",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withObjectLock-POST-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withObjectLock",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "2113D3DD89F7480B85617C857A770A55"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>2B5C91AD399409EC9B409B66F5BB00FB</ETag></Part><Part><PartNumber>2</PartNumber><ETag>267C038CC2EC32FFD0EE2512FF5DA5A5</ETag></Part></CompleteMultipartUpload>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CompleteMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Location>https://chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com/conformance-tests/multipart-withObjectLock</Location>\n  <Bucket>chameleon-multicloudj-test-versioned</Bucket>\n  <Key>conformance-tests%2Fmultipart-withObjectLock</Key>\n  <ETag>\"8C11B624ED7D61A26D45D7A28FE98349-2\"</ETag>\n</CompleteMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-version-id" : "CAEQ3w0YnpXBrNbCyfYZIiA2NjM3NjhlNTdjMzU0OGJlOWQzY2YzMmYzZWU3OTk2ZA--",
+      "x-oss-request-id" : "6A31C2E6AF19EA3835FF85D8",
+      "x-oss-server-time" : "134",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "16941702395769382088",
+      "ETag" : "\"8C11B624ED7D61A26D45D7A28FE98349-2\"",
+      "Date" : "Tue, 16 Jun 2026 21:40:55 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "c1b829d0-9d70-4eba-a246-2fc2440b1da8",
+  "persistent" : true,
+  "insertionIndex" : 48
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-post-7.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-post-7.json
@@ -1,0 +1,42 @@
+{
+  "id" : "bd5a1f4e-725b-4344-bf72-30629b14719e",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withObjectLock-POST-7",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withObjectLock",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test-versioned</Bucket>\n  <Key>conformance-tests%2Fmultipart-withObjectLock</Key>\n  <UploadId>2113D3DD89F7480B85617C857A770A55</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A31C2E006B2B235338DDD33",
+      "x-oss-server-time" : "91",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:40:48 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "bd5a1f4e-725b-4344-bf72-30629b14719e",
+  "persistent" : true,
+  "insertionIndex" : 51
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-put-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-put-3.json
@@ -1,0 +1,44 @@
+{
+  "id" : "fcb09cc1-20e6-40df-a39a-c470be4055fe",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withObjectLock-PUT-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withObjectLock",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CAEQ3w0YnpXBrNbCyfYZIiA2NjM3NjhlNTdjMzU0OGJlOWQzY2YzMmYzZWU3OTk2ZA--"
+        } ]
+      },
+      "retention" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<Retention><Mode>GOVERNANCE</Mode><RetainUntilDate>2100-01-01T00:00:00Z</RetainUntilDate></Retention>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-version-id" : "CAEQ3w0YnpXBrNbCyfYZIiA2NjM3NjhlNTdjMzU0OGJlOWQzY2YzMmYzZWU3OTk2ZA--",
+      "x-oss-request-id" : "6A31C2E7DA12F939365AF438",
+      "x-oss-server-time" : "70",
+      "Server" : "AliyunOSS",
+      "Date" : "Tue, 16 Jun 2026 21:40:55 GMT"
+    }
+  },
+  "uuid" : "fcb09cc1-20e6-40df-a39a-c470be4055fe",
+  "persistent" : true,
+  "insertionIndex" : 47
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-put-5.json
@@ -1,0 +1,44 @@
+{
+  "id" : "d1dde7b0-072e-4244-b6ab-edbe8b85dc5d",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withObjectLock-PUT-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withObjectLock",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "2113D3DD89F7480B85617C857A770A55"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31C2E41AA5CE3232642B37",
+      "x-oss-server-time" : "188",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "9618452871104087932",
+      "ETag" : "\"267C038CC2EC32FFD0EE2512FF5DA5A5\"",
+      "Date" : "Tue, 16 Jun 2026 21:40:54 GMT",
+      "Content-MD5" : "JnwDjMLsMv/Q7iUS/12lpQ=="
+    }
+  },
+  "uuid" : "d1dde7b0-072e-4244-b6ab-edbe8b85dc5d",
+  "persistent" : true,
+  "insertionIndex" : 49
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withobjectlock-put-6.json
@@ -1,0 +1,44 @@
+{
+  "id" : "d5f4b2dc-91df-4ab7-86dc-b759a73eba48",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withObjectLock-PUT-6",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withObjectLock",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test-versioned.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "2113D3DD89F7480B85617C857A770A55"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A31C2E189F0063134AA2CBD",
+      "x-oss-server-time" : "180",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"2B5C91AD399409EC9B409B66F5BB00FB\"",
+      "Date" : "Tue, 16 Jun 2026 21:40:51 GMT",
+      "Content-MD5" : "K1yRrTmUCeybQJtm9bsA+w=="
+    }
+  },
+  "uuid" : "d5f4b2dc-91df-4ab7-86dc-b759a73eba48",
+  "persistent" : true,
+  "insertionIndex" : 50
+}

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -5658,9 +5658,10 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testMultipartUpload_withObjectLock() {
-    // Ali: WireMock cannot replay 5MB multipart part bodies (body regex matching fails on large
-    // binary payloads). This is a WireMock harness limitation, not an object lock issue —
-    // the test passes in record mode against live OSS.
+    // Ali: the recorded part-upload PUT stubs intentionally use empty bodyPatterns (no body
+    // matching) because WireMock's regex body matching fails on large (5MB) binary payloads.
+    // Requests are still uniquely matched by method + URL + query (uploadId/partNumber), so the
+    // test passes in both record and replay mode.
 
     String expectedKey = DEFAULT_MULTIPART_KEY_PREFIX + "withObjectLock";
     // Keep retainUntil in the future so record mode remains valid over time.

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -3559,7 +3559,6 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testMultipartUpload_invalidMultipartUpload() {
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
     BucketClient bucketClient = new BucketClient(blobStore);
 
@@ -3613,7 +3612,6 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testMultipartUpload_multipleMultipartUploadsForSameKey() {
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
     BucketClient bucketClient = new BucketClient(blobStore);
 
@@ -3646,7 +3644,6 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testMultipartUpload_completeAnAbortedUpload() {
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
     BucketClient bucketClient = new BucketClient(blobStore);
 
@@ -5069,7 +5066,6 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testMultipartUpload_withSha256Checksum() {
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     Assumptions.assumeTrue(
         harness.isSha256Supported(),
         "SHA256 checksum not supported by " + harness.getProviderId());
@@ -5139,7 +5135,6 @@ public abstract class AbstractBlobStoreIT {
 
   @Test
   public void testMultipartUpload_withContentType() {
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     String expectedKey = DEFAULT_MULTIPART_KEY_PREFIX + "withContentType";
     String contentType = "text/plain";
 
@@ -5666,7 +5661,6 @@ public abstract class AbstractBlobStoreIT {
     // Ali: WireMock cannot replay 5MB multipart part bodies (body regex matching fails on large
     // binary payloads). This is a WireMock harness limitation, not an object lock issue —
     // the test passes in record mode against live OSS.
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
 
     String expectedKey = DEFAULT_MULTIPART_KEY_PREFIX + "withObjectLock";
     // Keep retainUntil in the future so record mode remains valid over time.


### PR DESCRIPTION
## Summary
Enables 5 multipart-upload conformance tests for Ali that were skipped via `assumeFalse(ALI_PROVIDER_ID)` guards pending WireMock recordings after the v1→v2 SDK migration.

## Changes
- Remove the `assumeFalse(ALI)` guards from these tests, now passing in replay:
  - `testMultipartUpload_invalidMultipartUpload`
  - `testMultipartUpload_multipleMultipartUploadsForSameKey`
  - `testMultipartUpload_completeAnAbortedUpload`
  - `testMultipartUpload_withContentType`
  - `testMultipartUpload_withObjectLock`
- Add the re-recorded Ali WireMock mappings for the 5 enabled tests.
- Override `AliBlobStoreIT.isSha256Supported()` to return `false`.

## Note on testMultipartUpload_withSha256Checksum
This test is intentionally not enabled. Ali OSS's only native object checksum is CRC64-ECMA; it rejects SHA256 for caller-supplied checksums (`AliTransformer.rejectUnsupportedChecksum`), so the upload cannot succeed with `ChecksumMethod.SHA256`. Rather than a provider-specific guard, the test is now skipped honestly through the existing `isSha256Supported()` capability flag (false for Ali). Its `assumeFalse(ALI)` guard is removed since the capability flag expresses the skip.

## Testing
- `mvn test -pl blob/blob-ali` — replay mode (no credentials): `AliBlobStoreIT` 119 run, 0 failures, 33 skipped.
- The 5 MPU tests above pass; `testMultipartUpload_withSha256Checksum` skips via the capability flag.
- No production code changes; conformance-test enablement only.

## Cross-Cloud Compatibility
- AWS / GCP: unaffected — changes are in the Ali IT harness and the (shared) abstract IT guards only.
- Alibaba: 5 MPU tests now covered in CI; SHA256 MPU checksum remains unsupported by OSS (capability gap, not a driver bug).