### PR TITLE
blobstore: enable Ali OSS multipart-upload helper tier + SSE-KMS conformance tests

### DIFF
--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
@@ -156,7 +156,9 @@ public class AliBlobStoreIT extends AbstractBlobStoreIT {
 
     @Override
     public String getKmsKeyId() {
-      return null;
+      // OSS KMS CMK in cn-shanghai (same region as the test bucket). Used by the SSE-KMS
+      // conformance tests. Not a secret (it's a key identifier, not key material).
+      return "acs:kms:cn-shanghai:1099202394511537:key/key-shh6a32d9fajtygsv4msy";
     }
 
     @Override

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownloadwithkmskey-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownloadwithkmskey-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "1a233ae4-b847-47fc-856e-403e6fa0d898",
+  "id" : "6cebddb6-5dc1-4eeb-94a2-506605a5ebde",
   "name" : "AliBlobStoreIT_testDownloadWithKmsKey-DELETE-0",
   "request" : {
     "url" : "/conformance-tests/kms/download-happy-path",
@@ -13,13 +13,13 @@
   "response" : {
     "status" : 204,
     "headers" : {
-      "x-oss-request-id" : "6A0F7EA999244C3638589DEA",
-      "x-oss-server-time" : "45",
+      "x-oss-request-id" : "6A32E19ABA20453636B2BC6D",
+      "x-oss-server-time" : "29",
       "Server" : "AliyunOSS",
-      "Date" : "Thu, 21 May 2026 21:52:41 GMT"
+      "Date" : "Wed, 17 Jun 2026 18:04:10 GMT"
     }
   },
-  "uuid" : "1a233ae4-b847-47fc-856e-403e6fa0d898",
+  "uuid" : "6cebddb6-5dc1-4eeb-94a2-506605a5ebde",
   "persistent" : true,
-  "insertionIndex" : 41
+  "insertionIndex" : 91
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownloadwithkmskey-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownloadwithkmskey-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "5f8159d7-1515-4cef-b0ed-760127c3f24d",
+  "id" : "b670ae85-04b2-48f2-9a22-d9e600832c40",
   "name" : "AliBlobStoreIT_testDownloadWithKmsKey-GET-1",
   "request" : {
     "url" : "/conformance-tests/kms/download-happy-path",
@@ -14,21 +14,23 @@
     "status" : 200,
     "base64Body" : "VGVzdCBkYXRhIGZvciBLTVMgZG93bmxvYWQ=",
     "headers" : {
-      "x-oss-request-id" : "6A0F7EA95AAB5E31354B8DB8",
-      "x-oss-server-time" : "3",
+      "x-oss-request-id" : "6A32E199A4C9F9313814A56F",
+      "x-oss-server-time" : "262",
       "Server" : "AliyunOSS",
       "x-oss-object-type" : "Normal",
-      "Last-Modified" : "Thu, 21 May 2026 21:52:40 GMT",
-      "Date" : "Thu, 21 May 2026 21:52:41 GMT",
+      "x-oss-server-side-encryption" : "KMS",
+      "Last-Modified" : "Wed, 17 Jun 2026 18:04:08 GMT",
+      "Date" : "Wed, 17 Jun 2026 18:04:09 GMT",
       "Content-MD5" : "HYA/8YGA96w8epKOb+FkdQ==",
       "Accept-Ranges" : "bytes",
       "x-oss-storage-class" : "Standard",
       "x-oss-hash-crc64ecma" : "4874043655706260165",
       "ETag" : "\"1D803FF18180F7AC3C7A928E6FE16475\"",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "5f8159d7-1515-4cef-b0ed-760127c3f24d",
+  "uuid" : "b670ae85-04b2-48f2-9a22-d9e600832c40",
   "persistent" : true,
-  "insertionIndex" : 42
+  "insertionIndex" : 92
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownloadwithkmskey-put-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testdownloadwithkmskey-put-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "0ad97c13-87c4-4103-baf7-3ce6c985458d",
+  "id" : "bc5addda-078d-4bfa-a10c-baa3d99e5c53",
   "name" : "AliBlobStoreIT_testDownloadWithKmsKey-PUT-2",
   "request" : {
     "url" : "/conformance-tests/kms/download-happy-path",
@@ -16,16 +16,18 @@
   "response" : {
     "status" : 200,
     "headers" : {
-      "x-oss-request-id" : "6A0F7EA8524E38333805C617",
-      "x-oss-server-time" : "37",
+      "x-oss-request-id" : "6A32E198AF19EA3133DF4509",
+      "x-oss-server-time" : "217",
       "Server" : "AliyunOSS",
       "x-oss-hash-crc64ecma" : "4874043655706260165",
       "ETag" : "\"1D803FF18180F7AC3C7A928E6FE16475\"",
-      "Date" : "Thu, 21 May 2026 21:52:40 GMT",
+      "x-oss-server-side-encryption" : "KMS",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
+      "Date" : "Wed, 17 Jun 2026 18:04:08 GMT",
       "Content-MD5" : "HYA/8YGA96w8epKOb+FkdQ=="
     }
   },
-  "uuid" : "0ad97c13-87c4-4103-baf7-3ce6c985458d",
+  "uuid" : "bc5addda-078d-4bfa-a10c-baa3d99e5c53",
   "persistent" : true,
-  "insertionIndex" : 43
+  "insertionIndex" : 93
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-delete-0.json
@@ -1,0 +1,35 @@
+{
+  "id" : "ce160824-ca80-48ce-b74f-1068bc4f7d3b",
+  "name" : "AliBlobStoreIT_testMultipartUpload_badETag-DELETE-0",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-badETag",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "2FDB397151204CD19BDA61A70809207E"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A3303F451175F3433BFB51A",
+      "x-oss-server-time" : "48",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:30:44 GMT"
+    }
+  },
+  "uuid" : "ce160824-ca80-48ce-b74f-1068bc4f7d3b",
+  "persistent" : true,
+  "insertionIndex" : 123
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-delete-1.json
@@ -1,0 +1,25 @@
+{
+  "id" : "79c6ab4c-b073-40f3-8fcf-731cc22b5103",
+  "name" : "AliBlobStoreIT_testMultipartUpload_badETag-DELETE-1",
+  "request" : {
+    "url" : "/conformance-tests/multipart-badETag",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A3303F33AD86E3835DB6681",
+      "x-oss-server-time" : "33",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:30:43 GMT"
+    }
+  },
+  "uuid" : "79c6ab4c-b073-40f3-8fcf-731cc22b5103",
+  "persistent" : true,
+  "insertionIndex" : 124
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-get-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-get-3.json
@@ -1,0 +1,42 @@
+{
+  "id" : "38d39092-ef0a-41f1-8438-7e56dda08bce",
+  "name" : "AliBlobStoreIT_testMultipartUpload_badETag-GET-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-badETag",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "2FDB397151204CD19BDA61A70809207E"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListPartsResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-badETag</Key>\n  <UploadId>2FDB397151204CD19BDA61A70809207E</UploadId>\n  <StorageClass>Standard</StorageClass>\n  <PartNumberMarker>0</PartNumberMarker>\n  <NextPartNumberMarker>4</NextPartNumberMarker>\n  <MaxParts>1000</MaxParts>\n  <IsTruncated>false</IsTruncated>\n  <Part>\n    <PartNumber>2</PartNumber>\n    <LastModified>2026-06-17T20:30:36.000Z</LastModified>\n    <ETag>\"2B5C91AD399409EC9B409B66F5BB00FB\"</ETag>\n    <HashCrc64ecma>14920568100270865136</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n  <Part>\n    <PartNumber>3</PartNumber>\n    <LastModified>2026-06-17T20:30:38.000Z</LastModified>\n    <ETag>\"267C038CC2EC32FFD0EE2512FF5DA5A5\"</ETag>\n    <HashCrc64ecma>9618452871104087932</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n  <Part>\n    <PartNumber>4</PartNumber>\n    <LastModified>2026-06-17T20:30:41.000Z</LastModified>\n    <ETag>\"FE9E522B589EF23E2C49B65C0522CE97\"</ETag>\n    <HashCrc64ecma>13592587331863467000</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n</ListPartsResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A3303F2945E9F3032CFE571",
+      "x-oss-server-time" : "72",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:30:42 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "38d39092-ef0a-41f1-8438-7e56dda08bce",
+  "persistent" : true,
+  "insertionIndex" : 126
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-post-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-post-2.json
@@ -1,0 +1,46 @@
+{
+  "id" : "9f6dd405-22c0-467b-9752-a8e81a018e02",
+  "name" : "AliBlobStoreIT_testMultipartUpload_badETag-POST-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-badETag",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "2FDB397151204CD19BDA61A70809207E"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<CompleteMultipartUpload><Part><PartNumber>2</PartNumber><ETag>2B5C91AD399409EC9B409B66F5BB00FB</ETag></Part><Part><PartNumber>3</PartNumber><ETag>267C038CC2EC32FFD0EE2512FF5DA5A5fake</ETag></Part><Part><PartNumber>4</PartNumber><ETag>FE9E522B589EF23E2C49B65C0522CE97</ETag></Part></CompleteMultipartUpload>"
+    } ]
+  },
+  "response" : {
+    "status" : 400,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>InvalidPart</Code>\n  <Message>One or more of the specified parts could not be found or the specified entity tag might not have matched the part's entity tag.</Message>\n  <RequestId>6A3303F3DCEE8230378AF17E</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <ETag>267C038CC2EC32FFD0EE2512FF5DA5A5fake</ETag>\n  <PartNumber>3</PartNumber>\n  <UploadId>2FDB397151204CD19BDA61A70809207E</UploadId>\n  <EC>0042-00000212</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0042-00000212</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A3303F3DCEE8230378AF17E",
+      "x-oss-server-time" : "46",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0042-00000212",
+      "Date" : "Wed, 17 Jun 2026 20:30:43 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "9f6dd405-22c0-467b-9752-a8e81a018e02",
+  "persistent" : true,
+  "insertionIndex" : 125
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-post-7.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-post-7.json
@@ -1,0 +1,42 @@
+{
+  "id" : "5365c79a-f30e-40c3-b740-cdc319e6659a",
+  "name" : "AliBlobStoreIT_testMultipartUpload_badETag-POST-7",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-badETag",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-badETag</Key>\n  <UploadId>2FDB397151204CD19BDA61A70809207E</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A3303E989F0063931F3437E",
+      "x-oss-server-time" : "59",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:30:33 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "5365c79a-f30e-40c3-b740-cdc319e6659a",
+  "persistent" : true,
+  "insertionIndex" : 130
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-put-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-put-4.json
@@ -1,0 +1,44 @@
+{
+  "id" : "e31327d7-93d7-4045-b48d-b04f0724429d",
+  "name" : "AliBlobStoreIT_testMultipartUpload_badETag-PUT-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-badETag",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "2FDB397151204CD19BDA61A70809207E"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "4"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A3303EF3D437D313462754A",
+      "x-oss-server-time" : "108",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "13592587331863467000",
+      "ETag" : "\"FE9E522B589EF23E2C49B65C0522CE97\"",
+      "Date" : "Wed, 17 Jun 2026 20:30:41 GMT",
+      "Content-MD5" : "/p5SK1ie8j4sSbZcBSLOlw=="
+    }
+  },
+  "uuid" : "e31327d7-93d7-4045-b48d-b04f0724429d",
+  "persistent" : true,
+  "insertionIndex" : 127
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-put-5.json
@@ -1,0 +1,44 @@
+{
+  "id" : "f8ac9e80-35ea-4528-a2df-7f10b27038a4",
+  "name" : "AliBlobStoreIT_testMultipartUpload_badETag-PUT-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-badETag",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "2FDB397151204CD19BDA61A70809207E"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "3"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A3303ED603E7D32397E329F",
+      "x-oss-server-time" : "90",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "9618452871104087932",
+      "ETag" : "\"267C038CC2EC32FFD0EE2512FF5DA5A5\"",
+      "Date" : "Wed, 17 Jun 2026 20:30:38 GMT",
+      "Content-MD5" : "JnwDjMLsMv/Q7iUS/12lpQ=="
+    }
+  },
+  "uuid" : "f8ac9e80-35ea-4528-a2df-7f10b27038a4",
+  "persistent" : true,
+  "insertionIndex" : 128
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_badetag-put-6.json
@@ -1,0 +1,44 @@
+{
+  "id" : "bfc5e62e-29f4-4661-9ee8-0fc81042a7e5",
+  "name" : "AliBlobStoreIT_testMultipartUpload_badETag-PUT-6",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-badETag",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "2FDB397151204CD19BDA61A70809207E"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A3303EA99244C3035040313",
+      "x-oss-server-time" : "127",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"2B5C91AD399409EC9B409B66F5BB00FB\"",
+      "Date" : "Wed, 17 Jun 2026 20:30:36 GMT",
+      "Content-MD5" : "K1yRrTmUCeybQJtm9bsA+w=="
+    }
+  },
+  "uuid" : "bfc5e62e-29f4-4661-9ee8-0fc81042a7e5",
+  "persistent" : true,
+  "insertionIndex" : 129
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-delete-0.json
@@ -1,0 +1,38 @@
+{
+  "id" : "6210367c-9ce7-4ecc-8a24-3f20fe74225c",
+  "name" : "AliBlobStoreIT_testMultipartUpload_duplicateParts-DELETE-0",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-duplicateParts",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "E8C79F1C396D410FAB710852FCC1A357"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchUpload</Code>\n  <Message>The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.</Message>\n  <RequestId>6A3304354896753331781A2D</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <UploadId>E8C79F1C396D410FAB710852FCC1A357</UploadId>\n  <EC>0042-00000002</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0042-00000002</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A3304354896753331781A2D",
+      "x-oss-server-time" : "42",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0042-00000002",
+      "Date" : "Wed, 17 Jun 2026 20:31:49 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "6210367c-9ce7-4ecc-8a24-3f20fe74225c",
+  "persistent" : true,
+  "insertionIndex" : 177
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-delete-1.json
@@ -1,0 +1,25 @@
+{
+  "id" : "3051ad4b-ad4a-42de-ac5c-1de205636bad",
+  "name" : "AliBlobStoreIT_testMultipartUpload_duplicateParts-DELETE-1",
+  "request" : {
+    "url" : "/conformance-tests/multipart-duplicateParts",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A3304357F7A763138F757FC",
+      "x-oss-server-time" : "17",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:31:49 GMT"
+    }
+  },
+  "uuid" : "3051ad4b-ad4a-42de-ac5c-1de205636bad",
+  "persistent" : true,
+  "insertionIndex" : 178
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-get-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-get-4.json
@@ -1,0 +1,42 @@
+{
+  "id" : "4c70e31f-822c-42de-80c8-89c678dd5fbb",
+  "name" : "AliBlobStoreIT_testMultipartUpload_duplicateParts-GET-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-duplicateParts",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "E8C79F1C396D410FAB710852FCC1A357"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListPartsResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-duplicateParts</Key>\n  <UploadId>E8C79F1C396D410FAB710852FCC1A357</UploadId>\n  <StorageClass>Standard</StorageClass>\n  <PartNumberMarker>0</PartNumberMarker>\n  <NextPartNumberMarker>3</NextPartNumberMarker>\n  <MaxParts>1000</MaxParts>\n  <IsTruncated>false</IsTruncated>\n  <Part>\n    <PartNumber>2</PartNumber>\n    <LastModified>2026-06-17T20:31:45.000Z</LastModified>\n    <ETag>\"FE9E522B589EF23E2C49B65C0522CE97\"</ETag>\n    <HashCrc64ecma>13592587331863467000</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n  <Part>\n    <PartNumber>3</PartNumber>\n    <LastModified>2026-06-17T20:31:43.000Z</LastModified>\n    <ETag>\"267C038CC2EC32FFD0EE2512FF5DA5A5\"</ETag>\n    <HashCrc64ecma>9618452871104087932</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n</ListPartsResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A3304323870173438A0A328",
+      "x-oss-server-time" : "11",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:31:46 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "4c70e31f-822c-42de-80c8-89c678dd5fbb",
+  "persistent" : true,
+  "insertionIndex" : 181
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-head-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-head-2.json
@@ -1,0 +1,34 @@
+{
+  "id" : "219618bb-00d8-41d2-b91b-1de1f4b3cf55",
+  "name" : "AliBlobStoreIT_testMultipartUpload_duplicateParts-HEAD-2",
+  "request" : {
+    "url" : "/conformance-tests/multipart-duplicateParts",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A33043451175F38387BBD1B",
+      "x-oss-server-time" : "12",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Multipart",
+      "Last-Modified" : "Wed, 17 Jun 2026 20:31:47 GMT",
+      "Date" : "Wed, 17 Jun 2026 20:31:48 GMT",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "2131419258895295297",
+      "ETag" : "\"8B2D0ADCE4928086C89F8F6B87E504C7-2\"",
+      "Vary" : "Accept-Encoding",
+      "x-oss-meta-567" : "456",
+      "Content-Type" : "text/plain"
+    }
+  },
+  "uuid" : "219618bb-00d8-41d2-b91b-1de1f4b3cf55",
+  "persistent" : true,
+  "insertionIndex" : 179
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-post-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-post-3.json
@@ -1,0 +1,47 @@
+{
+  "id" : "747c5979-83b3-4fe7-a2f6-74a6bd8ce87b",
+  "name" : "AliBlobStoreIT_testMultipartUpload_duplicateParts-POST-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-duplicateParts",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "E8C79F1C396D410FAB710852FCC1A357"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<CompleteMultipartUpload><Part><PartNumber>2</PartNumber><ETag>FE9E522B589EF23E2C49B65C0522CE97</ETag></Part><Part><PartNumber>3</PartNumber><ETag>267C038CC2EC32FFD0EE2512FF5DA5A5</ETag></Part></CompleteMultipartUpload>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CompleteMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Location>https://chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com/conformance-tests/multipart-duplicateParts</Location>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-duplicateParts</Key>\n  <ETag>\"8B2D0ADCE4928086C89F8F6B87E504C7-2\"</ETag>\n</CompleteMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A330433598BE13230433CE7",
+      "x-oss-server-time" : "68",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "2131419258895295297",
+      "ETag" : "\"8B2D0ADCE4928086C89F8F6B87E504C7-2\"",
+      "Date" : "Wed, 17 Jun 2026 20:31:47 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "747c5979-83b3-4fe7-a2f6-74a6bd8ce87b",
+  "persistent" : true,
+  "insertionIndex" : 180
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-post-8.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-post-8.json
@@ -1,0 +1,42 @@
+{
+  "id" : "abf49404-301a-4db4-83cd-0f6a12b66f13",
+  "name" : "AliBlobStoreIT_testMultipartUpload_duplicateParts-POST-8",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-duplicateParts",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-duplicateParts</Key>\n  <UploadId>E8C79F1C396D410FAB710852FCC1A357</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A33042A7F7A7637398A28FC",
+      "x-oss-server-time" : "56",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:31:38 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "abf49404-301a-4db4-83cd-0f6a12b66f13",
+  "persistent" : true,
+  "insertionIndex" : 185
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-put-5.json
@@ -1,0 +1,46 @@
+{
+  "id" : "cc90815c-37b0-4e33-b00d-62da9cdfaf1d",
+  "name" : "AliBlobStoreIT_testMultipartUpload_duplicateParts-PUT-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-duplicateParts",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "E8C79F1C396D410FAB710852FCC1A357"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A33043078C4B53939402505",
+      "x-oss-server-time" : "66",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "13592587331863467000",
+      "ETag" : "\"FE9E522B589EF23E2C49B65C0522CE97\"",
+      "Date" : "Wed, 17 Jun 2026 20:31:45 GMT",
+      "Content-MD5" : "/p5SK1ie8j4sSbZcBSLOlw=="
+    }
+  },
+  "uuid" : "cc90815c-37b0-4e33-b00d-62da9cdfaf1d",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-multipart-duplicateParts",
+  "requiredScenarioState" : "scenario-1-conformance-tests-multipart-duplicateParts-2",
+  "insertionIndex" : 182
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-put-6.json
@@ -1,0 +1,44 @@
+{
+  "id" : "c2d84689-07af-460e-97a8-c943fb23e0f5",
+  "name" : "AliBlobStoreIT_testMultipartUpload_duplicateParts-PUT-6",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-duplicateParts",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "E8C79F1C396D410FAB710852FCC1A357"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "3"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A33042D9357953431A57335",
+      "x-oss-server-time" : "70",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "9618452871104087932",
+      "ETag" : "\"267C038CC2EC32FFD0EE2512FF5DA5A5\"",
+      "Date" : "Wed, 17 Jun 2026 20:31:43 GMT",
+      "Content-MD5" : "JnwDjMLsMv/Q7iUS/12lpQ=="
+    }
+  },
+  "uuid" : "c2d84689-07af-460e-97a8-c943fb23e0f5",
+  "persistent" : true,
+  "insertionIndex" : 183
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-put-7.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_duplicateparts-put-7.json
@@ -1,0 +1,47 @@
+{
+  "id" : "7a89d7e4-e52b-4565-ad0f-43f9b9b73700",
+  "name" : "AliBlobStoreIT_testMultipartUpload_duplicateParts-PUT-7",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-duplicateParts",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "E8C79F1C396D410FAB710852FCC1A357"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A33042BEE609A3932A1B944",
+      "x-oss-server-time" : "96",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"2B5C91AD399409EC9B409B66F5BB00FB\"",
+      "Date" : "Wed, 17 Jun 2026 20:31:41 GMT",
+      "Content-MD5" : "K1yRrTmUCeybQJtm9bsA+w=="
+    }
+  },
+  "uuid" : "7a89d7e4-e52b-4565-ad0f-43f9b9b73700",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-conformance-tests-multipart-duplicateParts",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-conformance-tests-multipart-duplicateParts-2",
+  "insertionIndex" : 184
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-delete-0.json
@@ -1,0 +1,38 @@
+{
+  "id" : "9b79d013-42c2-4ad1-8427-0cc31b35fd5c",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleParts-DELETE-0",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-multipleParts",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "1193F808DD6D40DFAE9259A34AE86870"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchUpload</Code>\n  <Message>The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.</Message>\n  <RequestId>6A3304291AA5CE32393E2EFC</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <UploadId>1193F808DD6D40DFAE9259A34AE86870</UploadId>\n  <EC>0042-00000002</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0042-00000002</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A3304291AA5CE32393E2EFC",
+      "x-oss-server-time" : "35",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0042-00000002",
+      "Date" : "Wed, 17 Jun 2026 20:31:37 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "9b79d013-42c2-4ad1-8427-0cc31b35fd5c",
+  "persistent" : true,
+  "insertionIndex" : 166
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-delete-1.json
@@ -1,0 +1,25 @@
+{
+  "id" : "a15d8aeb-f81a-4b76-bbe6-58a9d5202d64",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleParts-DELETE-1",
+  "request" : {
+    "url" : "/conformance-tests/multipart-multipleParts",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A3304283870173231497A28",
+      "x-oss-server-time" : "64",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:31:36 GMT"
+    }
+  },
+  "uuid" : "a15d8aeb-f81a-4b76-bbe6-58a9d5202d64",
+  "persistent" : true,
+  "insertionIndex" : 167
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-get-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-get-4.json
@@ -1,0 +1,42 @@
+{
+  "id" : "466321ba-688e-46ac-9b0c-d1fb4fa444b5",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleParts-GET-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-multipleParts",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "1193F808DD6D40DFAE9259A34AE86870"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListPartsResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-multipleParts</Key>\n  <UploadId>1193F808DD6D40DFAE9259A34AE86870</UploadId>\n  <StorageClass>Standard</StorageClass>\n  <PartNumberMarker>0</PartNumberMarker>\n  <NextPartNumberMarker>4</NextPartNumberMarker>\n  <MaxParts>1000</MaxParts>\n  <IsTruncated>false</IsTruncated>\n  <Part>\n    <PartNumber>1</PartNumber>\n    <LastModified>2026-06-17T20:31:25.000Z</LastModified>\n    <ETag>\"2B5C91AD399409EC9B409B66F5BB00FB\"</ETag>\n    <HashCrc64ecma>14920568100270865136</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n  <Part>\n    <PartNumber>2</PartNumber>\n    <LastModified>2026-06-17T20:31:28.000Z</LastModified>\n    <ETag>\"267C038CC2EC32FFD0EE2512FF5DA5A5\"</ETag>\n    <HashCrc64ecma>9618452871104087932</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n  <Part>\n    <PartNumber>3</PartNumber>\n    <LastModified>2026-06-17T20:31:30.000Z</LastModified>\n    <ETag>\"FE9E522B589EF23E2C49B65C0522CE97\"</ETag>\n    <HashCrc64ecma>13592587331863467000</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n  <Part>\n    <PartNumber>4</PartNumber>\n    <LastModified>2026-06-17T20:31:33.000Z</LastModified>\n    <ETag>\"00AD619297CCD041956FE69BE4251D30\"</ETag>\n    <HashCrc64ecma>1273867173178489956</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n</ListPartsResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A33042678C4B53733CFF804",
+      "x-oss-server-time" : "45",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:31:34 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "466321ba-688e-46ac-9b0c-d1fb4fa444b5",
+  "persistent" : true,
+  "insertionIndex" : 170
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-head-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-head-2.json
@@ -1,0 +1,34 @@
+{
+  "id" : "122defd6-29bf-4e2d-b13b-5d8f25c54fb8",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleParts-HEAD-2",
+  "request" : {
+    "url" : "/conformance-tests/multipart-multipleParts",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A330427DF515539329EB4BA",
+      "x-oss-server-time" : "41",
+      "x-oss-meta-234" : "456",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Multipart",
+      "Last-Modified" : "Wed, 17 Jun 2026 20:31:35 GMT",
+      "Date" : "Wed, 17 Jun 2026 20:31:35 GMT",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "11036478350852953674",
+      "ETag" : "\"BFA040D81294131557D89349E5E51658-4\"",
+      "Vary" : "Accept-Encoding",
+      "Content-Type" : "text/plain"
+    }
+  },
+  "uuid" : "122defd6-29bf-4e2d-b13b-5d8f25c54fb8",
+  "persistent" : true,
+  "insertionIndex" : 168
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-post-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-post-3.json
@@ -1,0 +1,47 @@
+{
+  "id" : "980069e2-7c76-4e7c-9720-59212065171a",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleParts-POST-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-multipleParts",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "1193F808DD6D40DFAE9259A34AE86870"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>2B5C91AD399409EC9B409B66F5BB00FB</ETag></Part><Part><PartNumber>2</PartNumber><ETag>267C038CC2EC32FFD0EE2512FF5DA5A5</ETag></Part><Part><PartNumber>3</PartNumber><ETag>FE9E522B589EF23E2C49B65C0522CE97</ETag></Part><Part><PartNumber>4</PartNumber><ETag>00AD619297CCD041956FE69BE4251D30</ETag></Part></CompleteMultipartUpload>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CompleteMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Location>https://chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com/conformance-tests/multipart-multipleParts</Location>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-multipleParts</Key>\n  <ETag>\"BFA040D81294131557D89349E5E51658-4\"</ETag>\n</CompleteMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A330427B899983130962D57",
+      "x-oss-server-time" : "73",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "11036478350852953674",
+      "ETag" : "\"BFA040D81294131557D89349E5E51658-4\"",
+      "Date" : "Wed, 17 Jun 2026 20:31:35 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "980069e2-7c76-4e7c-9720-59212065171a",
+  "persistent" : true,
+  "insertionIndex" : 169
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-post-9.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-post-9.json
@@ -1,0 +1,42 @@
+{
+  "id" : "7e4306e0-613f-4c59-83d5-771a6b289a1c",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleParts-POST-9",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-multipleParts",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-multipleParts</Key>\n  <UploadId>1193F808DD6D40DFAE9259A34AE86870</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A33041A26AA8C37320DF1B2",
+      "x-oss-server-time" : "55",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:31:22 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "7e4306e0-613f-4c59-83d5-771a6b289a1c",
+  "persistent" : true,
+  "insertionIndex" : 175
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-put-5.json
@@ -1,0 +1,44 @@
+{
+  "id" : "cfc6dc64-fcb5-4dba-9f4c-d5791dcce396",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleParts-PUT-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-multipleParts",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "1193F808DD6D40DFAE9259A34AE86870"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "4"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A330423933F913131B92B89",
+      "x-oss-server-time" : "112",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "1273867173178489956",
+      "ETag" : "\"00AD619297CCD041956FE69BE4251D30\"",
+      "Date" : "Wed, 17 Jun 2026 20:31:33 GMT",
+      "Content-MD5" : "AK1hkpfM0EGVb+ab5CUdMA=="
+    }
+  },
+  "uuid" : "cfc6dc64-fcb5-4dba-9f4c-d5791dcce396",
+  "persistent" : true,
+  "insertionIndex" : 171
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-put-6.json
@@ -1,0 +1,44 @@
+{
+  "id" : "61fd356b-28e4-412f-b1a6-3a56c9bcd436",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleParts-PUT-6",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-multipleParts",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "1193F808DD6D40DFAE9259A34AE86870"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "3"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A3304203BC91B36315DDC95",
+      "x-oss-server-time" : "76",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "13592587331863467000",
+      "ETag" : "\"FE9E522B589EF23E2C49B65C0522CE97\"",
+      "Date" : "Wed, 17 Jun 2026 20:31:30 GMT",
+      "Content-MD5" : "/p5SK1ie8j4sSbZcBSLOlw=="
+    }
+  },
+  "uuid" : "61fd356b-28e4-412f-b1a6-3a56c9bcd436",
+  "persistent" : true,
+  "insertionIndex" : 172
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-put-7.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-put-7.json
@@ -1,0 +1,44 @@
+{
+  "id" : "d3371ab2-25e7-4201-99ad-057ac5f79dd8",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleParts-PUT-7",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-multipleParts",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "1193F808DD6D40DFAE9259A34AE86870"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A33041EA79166343862F5D7",
+      "x-oss-server-time" : "78",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "9618452871104087932",
+      "ETag" : "\"267C038CC2EC32FFD0EE2512FF5DA5A5\"",
+      "Date" : "Wed, 17 Jun 2026 20:31:28 GMT",
+      "Content-MD5" : "JnwDjMLsMv/Q7iUS/12lpQ=="
+    }
+  },
+  "uuid" : "d3371ab2-25e7-4201-99ad-057ac5f79dd8",
+  "persistent" : true,
+  "insertionIndex" : 173
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-put-8.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_multipleparts-put-8.json
@@ -1,0 +1,44 @@
+{
+  "id" : "d031ec7d-084c-4d18-ac5d-9280aca78aad",
+  "name" : "AliBlobStoreIT_testMultipartUpload_multipleParts-PUT-8",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-multipleParts",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "1193F808DD6D40DFAE9259A34AE86870"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A33041B81731C31313D3A9A",
+      "x-oss-server-time" : "126",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"2B5C91AD399409EC9B409B66F5BB00FB\"",
+      "Date" : "Wed, 17 Jun 2026 20:31:25 GMT",
+      "Content-MD5" : "K1yRrTmUCeybQJtm9bsA+w=="
+    }
+  },
+  "uuid" : "d031ec7d-084c-4d18-ac5d-9280aca78aad",
+  "persistent" : true,
+  "insertionIndex" : 174
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_nonexistentparts-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_nonexistentparts-delete-0.json
@@ -1,0 +1,35 @@
+{
+  "id" : "b7c32a46-4576-48ae-a9ed-06855834345e",
+  "name" : "AliBlobStoreIT_testMultipartUpload_nonExistentParts-DELETE-0",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-nonExistentParts",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "73F26E07F6A94FEF92F438D34AFE2B3C"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A3304109357953335FBF734",
+      "x-oss-server-time" : "13",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:31:12 GMT"
+    }
+  },
+  "uuid" : "b7c32a46-4576-48ae-a9ed-06855834345e",
+  "persistent" : true,
+  "insertionIndex" : 150
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_nonexistentparts-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_nonexistentparts-delete-1.json
@@ -1,0 +1,25 @@
+{
+  "id" : "cf7a3e42-1ef7-4488-9bcc-8106d439fec1",
+  "name" : "AliBlobStoreIT_testMultipartUpload_nonExistentParts-DELETE-1",
+  "request" : {
+    "url" : "/conformance-tests/multipart-nonExistentParts",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A33040F8896FB3339F90772",
+      "x-oss-server-time" : "10",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:31:11 GMT"
+    }
+  },
+  "uuid" : "cf7a3e42-1ef7-4488-9bcc-8106d439fec1",
+  "persistent" : true,
+  "insertionIndex" : 151
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_nonexistentparts-get-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_nonexistentparts-get-3.json
@@ -1,0 +1,42 @@
+{
+  "id" : "ee5d5784-9145-4deb-80c9-6484bd006d50",
+  "name" : "AliBlobStoreIT_testMultipartUpload_nonExistentParts-GET-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-nonExistentParts",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "73F26E07F6A94FEF92F438D34AFE2B3C"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListPartsResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-nonExistentParts</Key>\n  <UploadId>73F26E07F6A94FEF92F438D34AFE2B3C</UploadId>\n  <StorageClass>Standard</StorageClass>\n  <PartNumberMarker>0</PartNumberMarker>\n  <NextPartNumberMarker>2</NextPartNumberMarker>\n  <MaxParts>1000</MaxParts>\n  <IsTruncated>false</IsTruncated>\n  <Part>\n    <PartNumber>2</PartNumber>\n    <LastModified>2026-06-17T20:31:08.000Z</LastModified>\n    <ETag>\"2B5C91AD399409EC9B409B66F5BB00FB\"</ETag>\n    <HashCrc64ecma>14920568100270865136</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n</ListPartsResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A33040D9357953239C5EB34",
+      "x-oss-server-time" : "42",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:31:09 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "ee5d5784-9145-4deb-80c9-6484bd006d50",
+  "persistent" : true,
+  "insertionIndex" : 153
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_nonexistentparts-post-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_nonexistentparts-post-2.json
@@ -1,0 +1,46 @@
+{
+  "id" : "8470d75f-1f96-4db0-90ff-6e5ac0a325d7",
+  "name" : "AliBlobStoreIT_testMultipartUpload_nonExistentParts-POST-2",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-nonExistentParts",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "73F26E07F6A94FEF92F438D34AFE2B3C"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<CompleteMultipartUpload><Part><PartNumber>2</PartNumber><ETag>2B5C91AD399409EC9B409B66F5BB00FB</ETag></Part><Part><PartNumber>3</PartNumber><ETag>fakeEtag</ETag></Part></CompleteMultipartUpload>"
+    } ]
+  },
+  "response" : {
+    "status" : 400,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>InvalidPart</Code>\n  <Message>One or more of the specified parts could not be found or the specified entity tag might not have matched the part's entity tag.</Message>\n  <RequestId>6A33040E3BC91B3739B58C95</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <ETag>fakeEtag</ETag>\n  <PartNumber>3</PartNumber>\n  <UploadId>73F26E07F6A94FEF92F438D34AFE2B3C</UploadId>\n  <EC>0042-00000212</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0042-00000212</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A33040E3BC91B3739B58C95",
+      "x-oss-server-time" : "40",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0042-00000212",
+      "Date" : "Wed, 17 Jun 2026 20:31:10 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "8470d75f-1f96-4db0-90ff-6e5ac0a325d7",
+  "persistent" : true,
+  "insertionIndex" : 152
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_nonexistentparts-post-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_nonexistentparts-post-5.json
@@ -1,0 +1,42 @@
+{
+  "id" : "00184717-d3b5-4f58-915d-94648f70bb14",
+  "name" : "AliBlobStoreIT_testMultipartUpload_nonExistentParts-POST-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-nonExistentParts",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-nonExistentParts</Key>\n  <UploadId>73F26E07F6A94FEF92F438D34AFE2B3C</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A33040A9670D23531820404",
+      "x-oss-server-time" : "49",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:31:06 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "00184717-d3b5-4f58-915d-94648f70bb14",
+  "persistent" : true,
+  "insertionIndex" : 155
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_nonexistentparts-put-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_nonexistentparts-put-4.json
@@ -1,0 +1,44 @@
+{
+  "id" : "10682f8b-f881-4746-8ae1-3ac8bc3a3ce8",
+  "name" : "AliBlobStoreIT_testMultipartUpload_nonExistentParts-PUT-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-nonExistentParts",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "73F26E07F6A94FEF92F438D34AFE2B3C"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A33040B46D8993036BC6460",
+      "x-oss-server-time" : "73",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"2B5C91AD399409EC9B409B66F5BB00FB\"",
+      "Date" : "Wed, 17 Jun 2026 20:31:08 GMT",
+      "Content-MD5" : "K1yRrTmUCeybQJtm9bsA+w=="
+    }
+  },
+  "uuid" : "10682f8b-f881-4746-8ae1-3ac8bc3a3ce8",
+  "persistent" : true,
+  "insertionIndex" : 154
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-delete-0.json
@@ -1,0 +1,38 @@
+{
+  "id" : "f750a30b-9d22-4662-aeab-fd154e976daf",
+  "name" : "AliBlobStoreIT_testMultipartUpload_singlePart-DELETE-0",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-singlePart",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "533523211BF844A3BC5CB48B0E17AA42"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchUpload</Code>\n  <Message>The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.</Message>\n  <RequestId>6A33040967EC9C32316C144A</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <UploadId>533523211BF844A3BC5CB48B0E17AA42</UploadId>\n  <EC>0042-00000002</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0042-00000002</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A33040967EC9C32316C144A",
+      "x-oss-server-time" : "50",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0042-00000002",
+      "Date" : "Wed, 17 Jun 2026 20:31:05 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "f750a30b-9d22-4662-aeab-fd154e976daf",
+  "persistent" : true,
+  "insertionIndex" : 142
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-delete-1.json
@@ -1,0 +1,25 @@
+{
+  "id" : "50569624-aec2-4e6b-87d9-35fa199fb796",
+  "name" : "AliBlobStoreIT_testMultipartUpload_singlePart-DELETE-1",
+  "request" : {
+    "url" : "/conformance-tests/multipart-singlePart",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A33040811D2913431D022B3",
+      "x-oss-server-time" : "130",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:31:04 GMT"
+    }
+  },
+  "uuid" : "50569624-aec2-4e6b-87d9-35fa199fb796",
+  "persistent" : true,
+  "insertionIndex" : 143
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-get-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-get-4.json
@@ -1,0 +1,42 @@
+{
+  "id" : "2ee41a20-3107-4dd1-83fc-2b8313009696",
+  "name" : "AliBlobStoreIT_testMultipartUpload_singlePart-GET-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-singlePart",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "533523211BF844A3BC5CB48B0E17AA42"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListPartsResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-singlePart</Key>\n  <UploadId>533523211BF844A3BC5CB48B0E17AA42</UploadId>\n  <StorageClass>Standard</StorageClass>\n  <PartNumberMarker>0</PartNumberMarker>\n  <NextPartNumberMarker>1</NextPartNumberMarker>\n  <MaxParts>1000</MaxParts>\n  <IsTruncated>false</IsTruncated>\n  <Part>\n    <PartNumber>1</PartNumber>\n    <LastModified>2026-06-17T20:31:00.000Z</LastModified>\n    <ETag>\"2B5C91AD399409EC9B409B66F5BB00FB\"</ETag>\n    <HashCrc64ecma>14920568100270865136</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n</ListPartsResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A33040582E54D3738DDF212",
+      "x-oss-server-time" : "50",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:31:01 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "2ee41a20-3107-4dd1-83fc-2b8313009696",
+  "persistent" : true,
+  "insertionIndex" : 146
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-head-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-head-2.json
@@ -1,0 +1,34 @@
+{
+  "id" : "1283efa5-77f6-44b0-ba15-0938cdb5f0c9",
+  "name" : "AliBlobStoreIT_testMultipartUpload_singlePart-HEAD-2",
+  "request" : {
+    "url" : "/conformance-tests/multipart-singlePart",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A330407DCEE82353889467F",
+      "x-oss-server-time" : "5",
+      "Server" : "AliyunOSS",
+      "x-oss-meta-123" : "456",
+      "x-oss-object-type" : "Multipart",
+      "Last-Modified" : "Wed, 17 Jun 2026 20:31:02 GMT",
+      "Date" : "Wed, 17 Jun 2026 20:31:03 GMT",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"E00BEA22A07DB22215B2A4D889CB4C8A-1\"",
+      "Vary" : "Accept-Encoding",
+      "Content-Type" : "text/plain"
+    }
+  },
+  "uuid" : "1283efa5-77f6-44b0-ba15-0938cdb5f0c9",
+  "persistent" : true,
+  "insertionIndex" : 144
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-post-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-post-3.json
@@ -1,0 +1,47 @@
+{
+  "id" : "0c6cd01e-e22b-4392-9dbe-b480dac50e44",
+  "name" : "AliBlobStoreIT_testMultipartUpload_singlePart-POST-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-singlePart",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "533523211BF844A3BC5CB48B0E17AA42"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>2B5C91AD399409EC9B409B66F5BB00FB</ETag></Part></CompleteMultipartUpload>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CompleteMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Location>https://chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com/conformance-tests/multipart-singlePart</Location>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-singlePart</Key>\n  <ETag>\"E00BEA22A07DB22215B2A4D889CB4C8A-1\"</ETag>\n</CompleteMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A3304063D437D30316DD14A",
+      "x-oss-server-time" : "23",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"E00BEA22A07DB22215B2A4D889CB4C8A-1\"",
+      "Date" : "Wed, 17 Jun 2026 20:31:02 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "0c6cd01e-e22b-4392-9dbe-b480dac50e44",
+  "persistent" : true,
+  "insertionIndex" : 145
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-post-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-post-6.json
@@ -1,0 +1,42 @@
+{
+  "id" : "8cf80652-bba9-46aa-9a9a-57878a07ca96",
+  "name" : "AliBlobStoreIT_testMultipartUpload_singlePart-POST-6",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-singlePart",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-singlePart</Key>\n  <UploadId>533523211BF844A3BC5CB48B0E17AA42</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A33040200A1C23931E57B84",
+      "x-oss-server-time" : "55",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:30:58 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "8cf80652-bba9-46aa-9a9a-57878a07ca96",
+  "persistent" : true,
+  "insertionIndex" : 148
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_singlepart-put-5.json
@@ -1,0 +1,44 @@
+{
+  "id" : "3d9f6e1d-cb07-4432-8f9c-e926a1649bca",
+  "name" : "AliBlobStoreIT_testMultipartUpload_singlePart-PUT-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-singlePart",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "533523211BF844A3BC5CB48B0E17AA42"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A330403D89153303640C8D7",
+      "x-oss-server-time" : "101",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"2B5C91AD399409EC9B409B66F5BB00FB\"",
+      "Date" : "Wed, 17 Jun 2026 20:31:00 GMT",
+      "Content-MD5" : "K1yRrTmUCeybQJtm9bsA+w=="
+    }
+  },
+  "uuid" : "3d9f6e1d-cb07-4432-8f9c-e926a1649bca",
+  "persistent" : true,
+  "insertionIndex" : 147
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-delete-0.json
@@ -1,0 +1,38 @@
+{
+  "id" : "f436fc9c-ba3f-46da-ad1d-46ba177f6e7f",
+  "name" : "AliBlobStoreIT_testMultipartUpload_skippingNumbers-DELETE-0",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-skippingNumbers",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "6682F54B0D2441AF94E4E34E58CFF0AF"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchUpload</Code>\n  <Message>The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.</Message>\n  <RequestId>6A33040199244C3233CB6013</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <UploadId>6682F54B0D2441AF94E4E34E58CFF0AF</UploadId>\n  <EC>0042-00000002</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0042-00000002</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A33040199244C3233CB6013",
+      "x-oss-server-time" : "4",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0042-00000002",
+      "Date" : "Wed, 17 Jun 2026 20:30:57 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "f436fc9c-ba3f-46da-ad1d-46ba177f6e7f",
+  "persistent" : true,
+  "insertionIndex" : 132
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-delete-1.json
@@ -1,0 +1,25 @@
+{
+  "id" : "408180d9-9aaf-4a92-b521-506f2cd55dc5",
+  "name" : "AliBlobStoreIT_testMultipartUpload_skippingNumbers-DELETE-1",
+  "request" : {
+    "url" : "/conformance-tests/multipart-skippingNumbers",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A330400F1AA1038373AC7DB",
+      "x-oss-server-time" : "80",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:30:56 GMT"
+    }
+  },
+  "uuid" : "408180d9-9aaf-4a92-b521-506f2cd55dc5",
+  "persistent" : true,
+  "insertionIndex" : 133
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-get-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-get-4.json
@@ -1,0 +1,42 @@
+{
+  "id" : "97eb8a23-70ff-4a26-8f76-2835abd5e7d3",
+  "name" : "AliBlobStoreIT_testMultipartUpload_skippingNumbers-GET-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-skippingNumbers",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "6682F54B0D2441AF94E4E34E58CFF0AF"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListPartsResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-skippingNumbers</Key>\n  <UploadId>6682F54B0D2441AF94E4E34E58CFF0AF</UploadId>\n  <StorageClass>Standard</StorageClass>\n  <PartNumberMarker>0</PartNumberMarker>\n  <NextPartNumberMarker>6</NextPartNumberMarker>\n  <MaxParts>1000</MaxParts>\n  <IsTruncated>false</IsTruncated>\n  <Part>\n    <PartNumber>2</PartNumber>\n    <LastModified>2026-06-17T20:30:48.000Z</LastModified>\n    <ETag>\"2B5C91AD399409EC9B409B66F5BB00FB\"</ETag>\n    <HashCrc64ecma>14920568100270865136</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n  <Part>\n    <PartNumber>3</PartNumber>\n    <LastModified>2026-06-17T20:30:50.000Z</LastModified>\n    <ETag>\"267C038CC2EC32FFD0EE2512FF5DA5A5\"</ETag>\n    <HashCrc64ecma>9618452871104087932</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n  <Part>\n    <PartNumber>6</PartNumber>\n    <LastModified>2026-06-17T20:30:53.000Z</LastModified>\n    <ETag>\"FE9E522B589EF23E2C49B65C0522CE97\"</ETag>\n    <HashCrc64ecma>13592587331863467000</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n</ListPartsResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A3303FEE116C630304255E4",
+      "x-oss-server-time" : "37",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:30:54 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "97eb8a23-70ff-4a26-8f76-2835abd5e7d3",
+  "persistent" : true,
+  "insertionIndex" : 136
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-head-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-head-2.json
@@ -1,0 +1,34 @@
+{
+  "id" : "7e426080-e052-4665-8eed-df2e5c753b3a",
+  "name" : "AliBlobStoreIT_testMultipartUpload_skippingNumbers-HEAD-2",
+  "request" : {
+    "url" : "/conformance-tests/multipart-skippingNumbers",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A3303FF57D51434369D3E0A",
+      "x-oss-server-time" : "32",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Multipart",
+      "Last-Modified" : "Wed, 17 Jun 2026 20:30:55 GMT",
+      "Date" : "Wed, 17 Jun 2026 20:30:55 GMT",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "10306256359930404492",
+      "ETag" : "\"CC02DC03DED7B38B441058D78C28066B-3\"",
+      "x-oss-meta-456" : "456",
+      "Vary" : "Accept-Encoding",
+      "Content-Type" : "text/plain"
+    }
+  },
+  "uuid" : "7e426080-e052-4665-8eed-df2e5c753b3a",
+  "persistent" : true,
+  "insertionIndex" : 134
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-post-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-post-3.json
@@ -1,0 +1,47 @@
+{
+  "id" : "70ac562e-aaf1-462c-aeba-7f17ce089dd2",
+  "name" : "AliBlobStoreIT_testMultipartUpload_skippingNumbers-POST-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-skippingNumbers",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "6682F54B0D2441AF94E4E34E58CFF0AF"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<CompleteMultipartUpload><Part><PartNumber>2</PartNumber><ETag>2B5C91AD399409EC9B409B66F5BB00FB</ETag></Part><Part><PartNumber>3</PartNumber><ETag>267C038CC2EC32FFD0EE2512FF5DA5A5</ETag></Part><Part><PartNumber>6</PartNumber><ETag>FE9E522B589EF23E2C49B65C0522CE97</ETag></Part></CompleteMultipartUpload>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CompleteMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Location>https://chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com/conformance-tests/multipart-skippingNumbers</Location>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-skippingNumbers</Key>\n  <ETag>\"CC02DC03DED7B38B441058D78C28066B-3\"</ETag>\n</CompleteMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A3303FFF1AA10383483C0DB",
+      "x-oss-server-time" : "86",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "10306256359930404492",
+      "ETag" : "\"CC02DC03DED7B38B441058D78C28066B-3\"",
+      "Date" : "Wed, 17 Jun 2026 20:30:55 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "70ac562e-aaf1-462c-aeba-7f17ce089dd2",
+  "persistent" : true,
+  "insertionIndex" : 135
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-post-8.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-post-8.json
@@ -1,0 +1,42 @@
+{
+  "id" : "7880eb9f-5de3-4c8e-8781-644b3d477e6c",
+  "name" : "AliBlobStoreIT_testMultipartUpload_skippingNumbers-POST-8",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-skippingNumbers",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-skippingNumbers</Key>\n  <UploadId>6682F54B0D2441AF94E4E34E58CFF0AF</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A3303F53AD86E3634236E81",
+      "x-oss-server-time" : "13",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:30:45 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "7880eb9f-5de3-4c8e-8781-644b3d477e6c",
+  "persistent" : true,
+  "insertionIndex" : 140
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-put-5.json
@@ -1,0 +1,44 @@
+{
+  "id" : "f23dc96e-00f4-4b8b-b076-9d007cf03189",
+  "name" : "AliBlobStoreIT_testMultipartUpload_skippingNumbers-PUT-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-skippingNumbers",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "6682F54B0D2441AF94E4E34E58CFF0AF"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "6"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A3303FBA38F1A3539DA4101",
+      "x-oss-server-time" : "99",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "13592587331863467000",
+      "ETag" : "\"FE9E522B589EF23E2C49B65C0522CE97\"",
+      "Date" : "Wed, 17 Jun 2026 20:30:53 GMT",
+      "Content-MD5" : "/p5SK1ie8j4sSbZcBSLOlw=="
+    }
+  },
+  "uuid" : "f23dc96e-00f4-4b8b-b076-9d007cf03189",
+  "persistent" : true,
+  "insertionIndex" : 137
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-put-6.json
@@ -1,0 +1,44 @@
+{
+  "id" : "e45af9b4-c6aa-4fde-ba6e-30f59811b656",
+  "name" : "AliBlobStoreIT_testMultipartUpload_skippingNumbers-PUT-6",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-skippingNumbers",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "6682F54B0D2441AF94E4E34E58CFF0AF"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "3"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A3303F93D437D3639DC9C4A",
+      "x-oss-server-time" : "60",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "9618452871104087932",
+      "ETag" : "\"267C038CC2EC32FFD0EE2512FF5DA5A5\"",
+      "Date" : "Wed, 17 Jun 2026 20:30:50 GMT",
+      "Content-MD5" : "JnwDjMLsMv/Q7iUS/12lpQ=="
+    }
+  },
+  "uuid" : "e45af9b4-c6aa-4fde-ba6e-30f59811b656",
+  "persistent" : true,
+  "insertionIndex" : 138
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-put-7.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_skippingnumbers-put-7.json
@@ -1,0 +1,44 @@
+{
+  "id" : "db0b4cf2-9403-41a4-a82a-714c56cc1c6d",
+  "name" : "AliBlobStoreIT_testMultipartUpload_skippingNumbers-PUT-7",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-skippingNumbers",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "6682F54B0D2441AF94E4E34E58CFF0AF"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A3303F6945E9F3931A6F771",
+      "x-oss-server-time" : "71",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"2B5C91AD399409EC9B409B66F5BB00FB\"",
+      "Date" : "Wed, 17 Jun 2026 20:30:48 GMT",
+      "Content-MD5" : "K1yRrTmUCeybQJtm9bsA+w=="
+    }
+  },
+  "uuid" : "db0b4cf2-9403-41a4-a82a-714c56cc1c6d",
+  "persistent" : true,
+  "insertionIndex" : 139
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-delete-0.json
@@ -1,0 +1,38 @@
+{
+  "id" : "5e7c31fa-abd9-49c3-b78b-36d7797a8e1f",
+  "name" : "AliBlobStoreIT_testMultipartUpload_unorderedMultipleParts-DELETE-0",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-unorderedMultipleParts",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CD239A88289643BD9BDA0720102EB42A"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchUpload</Code>\n  <Message>The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.</Message>\n  <RequestId>6A330A06986E29393372A772</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <UploadId>CD239A88289643BD9BDA0720102EB42A</UploadId>\n  <EC>0042-00000002</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0042-00000002</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A330A06986E29393372A772",
+      "x-oss-server-time" : "40",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0042-00000002",
+      "Date" : "Wed, 17 Jun 2026 20:56:38 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "5e7c31fa-abd9-49c3-b78b-36d7797a8e1f",
+  "persistent" : true,
+  "insertionIndex" : 139
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-delete-1.json
@@ -1,0 +1,25 @@
+{
+  "id" : "5bc81b8d-82fe-407d-85b4-15bf043d2c1c",
+  "name" : "AliBlobStoreIT_testMultipartUpload_unorderedMultipleParts-DELETE-1",
+  "request" : {
+    "url" : "/conformance-tests/multipart-unorderedMultipleParts",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A330A054A9D983537368C63",
+      "x-oss-server-time" : "32",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:56:37 GMT"
+    }
+  },
+  "uuid" : "5bc81b8d-82fe-407d-85b4-15bf043d2c1c",
+  "persistent" : true,
+  "insertionIndex" : 140
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-get-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-get-4.json
@@ -1,0 +1,42 @@
+{
+  "id" : "a3a2c49e-e6aa-44d7-b324-7e00756a1308",
+  "name" : "AliBlobStoreIT_testMultipartUpload_unorderedMultipleParts-GET-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-unorderedMultipleParts",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CD239A88289643BD9BDA0720102EB42A"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListPartsResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-unorderedMultipleParts</Key>\n  <UploadId>CD239A88289643BD9BDA0720102EB42A</UploadId>\n  <StorageClass>Standard</StorageClass>\n  <PartNumberMarker>0</PartNumberMarker>\n  <NextPartNumberMarker>2</NextPartNumberMarker>\n  <MaxParts>1000</MaxParts>\n  <IsTruncated>false</IsTruncated>\n  <Part>\n    <PartNumber>1</PartNumber>\n    <LastModified>2026-06-17T20:56:31.000Z</LastModified>\n    <ETag>\"2B5C91AD399409EC9B409B66F5BB00FB\"</ETag>\n    <HashCrc64ecma>14920568100270865136</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n  <Part>\n    <PartNumber>2</PartNumber>\n    <LastModified>2026-06-17T20:56:34.000Z</LastModified>\n    <ETag>\"267C038CC2EC32FFD0EE2512FF5DA5A5\"</ETag>\n    <HashCrc64ecma>9618452871104087932</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n</ListPartsResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A330A03A1E8F83333D51E4E",
+      "x-oss-server-time" : "26",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:56:35 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "a3a2c49e-e6aa-44d7-b324-7e00756a1308",
+  "persistent" : true,
+  "insertionIndex" : 143
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-head-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-head-2.json
@@ -1,0 +1,34 @@
+{
+  "id" : "184555fa-7648-4f05-bc84-90e56890afe4",
+  "name" : "AliBlobStoreIT_testMultipartUpload_unorderedMultipleParts-HEAD-2",
+  "request" : {
+    "url" : "/conformance-tests/multipart-unorderedMultipleParts",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A330A0467EC9C32381E9163",
+      "x-oss-server-time" : "43",
+      "Server" : "AliyunOSS",
+      "x-oss-meta-345" : "456",
+      "x-oss-object-type" : "Multipart",
+      "Last-Modified" : "Wed, 17 Jun 2026 20:56:36 GMT",
+      "Date" : "Wed, 17 Jun 2026 20:56:36 GMT",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "16941702395769382088",
+      "ETag" : "\"8C11B624ED7D61A26D45D7A28FE98349-2\"",
+      "Vary" : "Accept-Encoding",
+      "Content-Type" : "text/plain"
+    }
+  },
+  "uuid" : "184555fa-7648-4f05-bc84-90e56890afe4",
+  "persistent" : true,
+  "insertionIndex" : 141
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-post-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-post-3.json
@@ -1,0 +1,47 @@
+{
+  "id" : "a8882537-da99-40cd-b69b-942329f8b235",
+  "name" : "AliBlobStoreIT_testMultipartUpload_unorderedMultipleParts-POST-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-unorderedMultipleParts",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CD239A88289643BD9BDA0720102EB42A"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>2B5C91AD399409EC9B409B66F5BB00FB</ETag></Part><Part><PartNumber>2</PartNumber><ETag>267C038CC2EC32FFD0EE2512FF5DA5A5</ETag></Part></CompleteMultipartUpload>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CompleteMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Location>https://chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com/conformance-tests/multipart-unorderedMultipleParts</Location>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-unorderedMultipleParts</Key>\n  <ETag>\"8C11B624ED7D61A26D45D7A28FE98349-2\"</ETag>\n</CompleteMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A330A049E5E0B3234025716",
+      "x-oss-server-time" : "51",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "16941702395769382088",
+      "ETag" : "\"8C11B624ED7D61A26D45D7A28FE98349-2\"",
+      "Date" : "Wed, 17 Jun 2026 20:56:36 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "a8882537-da99-40cd-b69b-942329f8b235",
+  "persistent" : true,
+  "insertionIndex" : 142
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-post-7.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-post-7.json
@@ -1,0 +1,42 @@
+{
+  "id" : "f9cd05a6-2859-4c7b-a3e8-fc941995ae58",
+  "name" : "AliBlobStoreIT_testMultipartUpload_unorderedMultipleParts-POST-7",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-unorderedMultipleParts",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-unorderedMultipleParts</Key>\n  <UploadId>CD239A88289643BD9BDA0720102EB42A</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A3309FDDA12F93335847016",
+      "x-oss-server-time" : "28",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 20:56:29 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "f9cd05a6-2859-4c7b-a3e8-fc941995ae58",
+  "persistent" : true,
+  "insertionIndex" : 146
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-put-5.json
@@ -1,0 +1,44 @@
+{
+  "id" : "05056c93-5fbf-4376-a99a-e5ca1c1a37bb",
+  "name" : "AliBlobStoreIT_testMultipartUpload_unorderedMultipleParts-PUT-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-unorderedMultipleParts",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CD239A88289643BD9BDA0720102EB42A"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A330A00BA2045363937C219",
+      "x-oss-server-time" : "122",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "9618452871104087932",
+      "ETag" : "\"267C038CC2EC32FFD0EE2512FF5DA5A5\"",
+      "Date" : "Wed, 17 Jun 2026 20:56:34 GMT",
+      "Content-MD5" : "JnwDjMLsMv/Q7iUS/12lpQ=="
+    }
+  },
+  "uuid" : "05056c93-5fbf-4376-a99a-e5ca1c1a37bb",
+  "persistent" : true,
+  "insertionIndex" : 144
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_unorderedmultipleparts-put-6.json
@@ -1,0 +1,44 @@
+{
+  "id" : "286f6158-0848-4d30-9409-5e6604cff894",
+  "name" : "AliBlobStoreIT_testMultipartUpload_unorderedMultipleParts-PUT-6",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-unorderedMultipleParts",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "CD239A88289643BD9BDA0720102EB42A"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A3309FED3D49733325A8A8D",
+      "x-oss-server-time" : "83",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"2B5C91AD399409EC9B409B66F5BB00FB\"",
+      "Date" : "Wed, 17 Jun 2026 20:56:31 GMT",
+      "Content-MD5" : "K1yRrTmUCeybQJtm9bsA+w=="
+    }
+  },
+  "uuid" : "286f6158-0848-4d30-9409-5e6604cff894",
+  "persistent" : true,
+  "insertionIndex" : 145
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-delete-0.json
@@ -1,0 +1,38 @@
+{
+  "id" : "9f5c630a-ca4d-44c5-b70e-cab98cea7be9",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withKms-DELETE-0",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withKms",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "585F5259F3BE433CBED29234B270C9BC"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error>\n  <Code>NoSuchUpload</Code>\n  <Message>The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.</Message>\n  <RequestId>6A32E1A7A4C9F934343DEC6F</RequestId>\n  <HostId>chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com</HostId>\n  <UploadId>585F5259F3BE433CBED29234B270C9BC</UploadId>\n  <EC>0042-00000002</EC>\n  <RecommendDoc>https://api.aliyun.com/troubleshoot?q=0042-00000002</RecommendDoc>\n</Error>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A32E1A7A4C9F934343DEC6F",
+      "x-oss-server-time" : "3",
+      "Server" : "AliyunOSS",
+      "x-oss-ec" : "0042-00000002",
+      "Date" : "Wed, 17 Jun 2026 18:04:23 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "9f5c630a-ca4d-44c5-b70e-cab98cea7be9",
+  "persistent" : true,
+  "insertionIndex" : 99
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-delete-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-delete-1.json
@@ -1,0 +1,25 @@
+{
+  "id" : "9d505b68-23e4-49f1-b1be-8896109818d1",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withKms-DELETE-1",
+  "request" : {
+    "url" : "/conformance-tests/multipart-withKms",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A32E1A706B2B23237F85964",
+      "x-oss-server-time" : "73",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 18:04:23 GMT"
+    }
+  },
+  "uuid" : "9d505b68-23e4-49f1-b1be-8896109818d1",
+  "persistent" : true,
+  "insertionIndex" : 100
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-get-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-get-4.json
@@ -1,0 +1,42 @@
+{
+  "id" : "42ee6f88-0cfd-4bb7-b99d-b110eefdaf21",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withKms-GET-4",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withKms",
+    "method" : "GET",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "585F5259F3BE433CBED29234B270C9BC"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListPartsResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-withKms</Key>\n  <UploadId>585F5259F3BE433CBED29234B270C9BC</UploadId>\n  <StorageClass>Standard</StorageClass>\n  <PartNumberMarker>0</PartNumberMarker>\n  <NextPartNumberMarker>2</NextPartNumberMarker>\n  <MaxParts>1000</MaxParts>\n  <IsTruncated>false</IsTruncated>\n  <Part>\n    <PartNumber>1</PartNumber>\n    <LastModified>2026-06-17T18:04:17.000Z</LastModified>\n    <ETag>\"2B5C91AD399409EC9B409B66F5BB00FB\"</ETag>\n    <HashCrc64ecma>14920568100270865136</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n  <Part>\n    <PartNumber>2</PartNumber>\n    <LastModified>2026-06-17T18:04:19.000Z</LastModified>\n    <ETag>\"267C038CC2EC32FFD0EE2512FF5DA5A5\"</ETag>\n    <HashCrc64ecma>9618452871104087932</HashCrc64ecma>\n    <Size>5242880</Size>\n  </Part>\n</ListPartsResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A32E1A41017793832443A71",
+      "x-oss-server-time" : "43",
+      "Server" : "AliyunOSS",
+      "Date" : "Wed, 17 Jun 2026 18:04:20 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "42ee6f88-0cfd-4bb7-b99d-b110eefdaf21",
+  "persistent" : true,
+  "insertionIndex" : 103
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-head-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-head-2.json
@@ -1,0 +1,36 @@
+{
+  "id" : "b739f6e3-e39a-4d0d-b7a9-f050b39fbdf3",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withKms-HEAD-2",
+  "request" : {
+    "url" : "/conformance-tests/multipart-withKms",
+    "method" : "HEAD",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A32E1A66AC388363234DA96",
+      "x-oss-server-time" : "63",
+      "Server" : "AliyunOSS",
+      "x-oss-object-type" : "Multipart",
+      "x-oss-server-side-encryption" : "KMS",
+      "Last-Modified" : "Wed, 17 Jun 2026 18:04:21 GMT",
+      "Date" : "Wed, 17 Jun 2026 18:04:22 GMT",
+      "Accept-Ranges" : "bytes",
+      "x-oss-storage-class" : "Standard",
+      "x-oss-hash-crc64ecma" : "16941702395769382088",
+      "ETag" : "\"8C11B624ED7D61A26D45D7A28FE98349-2\"",
+      "Vary" : "Accept-Encoding",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
+      "x-oss-meta-encryption" : "kms",
+      "Content-Type" : "text/plain"
+    }
+  },
+  "uuid" : "b739f6e3-e39a-4d0d-b7a9-f050b39fbdf3",
+  "persistent" : true,
+  "insertionIndex" : 101
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-post-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-post-3.json
@@ -1,0 +1,49 @@
+{
+  "id" : "8281e070-7ce8-41d3-a464-d4171afee060",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withKms-POST-3",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withKms",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "585F5259F3BE433CBED29234B270C9BC"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>2B5C91AD399409EC9B409B66F5BB00FB</ETag></Part><Part><PartNumber>2</PartNumber><ETag>267C038CC2EC32FFD0EE2512FF5DA5A5</ETag></Part></CompleteMultipartUpload>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<CompleteMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Location>https://chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com/conformance-tests/multipart-withKms</Location>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-withKms</Key>\n  <ETag>\"8C11B624ED7D61A26D45D7A28FE98349-2\"</ETag>\n</CompleteMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A32E1A5279F713739817F0F",
+      "x-oss-server-time" : "72",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "16941702395769382088",
+      "ETag" : "\"8C11B624ED7D61A26D45D7A28FE98349-2\"",
+      "x-oss-server-side-encryption" : "KMS",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
+      "Date" : "Wed, 17 Jun 2026 18:04:21 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "8281e070-7ce8-41d3-a464-d4171afee060",
+  "persistent" : true,
+  "insertionIndex" : 102
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-post-7.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-post-7.json
@@ -1,0 +1,44 @@
+{
+  "id" : "7173d6c0-aae1-412f-8cf4-32a0c1c1db9f",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withKms-POST-7",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withKms",
+    "method" : "POST",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "encoding-type" : {
+        "hasExactly" : [ {
+          "equalTo" : "url"
+        } ]
+      },
+      "uploads" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<InitiateMultipartUploadResult>\n  <EncodingType>url</EncodingType>\n  <Bucket>chameleon-multicloudj-test</Bucket>\n  <Key>conformance-tests%2Fmultipart-withKms</Key>\n  <UploadId>585F5259F3BE433CBED29234B270C9BC</UploadId>\n</InitiateMultipartUploadResult>\n",
+    "headers" : {
+      "x-oss-request-id" : "6A32E19E75B8B633383201BF",
+      "x-oss-server-time" : "170",
+      "Server" : "AliyunOSS",
+      "x-oss-server-side-encryption" : "KMS",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
+      "Date" : "Wed, 17 Jun 2026 18:04:14 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "7173d6c0-aae1-412f-8cf4-32a0c1c1db9f",
+  "persistent" : true,
+  "insertionIndex" : 106
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-put-5.json
@@ -1,0 +1,46 @@
+{
+  "id" : "0958282a-6dd5-431e-8031-4b3cf8713393",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withKms-PUT-5",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withKms",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "585F5259F3BE433CBED29234B270C9BC"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "2"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A32E1A23BC91B37319BFE01",
+      "x-oss-server-time" : "287",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "9618452871104087932",
+      "ETag" : "\"267C038CC2EC32FFD0EE2512FF5DA5A5\"",
+      "x-oss-server-side-encryption" : "KMS",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
+      "Date" : "Wed, 17 Jun 2026 18:04:19 GMT",
+      "Content-MD5" : "JnwDjMLsMv/Q7iUS/12lpQ=="
+    }
+  },
+  "uuid" : "0958282a-6dd5-431e-8031-4b3cf8713393",
+  "persistent" : true,
+  "insertionIndex" : 104
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-put-6.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testmultipartupload_withkms-put-6.json
@@ -1,0 +1,46 @@
+{
+  "id" : "6758b29e-7b0b-4bcb-8bc1-c8b4436b083f",
+  "name" : "AliBlobStoreIT_testMultipartUpload_withKms-PUT-6",
+  "request" : {
+    "urlPath" : "/conformance-tests/multipart-withKms",
+    "method" : "PUT",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      },
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "uploadId" : {
+        "hasExactly" : [ {
+          "equalTo" : "585F5259F3BE433CBED29234B270C9BC"
+        } ]
+      },
+      "partNumber" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "x-oss-request-id" : "6A32E19F603E7D3333EAF60B",
+      "x-oss-server-time" : "233",
+      "Server" : "AliyunOSS",
+      "x-oss-hash-crc64ecma" : "14920568100270865136",
+      "ETag" : "\"2B5C91AD399409EC9B409B66F5BB00FB\"",
+      "x-oss-server-side-encryption" : "KMS",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
+      "Date" : "Wed, 17 Jun 2026 18:04:17 GMT",
+      "Content-MD5" : "K1yRrTmUCeybQJtm9bsA+w=="
+    }
+  },
+  "uuid" : "6758b29e-7b0b-4bcb-8bc1-c8b4436b083f",
+  "persistent" : true,
+  "insertionIndex" : 105
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testrangedreadwithkmskey-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testrangedreadwithkmskey-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "0ddd580e-13cf-4b38-9856-dce512c3435b",
+  "id" : "960360d1-5373-40cd-80fd-58e9f5a6c6b7",
   "name" : "AliBlobStoreIT_testRangedReadWithKmsKey-DELETE-0",
   "request" : {
     "url" : "/conformance-tests/kms/ranged-read",
@@ -13,13 +13,13 @@
   "response" : {
     "status" : 204,
     "headers" : {
-      "x-oss-request-id" : "6A0F7F725E37263935490647",
-      "x-oss-server-time" : "79",
+      "x-oss-request-id" : "6A32E1AD99244C30339A7780",
+      "x-oss-server-time" : "65",
       "Server" : "AliyunOSS",
-      "Date" : "Thu, 21 May 2026 21:56:02 GMT"
+      "Date" : "Wed, 17 Jun 2026 18:04:29 GMT"
     }
   },
-  "uuid" : "0ddd580e-13cf-4b38-9856-dce512c3435b",
+  "uuid" : "960360d1-5373-40cd-80fd-58e9f5a6c6b7",
   "persistent" : true,
-  "insertionIndex" : 360
+  "insertionIndex" : 108
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testrangedreadwithkmskey-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testrangedreadwithkmskey-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "ec230159-6945-41c5-a25f-40f19413180c",
+  "id" : "96609b3e-ad1f-4b68-85c0-a7ff7fbd1dfa",
   "name" : "AliBlobStoreIT_testRangedReadWithKmsKey-GET-1",
   "request" : {
     "url" : "/conformance-tests/kms/ranged-read",
@@ -14,23 +14,25 @@
     "status" : 206,
     "base64Body" : "IHRlc3QgZmlsZQ==",
     "headers" : {
-      "x-oss-request-id" : "6A0F7F71AF19EA383936CFA3",
-      "x-oss-server-time" : "7",
+      "x-oss-request-id" : "6A32E1AC3BC91B3036C23102",
+      "x-oss-server-time" : "45",
       "Server" : "AliyunOSS",
       "Content-Range" : "bytes 41-50/51",
       "x-oss-object-type" : "Normal",
-      "Last-Modified" : "Thu, 21 May 2026 21:55:58 GMT",
-      "Date" : "Thu, 21 May 2026 21:56:01 GMT",
+      "x-oss-server-side-encryption" : "KMS",
+      "Last-Modified" : "Wed, 17 Jun 2026 18:04:25 GMT",
+      "Date" : "Wed, 17 Jun 2026 18:04:28 GMT",
       "Accept-Ranges" : "bytes",
       "x-oss-storage-class" : "Standard",
       "x-oss-hash-crc64ecma" : "17862811016356862860",
       "ETag" : "\"D78F126840EC9CBEFD5252BA8EF7EFD5\"",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "ec230159-6945-41c5-a25f-40f19413180c",
+  "uuid" : "96609b3e-ad1f-4b68-85c0-a7ff7fbd1dfa",
   "persistent" : true,
   "scenarioName" : "scenario-1-conformance-tests-kms-ranged-read",
   "requiredScenarioState" : "scenario-1-conformance-tests-kms-ranged-read-4",
-  "insertionIndex" : 361
+  "insertionIndex" : 109
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testrangedreadwithkmskey-get-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testrangedreadwithkmskey-get-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "dcbfd7b9-3400-4566-8d31-50731f5fc85c",
+  "id" : "7bbe6bdd-69ea-4e6a-af51-124d1913b7ca",
   "name" : "AliBlobStoreIT_testRangedReadWithKmsKey-GET-2",
   "request" : {
     "url" : "/conformance-tests/kms/ranged-read",
@@ -14,24 +14,26 @@
     "status" : 206,
     "base64Body" : "c3QgZGF0YSBmb3IgdGhlIEtNUyByYW5nZWQgcmVhZCB0ZXN0IGZpbGU=",
     "headers" : {
-      "x-oss-request-id" : "6A0F7F71D6C2B53337BDE067",
-      "x-oss-server-time" : "5",
+      "x-oss-request-id" : "6A32E1AB9E87C13339700B59",
+      "x-oss-server-time" : "161",
       "Server" : "AliyunOSS",
       "Content-Range" : "bytes 10-50/51",
       "x-oss-object-type" : "Normal",
-      "Last-Modified" : "Thu, 21 May 2026 21:55:58 GMT",
-      "Date" : "Thu, 21 May 2026 21:56:01 GMT",
+      "x-oss-server-side-encryption" : "KMS",
+      "Last-Modified" : "Wed, 17 Jun 2026 18:04:25 GMT",
+      "Date" : "Wed, 17 Jun 2026 18:04:28 GMT",
       "Accept-Ranges" : "bytes",
       "x-oss-storage-class" : "Standard",
       "x-oss-hash-crc64ecma" : "17862811016356862860",
       "ETag" : "\"D78F126840EC9CBEFD5252BA8EF7EFD5\"",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "dcbfd7b9-3400-4566-8d31-50731f5fc85c",
+  "uuid" : "7bbe6bdd-69ea-4e6a-af51-124d1913b7ca",
   "persistent" : true,
   "scenarioName" : "scenario-1-conformance-tests-kms-ranged-read",
   "requiredScenarioState" : "scenario-1-conformance-tests-kms-ranged-read-3",
   "newScenarioState" : "scenario-1-conformance-tests-kms-ranged-read-4",
-  "insertionIndex" : 362
+  "insertionIndex" : 110
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testrangedreadwithkmskey-get-3.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testrangedreadwithkmskey-get-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "760ce316-7717-4aad-8f4b-9d7aff2abb12",
+  "id" : "7f2ec171-78b5-4493-8ca8-3c40dcf487ad",
   "name" : "AliBlobStoreIT_testRangedReadWithKmsKey-GET-3",
   "request" : {
     "url" : "/conformance-tests/kms/ranged-read",
@@ -14,24 +14,26 @@
     "status" : 206,
     "base64Body" : "c3QgZGF0YSBmb3IgdGhlIEtNUyA=",
     "headers" : {
-      "x-oss-request-id" : "6A0F7F706D612F3239F5A1F9",
-      "x-oss-server-time" : "8",
+      "x-oss-request-id" : "6A32E1AA9357953831F0D2A1",
+      "x-oss-server-time" : "191",
       "Server" : "AliyunOSS",
       "Content-Range" : "bytes 10-29/51",
       "x-oss-object-type" : "Normal",
-      "Last-Modified" : "Thu, 21 May 2026 21:55:58 GMT",
-      "Date" : "Thu, 21 May 2026 21:56:00 GMT",
+      "x-oss-server-side-encryption" : "KMS",
+      "Last-Modified" : "Wed, 17 Jun 2026 18:04:25 GMT",
+      "Date" : "Wed, 17 Jun 2026 18:04:27 GMT",
       "Accept-Ranges" : "bytes",
       "x-oss-storage-class" : "Standard",
       "x-oss-hash-crc64ecma" : "17862811016356862860",
       "ETag" : "\"D78F126840EC9CBEFD5252BA8EF7EFD5\"",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "760ce316-7717-4aad-8f4b-9d7aff2abb12",
+  "uuid" : "7f2ec171-78b5-4493-8ca8-3c40dcf487ad",
   "persistent" : true,
   "scenarioName" : "scenario-1-conformance-tests-kms-ranged-read",
   "requiredScenarioState" : "scenario-1-conformance-tests-kms-ranged-read-2",
   "newScenarioState" : "scenario-1-conformance-tests-kms-ranged-read-3",
-  "insertionIndex" : 363
+  "insertionIndex" : 111
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testrangedreadwithkmskey-get-4.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testrangedreadwithkmskey-get-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "5914186d-4740-4e79-acf1-420c91a22ca5",
+  "id" : "dd3076f7-58b9-47da-88f0-870a267fb48f",
   "name" : "AliBlobStoreIT_testRangedReadWithKmsKey-GET-4",
   "request" : {
     "url" : "/conformance-tests/kms/ranged-read",
@@ -14,24 +14,26 @@
     "status" : 206,
     "base64Body" : "VGhpcyBpcyB0ZQ==",
     "headers" : {
-      "x-oss-request-id" : "6A0F7F6F5AAB5E30381977BB",
-      "x-oss-server-time" : "3",
+      "x-oss-request-id" : "6A32E1A9A8277C3431557904",
+      "x-oss-server-time" : "190",
       "Server" : "AliyunOSS",
       "Content-Range" : "bytes 0-9/51",
       "x-oss-object-type" : "Normal",
-      "Last-Modified" : "Thu, 21 May 2026 21:55:58 GMT",
-      "Date" : "Thu, 21 May 2026 21:55:59 GMT",
+      "x-oss-server-side-encryption" : "KMS",
+      "Last-Modified" : "Wed, 17 Jun 2026 18:04:25 GMT",
+      "Date" : "Wed, 17 Jun 2026 18:04:26 GMT",
       "Accept-Ranges" : "bytes",
       "x-oss-storage-class" : "Standard",
       "x-oss-hash-crc64ecma" : "17862811016356862860",
       "ETag" : "\"D78F126840EC9CBEFD5252BA8EF7EFD5\"",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "5914186d-4740-4e79-acf1-420c91a22ca5",
+  "uuid" : "dd3076f7-58b9-47da-88f0-870a267fb48f",
   "persistent" : true,
   "scenarioName" : "scenario-1-conformance-tests-kms-ranged-read",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-conformance-tests-kms-ranged-read-2",
-  "insertionIndex" : 364
+  "insertionIndex" : 112
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testrangedreadwithkmskey-put-5.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testrangedreadwithkmskey-put-5.json
@@ -1,5 +1,5 @@
 {
-  "id" : "421149c7-d68d-4887-9407-b3a0a5b5c7fd",
+  "id" : "3d3b021e-e851-40a0-9b74-59b28c63fe38",
   "name" : "AliBlobStoreIT_testRangedReadWithKmsKey-PUT-5",
   "request" : {
     "url" : "/conformance-tests/kms/ranged-read",
@@ -16,16 +16,18 @@
   "response" : {
     "status" : 200,
     "headers" : {
-      "x-oss-request-id" : "6A0F7F6E6D612F32304A9CF9",
-      "x-oss-server-time" : "13",
+      "x-oss-request-id" : "6A32E1A88D81BD3334365D12",
+      "x-oss-server-time" : "184",
       "Server" : "AliyunOSS",
       "x-oss-hash-crc64ecma" : "17862811016356862860",
       "ETag" : "\"D78F126840EC9CBEFD5252BA8EF7EFD5\"",
-      "Date" : "Thu, 21 May 2026 21:55:58 GMT",
+      "x-oss-server-side-encryption" : "KMS",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
+      "Date" : "Wed, 17 Jun 2026 18:04:25 GMT",
       "Content-MD5" : "148SaEDsnL79UlK6jvfv1Q=="
     }
   },
-  "uuid" : "421149c7-d68d-4887-9407-b3a0a5b5c7fd",
+  "uuid" : "3d3b021e-e851-40a0-9b74-59b28c63fe38",
   "persistent" : true,
-  "insertionIndex" : 365
+  "insertionIndex" : 113
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testuploadwithkmskey_happypath-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testuploadwithkmskey_happypath-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "b3e11d35-536f-439f-870e-56b0affd198b",
+  "id" : "7e183f2f-9b99-4cc4-828c-83b5fdb014c0",
   "name" : "AliBlobStoreIT_testUploadWithKmsKey_happyPath-DELETE-0",
   "request" : {
     "url" : "/conformance-tests/kms/upload-happy-path",
@@ -13,13 +13,13 @@
   "response" : {
     "status" : 204,
     "headers" : {
-      "x-oss-request-id" : "6A0F7F135C5E11323570DBCB",
-      "x-oss-server-time" : "46",
+      "x-oss-request-id" : "6A32E19DE05A52353710BF94",
+      "x-oss-server-time" : "69",
       "Server" : "AliyunOSS",
-      "Date" : "Thu, 21 May 2026 21:54:27 GMT"
+      "Date" : "Wed, 17 Jun 2026 18:04:13 GMT"
     }
   },
-  "uuid" : "b3e11d35-536f-439f-870e-56b0affd198b",
+  "uuid" : "7e183f2f-9b99-4cc4-828c-83b5fdb014c0",
   "persistent" : true,
-  "insertionIndex" : 193
+  "insertionIndex" : 95
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testuploadwithkmskey_happypath-get-1.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testuploadwithkmskey_happypath-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "2e48f45f-4ef9-453d-bcb1-47c3cedf3fff",
+  "id" : "7e234b82-dd27-4f9b-9bfd-879516c1fe62",
   "name" : "AliBlobStoreIT_testUploadWithKmsKey_happyPath-GET-1",
   "request" : {
     "url" : "/conformance-tests/kms/upload-happy-path",
@@ -14,21 +14,23 @@
     "status" : 200,
     "base64Body" : "VGVzdCBkYXRhIHdpdGggS01TIGVuY3J5cHRpb24=",
     "headers" : {
-      "x-oss-request-id" : "6A0F7F123E95CC32310CDFEA",
-      "x-oss-server-time" : "20",
+      "x-oss-request-id" : "6A32E19C387017303270B394",
+      "x-oss-server-time" : "204",
       "Server" : "AliyunOSS",
       "x-oss-object-type" : "Normal",
-      "Last-Modified" : "Thu, 21 May 2026 21:54:26 GMT",
-      "Date" : "Thu, 21 May 2026 21:54:26 GMT",
+      "x-oss-server-side-encryption" : "KMS",
+      "Last-Modified" : "Wed, 17 Jun 2026 18:04:11 GMT",
+      "Date" : "Wed, 17 Jun 2026 18:04:12 GMT",
       "Content-MD5" : "H9lgtieDqK4r0a/+cewbhw==",
       "Accept-Ranges" : "bytes",
       "x-oss-storage-class" : "Standard",
       "x-oss-hash-crc64ecma" : "17362283864712615466",
       "ETag" : "\"1FD960B62783A8AE2BD1AFFE71EC1B87\"",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "2e48f45f-4ef9-453d-bcb1-47c3cedf3fff",
+  "uuid" : "7e234b82-dd27-4f9b-9bfd-879516c1fe62",
   "persistent" : true,
-  "insertionIndex" : 194
+  "insertionIndex" : 96
 }

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testuploadwithkmskey_happypath-put-2.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testuploadwithkmskey_happypath-put-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "89b6a3dc-8219-49a3-ad08-611987ff46c6",
+  "id" : "ea325531-335c-46d2-b698-204413c867f8",
   "name" : "AliBlobStoreIT_testUploadWithKmsKey_happyPath-PUT-2",
   "request" : {
     "url" : "/conformance-tests/kms/upload-happy-path",
@@ -16,16 +16,18 @@
   "response" : {
     "status" : 200,
     "headers" : {
-      "x-oss-request-id" : "6A0F7F1299244C31380B2BEC",
-      "x-oss-server-time" : "14",
+      "x-oss-request-id" : "6A32E19B4A9D9830331B0FB8",
+      "x-oss-server-time" : "172",
       "Server" : "AliyunOSS",
       "x-oss-hash-crc64ecma" : "17362283864712615466",
       "ETag" : "\"1FD960B62783A8AE2BD1AFFE71EC1B87\"",
-      "Date" : "Thu, 21 May 2026 21:54:26 GMT",
+      "x-oss-server-side-encryption" : "KMS",
+      "x-oss-server-side-encryption-key-id" : "key-shh6a32d9fajtygsv4msy",
+      "Date" : "Wed, 17 Jun 2026 18:04:11 GMT",
       "Content-MD5" : "H9lgtieDqK4r0a/+cewbhw=="
     }
   },
-  "uuid" : "89b6a3dc-8219-49a3-ad08-611987ff46c6",
+  "uuid" : "ea325531-335c-46d2-b698-204413c867f8",
   "persistent" : true,
-  "insertionIndex" : 195
+  "insertionIndex" : 97
 }

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -3285,7 +3285,6 @@ public abstract class AbstractBlobStoreIT {
   }
 
   private void runMultipartUploadTest(MultipartUploadTestConfig testConfig) {
-    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
     // Create the BucketClient
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
     BucketClient bucketClient = new BucketClient(blobStore);


### PR DESCRIPTION
## Summary
Enables the Ali OSS multipart-upload helper-tier and SSE-KMS conformance tests, which were previously skipped via a provider guard / unconfigured KMS key. No production code changes — test enablement plus WireMock recordings only.

## Changes
- Remove the Ali provider guard from `runMultipartUploadTest` in `AbstractBlobStoreIT`. This un-gates the 8 active helper-based MPU tests for Ali: `singlePart`, `multipleParts`, `unorderedMultipleParts`, `skippingNumbers`, `duplicateParts`, `nonExistentParts`, `badETag`, and `withKms`.
- Configure `AliBlobStoreIT.getKmsKeyId()` with the cn-shanghai CMK so the SSE-KMS conformance tests genuinely exercise server-side KMS encryption.
- Add WireMock recordings for the 7 non-KMS helper MPU tests and the `withKms` MPU test, and refresh the three simple SSE-KMS recordings (upload happy-path, download, ranged-read) so they carry the `x-oss-server-side-encryption` response headers.

## Why KMS is bundled with the MPU helper tier
`testMultipartUpload_withKms` shares the `runMultipartUploadTest` helper with the other 7 helper-tier MPU tests. Removing the single provider guard on that helper enables all 8 at once — `withKms` cannot be enabled independently of the helper tier, and the helper tier cannot be enabled while leaving `withKms` gated. Wiring up `getKmsKeyId()` in the same change is therefore required for `withKms` to do real KMS work rather than fall back to an `assumeTrue` skip, and the three simple SSE-KMS tests (upload/download/ranged-read) are recorded with the same CMK in the same pass for a coherent KMS coverage story.

## Testing
Verified in replay mode (no credentials):
- **Ali:** 119 run, 0 failures, 23 skipped (remaining skips are sha256, directory ops, presign v2, invalid-checksum, object-lock/retention, versionedCopyFrom — all tracked separately).
- **AWS:** 119 run, 0 failures, 11 skipped.
- **GCP:** 119 run, 0 failures, 6 skipped.

All 8 newly-enabled Ali tests ran and passed. Checkstyle passes; recordings contain no credentials.