### PR TITLE
blobstore: gate Ali directory conformance tests on the capability flag

### DIFF
--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
@@ -168,6 +168,14 @@ public class AliBlobStoreIT extends AbstractBlobStoreIT {
     }
 
     @Override
+    public boolean isDirectoryUploadSupported() {
+      // Ali implements directory operations only on the async blob store; the synchronous
+      // AliBlobStore does not, so the sync directory conformance tests are skipped via this
+      // capability flag (matching the AWS harness, which is also async-only for directory ops).
+      return false;
+    }
+
+    @Override
     public String computeChecksum(byte[] content) {
       CRC64 crc64 = new CRC64();
       crc64.update(content, content.length);

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -5277,7 +5277,6 @@ public abstract class AbstractBlobStoreIT {
   public void testUploadDirectory_basic(@TempDir Path tempDir) throws Exception {
     Assumptions.assumeTrue(
         harness.isDirectoryUploadSupported(), "Directory upload not supported by this provider");
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
 
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
     BucketClient bucketClient = new BucketClient(blobStore);
@@ -5341,7 +5340,6 @@ public abstract class AbstractBlobStoreIT {
   public void testUploadDirectory_withoutSubFolders(@TempDir Path tempDir) throws Exception {
     Assumptions.assumeTrue(
         harness.isDirectoryUploadSupported(), "Directory upload not supported by this provider");
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
 
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
 
@@ -5397,7 +5395,6 @@ public abstract class AbstractBlobStoreIT {
   public void testUploadDirectory_withTags(@TempDir Path tempDir) throws Exception {
     Assumptions.assumeTrue(
         harness.isDirectoryUploadSupported(), "Directory upload not supported by this provider");
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
 
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
     BucketClient bucketClient = new BucketClient(blobStore);
@@ -5444,7 +5441,6 @@ public abstract class AbstractBlobStoreIT {
   public void testDownloadDirectory_basic(@TempDir Path tempDir) throws Exception {
     Assumptions.assumeTrue(
         harness.isDirectoryUploadSupported(), "Directory upload not supported by this provider");
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
 
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
     BucketClient bucketClient = new BucketClient(blobStore);
@@ -5525,7 +5521,6 @@ public abstract class AbstractBlobStoreIT {
   public void testDeleteDirectory_basic(@TempDir Path tempDir) throws Exception {
     Assumptions.assumeTrue(
         harness.isDirectoryUploadSupported(), "Directory upload not supported by this provider");
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
 
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
     BucketClient bucketClient = new BucketClient(blobStore);


### PR DESCRIPTION
## Summary
The synchronous directory-operations conformance tests in `AbstractBlobStoreIT` (`testUploadDirectory_basic`, `testUploadDirectory_withoutSubFolders`, `testUploadDirectory_withTags`, `testDownloadDirectory_basic`, `testDeleteDirectory_basic`) were skipped for Ali via provider-specific `assumeFalse(ALI_PROVIDER_ID)` guards. Ali implements directory operations only on the async blob store; the synchronous `AliBlobStore` does not — the same design AWS uses. This switches Ali to skip these via the existing `isDirectoryUploadSupported()` capability flag, matching how AWS already handles it.

## Changes
- Override `AliBlobStoreIT.isDirectoryUploadSupported()` to return `false` (mirrors the AWS harness).
- Remove the now-redundant `assumeFalse(ALI_PROVIDER_ID)` guards from the 5 directory tests. The existing `assumeTrue(isDirectoryUploadSupported())` gate handles the skip for both AWS and Ali, so the abstract IT no longer needs provider-specific coupling for these.

## Testing
- `mvn test -pl blob/blob-ali` — replay mode (no credentials): `AliBlobStoreIT` 119 run, 0 failures, 38 skipped. The 5 directory tests skip with the reason "Directory upload not supported by this provider", identical to AWS.
- No production code changes and no WireMock recordings — test configuration only.

## Cross-Cloud Compatibility
- AWS: unchanged — already skips these via `isDirectoryUploadSupported()=false`.
- GCP: unchanged — implements sync directory ops, so these tests run.
- Alibaba: directory ops are async-only (sync `AliBlobStore` does not implement them), now represented honestly through the capability flag rather than a provider guard. Implementing synchronous directory ops for Ali is a separate driver-feature decision (AWS does not have it either).