### PR TITLE
blobstore: wire maxConnections and idleConnectionTimeout into the Ali OSS client

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -38,6 +38,7 @@ import com.aliyun.sdk.service.oss2.models.UploadPartRequest;
 import com.aliyun.sdk.service.oss2.models.UploadPartResult;
 import com.aliyun.sdk.service.oss2.retry.Retryer;
 import com.aliyun.sdk.service.oss2.transport.BinaryData;
+import com.aliyun.sdk.service.oss2.transport.apache5client.Apache5HttpClientBuilder;
 import com.google.auto.service.AutoService;
 import com.salesforce.multicloudj.blob.driver.AbstractBlobStore;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
@@ -981,7 +982,25 @@ public class AliBlobStore extends AbstractBlobStore implements AliSdkService {
 
       Duration readWriteTimeout =
           resolveReadWriteTimeout(builder.getRetryConfig(), builder.getSocketTimeout());
-      if (readWriteTimeout != null) {
+
+      // Connection-pool size and idle-connection timeout are only settable via HttpClientOptions,
+      // not on the OSS client builder. When the caller sets either, build an explicit transport
+      // client from those options (carrying proxyHost + readWriteTimeout forward so nothing the
+      // builder would otherwise set is lost). When neither is set, leave the SDK to construct its
+      // own default client and set readWriteTimeout directly, preserving the prior behavior.
+      if (builder.getMaxConnections() != null || builder.getIdleConnectionTimeout() != null) {
+        String proxyHost = builder.getProxyEndpoint() != null
+            ? builder.getProxyEndpoint().getHost() + ":" + builder.getProxyEndpoint().getPort()
+            : null;
+        clientBuilder.httpClient(
+            Apache5HttpClientBuilder.create()
+                .options(AliTransformer.toHttpClientOptions(
+                    proxyHost,
+                    readWriteTimeout,
+                    builder.getMaxConnections(),
+                    builder.getIdleConnectionTimeout()))
+                .build());
+      } else if (readWriteTimeout != null) {
         clientBuilder.readWriteTimeout(readWriteTimeout);
       }
 

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -48,6 +48,7 @@ import com.aliyun.sdk.service.oss2.retry.FixedDelayBackoff;
 import com.aliyun.sdk.service.oss2.retry.Retryer;
 import com.aliyun.sdk.service.oss2.retry.StandardRetryer;
 import com.aliyun.sdk.service.oss2.transport.BinaryData;
+import com.aliyun.sdk.service.oss2.transport.HttpClientOptions;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
@@ -800,6 +801,48 @@ public class AliTransformer {
       builder.backoffDelayer(backoff);
     }
 
+    return builder.build();
+  }
+
+  /**
+   * Builds {@link HttpClientOptions} carrying the transport settings MultiCloudJ exposes that map
+   * onto the OSS SDK's HTTP client. Only non-null inputs are applied; any option left unset keeps
+   * the SDK's own default, so a client built from these options behaves identically to the SDK
+   * default client for the unset fields.
+   *
+   * <p>The OSS SDK's {@code OSSClient}/{@code OSSAsyncClient} builders expose no connection-pool or
+   * idle-timeout setters directly; those live only on {@code HttpClientOptions}. Callers therefore
+   * build a transport client (sync {@code Apache5HttpClientBuilder} or async
+   * {@code Apache5AsyncHttpClientBuilder}) from these options and supply it via
+   * {@code .httpClient(...)}. Because supplying a client bypasses the SDK's own
+   * {@code toHttpClientOptions} derivation, the two transport fields the driver otherwise sets on
+   * the client builder ({@code proxyHost}, {@code readWriteTimeout}) must be passed in here so they
+   * are preserved. Reconciled against {@code alibabacloud-oss-v2:0.4.0}.
+   *
+   * @param proxyHost host:port proxy string, or null to leave unset
+   * @param readWriteTimeout resolved read/write timeout, or null to leave unset
+   * @param maxConnections max connection-pool size, or null to leave unset
+   * @param idleConnectionTimeout idle-connection (keep-alive) timeout, or null to leave unset
+   * @return the assembled {@link HttpClientOptions}
+   */
+  public static HttpClientOptions toHttpClientOptions(
+      String proxyHost,
+      Duration readWriteTimeout,
+      Integer maxConnections,
+      Duration idleConnectionTimeout) {
+    HttpClientOptions.Builder builder = HttpClientOptions.custom();
+    if (proxyHost != null) {
+      builder.proxyHost(proxyHost);
+    }
+    if (readWriteTimeout != null) {
+      builder.readWriteTimeout(readWriteTimeout);
+    }
+    if (maxConnections != null) {
+      builder.maxConnections(maxConnections);
+    }
+    if (idleConnectionTimeout != null) {
+      builder.keepAliveTimeout(idleConnectionTimeout);
+    }
     return builder.build();
   }
 

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -72,6 +72,7 @@ import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -940,9 +941,9 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
         // single readWriteTimeout setting. When both are set, attemptTimeout (the
         // more specific per-attempt deadline) takes precedence over the
         // transport-level socketTimeout.
-        java.time.Duration asyncReadWriteTimeout =
+        Duration asyncReadWriteTimeout =
             getRetryConfig() != null && getRetryConfig().getAttemptTimeout() != null
-                ? java.time.Duration.ofMillis(getRetryConfig().getAttemptTimeout())
+                ? Duration.ofMillis(getRetryConfig().getAttemptTimeout())
                 : getSocketTimeout();
         // Connection-pool size and idle-connection timeout are only settable via
         // HttpClientOptions, not on the async client builder. When the caller sets either, build
@@ -988,9 +989,9 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
         // single readWriteTimeout setting. When both are set, attemptTimeout (the
         // more specific per-attempt deadline) takes precedence over the
         // transport-level socketTimeout.
-        java.time.Duration syncReadWriteTimeout =
+        Duration syncReadWriteTimeout =
             getRetryConfig() != null && getRetryConfig().getAttemptTimeout() != null
-                ? java.time.Duration.ofMillis(getRetryConfig().getAttemptTimeout())
+                ? Duration.ofMillis(getRetryConfig().getAttemptTimeout())
                 : getSocketTimeout();
         // Connection-pool size and idle-connection timeout are only settable via
         // HttpClientOptions, not on the sync client builder. When the caller sets either, build

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -21,6 +21,8 @@ import com.aliyun.sdk.service.oss2.retry.Retryer;
 import com.aliyun.sdk.service.oss2.transfermanager.DownloadError;
 import com.aliyun.sdk.service.oss2.transfermanager.Downloader;
 import com.aliyun.sdk.service.oss2.transport.BinaryData;
+import com.aliyun.sdk.service.oss2.transport.apache5client.Apache5AsyncHttpClientBuilder;
+import com.aliyun.sdk.service.oss2.transport.apache5client.Apache5HttpClientBuilder;
 import com.salesforce.multicloudj.blob.ali.AliSdkService;
 import com.salesforce.multicloudj.blob.ali.AliTransformer;
 import com.salesforce.multicloudj.blob.ali.AliTransformerSupplier;
@@ -938,12 +940,30 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
         // single readWriteTimeout setting. When both are set, attemptTimeout (the
         // more specific per-attempt deadline) takes precedence over the
         // transport-level socketTimeout.
-        if (getRetryConfig() != null
-            && getRetryConfig().getAttemptTimeout() != null) {
-          asyncBuilder.readWriteTimeout(
-              java.time.Duration.ofMillis(getRetryConfig().getAttemptTimeout()));
-        } else if (getSocketTimeout() != null) {
-          asyncBuilder.readWriteTimeout(getSocketTimeout());
+        java.time.Duration asyncReadWriteTimeout =
+            getRetryConfig() != null && getRetryConfig().getAttemptTimeout() != null
+                ? java.time.Duration.ofMillis(getRetryConfig().getAttemptTimeout())
+                : getSocketTimeout();
+        // Connection-pool size and idle-connection timeout are only settable via
+        // HttpClientOptions, not on the async client builder. When the caller sets either, build
+        // an explicit async transport client from those options (carrying proxyHost +
+        // readWriteTimeout forward so nothing the builder would otherwise set is lost). When
+        // neither is set, leave the SDK to construct its own default client and set
+        // readWriteTimeout directly, preserving the prior behavior.
+        if (getMaxConnections() != null || getIdleConnectionTimeout() != null) {
+          String proxyHost = getProxyEndpoint() != null
+              ? getProxyEndpoint().getHost() + ":" + getProxyEndpoint().getPort()
+              : null;
+          asyncBuilder.httpClient(
+              Apache5AsyncHttpClientBuilder.create()
+                  .options(AliTransformer.toHttpClientOptions(
+                      proxyHost,
+                      asyncReadWriteTimeout,
+                      getMaxConnections(),
+                      getIdleConnectionTimeout()))
+                  .build());
+        } else if (asyncReadWriteTimeout != null) {
+          asyncBuilder.readWriteTimeout(asyncReadWriteTimeout);
         }
         async = asyncBuilder.build();
       }
@@ -968,12 +988,30 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
         // single readWriteTimeout setting. When both are set, attemptTimeout (the
         // more specific per-attempt deadline) takes precedence over the
         // transport-level socketTimeout.
-        if (getRetryConfig() != null
-            && getRetryConfig().getAttemptTimeout() != null) {
-          syncBuilder.readWriteTimeout(
-              java.time.Duration.ofMillis(getRetryConfig().getAttemptTimeout()));
-        } else if (getSocketTimeout() != null) {
-          syncBuilder.readWriteTimeout(getSocketTimeout());
+        java.time.Duration syncReadWriteTimeout =
+            getRetryConfig() != null && getRetryConfig().getAttemptTimeout() != null
+                ? java.time.Duration.ofMillis(getRetryConfig().getAttemptTimeout())
+                : getSocketTimeout();
+        // Connection-pool size and idle-connection timeout are only settable via
+        // HttpClientOptions, not on the sync client builder. When the caller sets either, build
+        // an explicit sync transport client from those options (carrying proxyHost +
+        // readWriteTimeout forward so nothing the builder would otherwise set is lost). When
+        // neither is set, leave the SDK to construct its own default client and set
+        // readWriteTimeout directly, preserving the prior behavior.
+        if (getMaxConnections() != null || getIdleConnectionTimeout() != null) {
+          String proxyHost = getProxyEndpoint() != null
+              ? getProxyEndpoint().getHost() + ":" + getProxyEndpoint().getPort()
+              : null;
+          syncBuilder.httpClient(
+              Apache5HttpClientBuilder.create()
+                  .options(AliTransformer.toHttpClientOptions(
+                      proxyHost,
+                      syncReadWriteTimeout,
+                      getMaxConnections(),
+                      getIdleConnectionTimeout()))
+                  .build());
+        } else if (syncReadWriteTimeout != null) {
+          syncBuilder.readWriteTimeout(syncReadWriteTimeout);
         }
         sync = syncBuilder.build();
       }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -2040,10 +2040,44 @@ public class AliBlobStoreTest {
   }
 
   @Test
+  void testBuildOSSClient_withOnlyIdleConnectionTimeout_buildsSuccessfully() {
+    AliBlobStore.Builder builder = newRealClientBuilder();
+    builder.withIdleConnectionTimeout(Duration.ofSeconds(45));
+    assertNotNull(builder.build());
+  }
+
+  @Test
   void testBuildOSSClient_withoutConnectionPoolConfig_buildsSuccessfully() {
     // Neither knob set — the SDK builds its own default client (no behavior change). Building
     // must still succeed; combined with the toHttpClientOptions defaults test this guards the
     // no-op path.
     assertDoesNotThrow(() -> newRealClientBuilder().build());
+  }
+
+  @Test
+  void testBuildOSSClient_withConnectionPoolConfigAndNoProxy_buildsSuccessfully() {
+    // Covers the proxyHost==null branch of the explicit-HttpClient path (no proxy endpoint set).
+    StsCredentials creds = new StsCredentials("key-1", "secret-1", "token-1");
+    CredentialsOverrider credsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(creds)
+            .build();
+    AliBlobStore.Builder builder = new AliBlobStore.Builder();
+    builder.withBucket("bucket-1");
+    builder.withRegion("cn-shanghai");
+    builder.withEndpoint(URI.create("https://test.example.com"));
+    builder.withCredentialsOverrider(credsOverrider);
+    builder.withMaxConnections(64);
+    builder.withIdleConnectionTimeout(Duration.ofSeconds(45));
+    assertNotNull(builder.build());
+  }
+
+  @Test
+  void testBuildOSSClient_withSocketTimeoutOnly_usesReadWriteTimeoutBranch() {
+    // No connection-pool knobs but a socketTimeout set — exercises the
+    // else-if readWriteTimeout fallback (default-client path with an explicit timeout).
+    AliBlobStore.Builder builder = newRealClientBuilder();
+    builder.withSocketTimeout(Duration.ofSeconds(30));
+    assertNotNull(builder.build());
   }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -1,5 +1,6 @@
 package com.salesforce.multicloudj.blob.ali;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -2001,5 +2002,48 @@ public class AliBlobStoreTest {
     assertEquals(
         socketTimeout,
         AliBlobStore.Builder.resolveReadWriteTimeout(retryConfig, socketTimeout));
+  }
+
+  // No withClient() — exercises the real buildOSSClient path. Setters are called as statements
+  // (not chained) because the base BlobStoreBuilder setters return BlobStoreBuilder, not the Ali
+  // subtype.
+  private AliBlobStore.Builder newRealClientBuilder() {
+    StsCredentials creds = new StsCredentials("key-1", "secret-1", "token-1");
+    CredentialsOverrider credsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(creds)
+            .build();
+    AliBlobStore.Builder builder = new AliBlobStore.Builder();
+    builder.withBucket("bucket-1");
+    builder.withRegion("cn-shanghai");
+    builder.withEndpoint(URI.create("https://test.example.com"));
+    builder.withProxyEndpoint(URI.create("http://proxy.example.com:80"));
+    builder.withCredentialsOverrider(credsOverrider);
+    return builder;
+  }
+
+  @Test
+  void testBuildOSSClient_withConnectionPoolConfig_buildsSuccessfully() {
+    // Setting maxConnections/idleConnectionTimeout routes through the explicit-HttpClient path
+    // (Apache5HttpClientBuilder.options(...)). Verify the client and store build without error.
+    AliBlobStore.Builder builder = newRealClientBuilder();
+    builder.withMaxConnections(64);
+    builder.withIdleConnectionTimeout(Duration.ofSeconds(45));
+    assertNotNull(builder.build());
+  }
+
+  @Test
+  void testBuildOSSClient_withOnlyMaxConnections_buildsSuccessfully() {
+    AliBlobStore.Builder builder = newRealClientBuilder();
+    builder.withMaxConnections(64);
+    assertNotNull(builder.build());
+  }
+
+  @Test
+  void testBuildOSSClient_withoutConnectionPoolConfig_buildsSuccessfully() {
+    // Neither knob set — the SDK builds its own default client (no behavior change). Building
+    // must still succeed; combined with the toHttpClientOptions defaults test this guards the
+    // no-op path.
+    assertDoesNotThrow(() -> newRealClientBuilder().build());
   }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliCheckArchivedSmokeIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliCheckArchivedSmokeIT.java
@@ -1,0 +1,254 @@
+package com.salesforce.multicloudj.blob.ali;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.aliyun.sdk.service.oss2.OSSClient;
+import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
+import com.aliyun.sdk.service.oss2.exceptions.ServiceException;
+import com.aliyun.sdk.service.oss2.models.DeleteMarkerEntry;
+import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectResult;
+import com.aliyun.sdk.service.oss2.models.ListObjectVersionsRequest;
+import com.aliyun.sdk.service.oss2.models.ListObjectVersionsResult;
+import com.aliyun.sdk.service.oss2.models.ObjectVersion;
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import com.salesforce.multicloudj.blob.driver.UploadRequest;
+import com.salesforce.multicloudj.blob.driver.UploadResponse;
+import com.salesforce.multicloudj.common.ali.AliConstants;
+import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Standalone direct test that empirically verifies what Alibaba OSS returns when a versioned
+ * object is deleted and a normal GET is attempted on the (now non-current) key. This validates the
+ * core assumption behind the Ali <code>checkArchived</code> implementation: that OSS signals the
+ * delete-marker scenario in a way comparable to S3's <code>x-amz-delete-marker</code> header.
+ *
+ * <p>This hits the real OSS service directly (gated on {@code ALIBABA_CLOUD_ACCESS_KEY_ID}, so it
+ * never runs in CI/replay). It uses the <b>raw {@link OSSClient}</b> for the GET attempt and the
+ * follow-up <code>ListObjectVersions</code> so the observable wire-level response is captured
+ * unmodified by the multicloudj transformer.
+ *
+ * <p><b>Requires:</b> {@link #BUCKET} must be a versioned bucket.
+ *
+ * <p>What this test confirms (the open questions from the checkArchived research):
+ * <ol>
+ *   <li>The exception class / status code OSS returns on a deleted-key GET (expected: 404).
+ *   <li>Whether a delete-marker signal is reachable on the response — via
+ *       {@link ServiceException#headers()} (the analog of S3's <code>x-amz-delete-marker</code>)
+ *       and/or {@link GetObjectResult#deleteMarker()}.
+ *   <li>That a follow-up <code>ListObjectVersions</code> returns the prior object version's
+ *       {@code versionId}, and that downloading by that id recovers the original bytes — which is
+ *       what the cross-cloud {@code testDownload_checkArchived} conformance test asserts.
+ * </ol>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfEnvironmentVariable(named = "ALIBABA_CLOUD_ACCESS_KEY_ID", matches = ".+")
+public class AliCheckArchivedSmokeIT {
+
+  private static final String ENDPOINT = "https://oss-cn-shanghai.aliyuncs.com";
+  // Must be a versioned bucket.
+  private static final String BUCKET = "chameleon-multicloudj-test-versioned";
+  private static final String REGION = "cn-shanghai";
+
+  private BucketClient client;
+  // Raw OSS client used for the GET attempt + ListObjectVersions, plus best-effort cleanup
+  // of any prior versions / delete markers left on the test key.
+  private OSSClient rawClient;
+  private String key;
+  private String originalVersionId;
+  private String deleteMarkerVersionId;
+
+  @BeforeAll
+  void setup() {
+    StsCredentials creds =
+        new StsCredentials(
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+            System.getenv("ALIBABA_CLOUD_SECURITY_TOKEN"));
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(creds)
+            .build();
+
+    client =
+        BucketClient.builder(AliConstants.PROVIDER_ID)
+            .withBucket(BUCKET)
+            .withRegion(REGION)
+            .withEndpoint(URI.create(ENDPOINT))
+            .withCredentialsOverrider(credentialsOverrider)
+            .build();
+
+    CredentialsProvider rawCreds =
+        OSSCredentialsProvider.getCredentialsProvider(credentialsOverrider, REGION);
+    rawClient =
+        OSSClient.newBuilder()
+            .region(REGION)
+            .endpoint(ENDPOINT)
+            .credentialsProvider(rawCreds)
+            .build();
+
+    key = "checkarchived-smoke/" + UUID.randomUUID() + "/object";
+  }
+
+  @AfterAll
+  void teardown() throws Exception {
+    // Best-effort cleanup of every version + the delete marker.
+    if (rawClient != null) {
+      if (originalVersionId != null) {
+        try {
+          rawClient.deleteObject(
+              DeleteObjectRequest.newBuilder()
+                  .bucket(BUCKET)
+                  .key(key)
+                  .versionId(originalVersionId)
+                  .build(),
+              OperationOptions.defaults());
+        } catch (Exception ignored) {
+          // ignore
+        }
+      }
+      if (deleteMarkerVersionId != null) {
+        try {
+          rawClient.deleteObject(
+              DeleteObjectRequest.newBuilder()
+                  .bucket(BUCKET)
+                  .key(key)
+                  .versionId(deleteMarkerVersionId)
+                  .build(),
+              OperationOptions.defaults());
+        } catch (Exception ignored) {
+          // ignore
+        }
+      }
+      rawClient.close();
+    }
+    if (client != null) {
+      client.close();
+    }
+  }
+
+  @Test
+  void deletedVersionedObject_get404AndPriorVersionRecoverable() throws Exception {
+    byte[] content = "checkArchived smoke test".getBytes(StandardCharsets.UTF_8);
+
+    // 1. Upload an object via the multicloudj client and capture its version id.
+    UploadResponse uploadResponse;
+    try (ByteArrayInputStream in = new ByteArrayInputStream(content)) {
+      uploadResponse = client.upload(
+          new UploadRequest.Builder()
+              .withKey(key)
+              .withContentLength(content.length)
+              .build(),
+          in);
+    }
+    originalVersionId = uploadResponse.getVersionId();
+    assertNotNull(originalVersionId, "Versioned bucket should return a versionId on upload");
+    System.out.printf("  uploaded %s (originalVersionId=%s)%n", key, originalVersionId);
+
+    // 2. Delete without versionId. On a versioned bucket this creates a delete marker; the prior
+    //    object version remains retrievable by id. multicloudj's delete() does not return the
+    //    delete-marker version id, so we'll discover it via the version listing in step 4.
+    client.delete(key, null);
+    System.out.println("  delete(key, null) issued (expected: delete marker created)");
+
+    // 3. Attempt a normal GET via the RAW OSS client and observe the exact response.
+    //    This is the wire behavior our checkArchived guard will react to.
+    Exception ex = assertThrows(Exception.class,
+        () -> rawClient.getObject(
+            GetObjectRequest.newBuilder().bucket(BUCKET).key(key).build(),
+            OperationOptions.defaults()),
+        "GET of a deleted versioned object should fail");
+    System.out.printf("  raw GET on deleted key threw: %s%n", ex.getClass().getName());
+    System.out.printf("  message: %s%n", ex.getMessage());
+
+    // Walk the cause chain to find the underlying OSS ServiceException so we can inspect
+    // the HTTP status code and the response headers (for delete-marker detection).
+    ServiceException service = findServiceException(ex);
+    assertNotNull(service, "Expected an OSS ServiceException somewhere in the cause chain");
+    System.out.printf("  ServiceException: statusCode=%d, errorCode=%s%n",
+        service.statusCode(), service.errorCode());
+    System.out.println("  ServiceException headers:");
+    Map<String, String> headers = service.headers();
+    if (headers != null) {
+      headers.forEach((k, v) -> System.out.printf("    %s: %s%n", k, v));
+    }
+    assertEquals(404, service.statusCode(),
+        "Expected HTTP 404 for GET on deleted versioned object");
+    // Delete-marker signal — print whether it's present (case-insensitive). This is the assumption
+    // we'll wire the production guard against.
+    boolean deleteMarkerHeaderPresent = headers != null && headers.entrySet().stream()
+        .anyMatch(e -> e.getKey().toLowerCase().contains("delete-marker")
+            && "true".equalsIgnoreCase(e.getValue()));
+    System.out.printf("  x-oss-delete-marker header present and true? %s%n",
+        deleteMarkerHeaderPresent);
+
+    // 4. ListObjectVersions on the prefix. We expect: 1 ObjectVersion (the original), plus
+    //    1 DeleteMarkerEntry (the marker created in step 2). Capture both for the by-version
+    //    download in step 5 and for teardown.
+    ListObjectVersionsResult listResult = rawClient.listObjectVersions(
+        ListObjectVersionsRequest.newBuilder()
+            .bucket(BUCKET)
+            .prefix(key)
+            .maxKeys(10L)
+            .build(),
+        OperationOptions.defaults());
+    List<ObjectVersion> versions = listResult.versions();
+    List<DeleteMarkerEntry> markers = listResult.deleteMarkers();
+    System.out.printf("  versions returned: %d, deleteMarkers returned: %d%n",
+        versions != null ? versions.size() : 0,
+        markers != null ? markers.size() : 0);
+    assertNotNull(versions);
+    assertTrue(versions.stream().anyMatch(v -> originalVersionId.equals(v.versionId())),
+        "ListObjectVersions should include the original version id");
+    if (markers != null && !markers.isEmpty()) {
+      deleteMarkerVersionId = markers.get(0).versionId();
+      System.out.printf("  deleteMarkerVersionId=%s (isLatest=%s)%n",
+          deleteMarkerVersionId, markers.get(0).isLatest());
+    }
+
+    // 5. Download by the prior version's id via the multicloudj client and assert the original
+    //    bytes are recovered. This is exactly what the cross-cloud
+    //    testDownload_checkArchived conformance test will assert once enabled for Ali.
+    java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+    com.salesforce.multicloudj.blob.driver.DownloadResponse dr = client.download(
+        com.salesforce.multicloudj.blob.driver.DownloadRequest.builder()
+            .withKey(key)
+            .withVersionId(originalVersionId)
+            .build(),
+        out);
+    assertNotNull(dr);
+    org.junit.jupiter.api.Assertions.assertArrayEquals(content, out.toByteArray(),
+        "Downloading by the prior version id should recover the original bytes");
+    System.out.println("  by-version download recovered original bytes — "
+        + "checkArchived contract is achievable on OSS");
+  }
+
+  private static ServiceException findServiceException(Throwable t) {
+    Throwable cur = t;
+    while (cur != null) {
+      if (cur instanceof ServiceException) {
+        return (ServiceException) cur;
+      }
+      cur = cur.getCause();
+    }
+    return null;
+  }
+}

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliChecksumHeaderSmokeIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliChecksumHeaderSmokeIT.java
@@ -1,0 +1,236 @@
+package com.salesforce.multicloudj.blob.ali;
+
+import com.aliyun.sdk.service.oss2.hash.CRC64;
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import com.salesforce.multicloudj.blob.driver.ChecksumMethod;
+import com.salesforce.multicloudj.blob.driver.UploadRequest;
+import com.salesforce.multicloudj.blob.driver.UploadResponse;
+import com.salesforce.multicloudj.common.ali.AliConstants;
+import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+import java.util.zip.CRC32C;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Standalone smoke test that probes OSS's behavior toward the {@code x-oss-hash-crc64ecma}
+ * request header. The driver currently routes any non-SHA256 user-supplied checksum into this
+ * header (see {@code AliTransformer.toPutObjectRequest} and {@code toPresignedPutObjectRequest}),
+ * including values computed with {@link ChecksumMethod#CRC32C}. CRC32C and CRC64 produce
+ * different bytes for the same content, so this test asks empirically:
+ *
+ * <ol>
+ *   <li>If the bytes match (real CRC64), does the upload succeed? (sanity)</li>
+ *   <li>If the bytes are obviously wrong, does OSS reject with 400 InvalidDigest, or silently
+ *       accept? Determines whether the header is validated server-side at all.</li>
+ *   <li>If the bytes are a CRC32C-of-the-content placed under the CRC64 header — exactly the
+ *       shape produced when a caller passes {@code ChecksumMethod.CRC32C} — does OSS notice?</li>
+ * </ol>
+ *
+ * <p>Outcome decides the bug severity:
+ * <ul>
+ *   <li>Cases 2 + 3 return <b>400</b> → OSS validates the header. The CRC32C bug manifests as a
+ *       loud failure on every Ali upload that supplies {@code ChecksumMethod.CRC32C}.</li>
+ *   <li>Cases 2 + 3 return <b>200</b> → OSS ignores wrong values in this header on PutObject.
+ *       The CRC32C bug is a silent-integrity-lie: the driver claims a checksum was bound when
+ *       in fact none was. This is the worse outcome.</li>
+ * </ul>
+ *
+ * <p>Gated on {@code ALIBABA_CLOUD_ACCESS_KEY_ID} so it never runs in CI/replay. Uses the
+ * non-versioned conformance bucket {@code chameleon-multicloudj-test}; cleans up after itself.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfEnvironmentVariable(named = "ALIBABA_CLOUD_ACCESS_KEY_ID", matches = ".+")
+public class AliChecksumHeaderSmokeIT {
+
+  private static final String ENDPOINT = "https://oss-cn-shanghai.aliyuncs.com";
+  private static final String BUCKET = "chameleon-multicloudj-test";
+  private static final String REGION = "cn-shanghai";
+
+  private BucketClient client;
+  private String runId;
+
+  @BeforeAll
+  void setup() {
+    StsCredentials creds =
+        new StsCredentials(
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+            System.getenv("ALIBABA_CLOUD_SECURITY_TOKEN"));
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(creds)
+            .build();
+
+    client =
+        BucketClient.builder(AliConstants.PROVIDER_ID)
+            .withBucket(BUCKET)
+            .withRegion(REGION)
+            .withEndpoint(URI.create(ENDPOINT))
+            .withCredentialsOverrider(credentialsOverrider)
+            .build();
+
+    runId = UUID.randomUUID().toString();
+  }
+
+  @AfterAll
+  void teardown() throws Exception {
+    if (client != null) {
+      client.close();
+    }
+  }
+
+  /**
+   * Case 1 (sanity): a real CRC64 of the content, labelled with the (currently unrouted) CRC64
+   * algorithm intent. The driver routes this into {@code x-oss-hash-crc64ecma}. Should succeed.
+   */
+  @Test
+  void case1_realCrc64_succeeds() {
+    String key = keyFor("real-crc64");
+    byte[] content = "smoke checksum test content".getBytes(StandardCharsets.UTF_8);
+    String realCrc64 = computeCrc64(content);
+
+    System.out.println("=== Case 1: real CRC64 in x-oss-hash-crc64ecma ===");
+    System.out.println("  bytes = real CRC64 = " + realCrc64);
+
+    try {
+      // ChecksumMethod.CRC32C is the only non-SHA256 enum value. Driver default routes it
+      // into x-oss-hash-crc64ecma regardless of the algorithm name. We supply a real CRC64 here
+      // so this case isolates "header value matches the body" from "algorithm label mismatch".
+      UploadResponse response = uploadWithChecksum(key, content, realCrc64, ChecksumMethod.CRC32C);
+      System.out.println("  RESULT: 200 OK, etag=" + response.getETag());
+      Assertions.assertNotNull(response.getKey());
+    } finally {
+      safeDelete(key);
+    }
+  }
+
+  /**
+   * Case 2 (validation probe): an obviously wrong CRC64 value. If OSS validates this header on
+   * PutObject, it returns 400 InvalidDigest; if not, it accepts. This case alone settles the
+   * "is the header validated at all" question.
+   */
+  @Test
+  void case2_obviouslyWrongCrc64_revealsValidation() {
+    String key = keyFor("wrong-crc64");
+    byte[] content = "smoke checksum test content".getBytes(StandardCharsets.UTF_8);
+    // Pick a value that cannot possibly be the CRC64 of the content.
+    String fakeChecksum = "12345";
+
+    System.out.println("=== Case 2: obviously wrong CRC64 in x-oss-hash-crc64ecma ===");
+    System.out.println("  bytes = literal '12345' (definitely not CRC64 of body)");
+
+    try {
+      UploadResponse response =
+          uploadWithChecksum(key, content, fakeChecksum, ChecksumMethod.CRC32C);
+      System.out.println("  RESULT: 200 OK — OSS DID NOT validate the header");
+      System.out.println("  → driver is silently shipping unvalidated 'integrity' headers");
+      Assertions.assertNotNull(response.getKey()); // Document the silent-accept outcome.
+    } catch (Exception e) {
+      System.out.println("  RESULT: rejected — OSS DOES validate the header");
+      System.out.println("  exception: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+      // Validation-rejection is also a valid (and louder) outcome; do not fail the test.
+    } finally {
+      safeDelete(key);
+    }
+  }
+
+  /**
+   * Case 3 (the actual bug shape): a real CRC32C of the content placed in the CRC64 header.
+   * This is exactly what the driver produces when a caller passes
+   * {@code ChecksumMethod.CRC32C} with a CRC32C-of-content value.
+   */
+  @Test
+  void case3_crc32cValueInCrc64Header_revealsBugSeverity() {
+    String key = keyFor("crc32c-as-crc64");
+    byte[] content = "smoke checksum test content".getBytes(StandardCharsets.UTF_8);
+    String realCrc32c = computeCrc32cBase64(content);
+    String realCrc64 = computeCrc64(content);
+
+    System.out.println("=== Case 3: real CRC32C bytes in x-oss-hash-crc64ecma ===");
+    System.out.println("  bytes = real CRC32C   = " + realCrc32c);
+    System.out.println("  (the right CRC64 is) = " + realCrc64);
+    System.out.println("  these MUST differ for the test to be meaningful: "
+        + !realCrc32c.equals(realCrc64));
+
+    try {
+      UploadResponse response =
+          uploadWithChecksum(key, content, realCrc32c, ChecksumMethod.CRC32C);
+      System.out.println("  RESULT: 200 OK — OSS accepted CRC32C bytes in CRC64 header");
+      System.out.println("  → SILENT BUG: driver claims integrity binding it does not have");
+      Assertions.assertNotNull(response.getKey());
+    } catch (Exception e) {
+      System.out.println("  RESULT: rejected — OSS noticed the value mismatch");
+      System.out.println("  → LOUD BUG: every Ali upload with ChecksumMethod.CRC32C will fail");
+      System.out.println("  exception: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+    } finally {
+      safeDelete(key);
+    }
+  }
+
+  // ---- helpers ----
+
+  private String keyFor(String label) {
+    return "checksum-smoke/" + runId + "/" + label;
+  }
+
+  private UploadResponse uploadWithChecksum(
+      String key, byte[] content, String checksumValue, ChecksumMethod algorithm) {
+    UploadRequest request =
+        new UploadRequest.Builder()
+            .withKey(key)
+            .withContentLength(content.length)
+            .withChecksumValue(checksumValue)
+            .withChecksumAlgorithm(algorithm)
+            .build();
+    return client.upload(request, new ByteArrayInputStream(content));
+  }
+
+  private void safeDelete(String key) {
+    try {
+      client.delete(key, null);
+    } catch (Exception ignored) {
+      // best-effort
+    }
+  }
+
+  /**
+   * Computes CRC64-ECMA of {@code content} using the Ali SDK's own CRC64 implementation, and
+   * returns the unsigned-decimal-string representation that the multicloudj UploadResponse
+   * surfaces back from a successful upload (matches what {@code AliBlobStoreIT.computeChecksum}
+   * already produces).
+   */
+  private static String computeCrc64(byte[] content) {
+    CRC64 crc64 = new CRC64();
+    crc64.update(content, content.length);
+    return Long.toUnsignedString(crc64.getValue());
+  }
+
+  /**
+   * Computes CRC32C of {@code content} and returns it as a base64-encoded 4-byte big-endian
+   * value — the exact format {@code AbstractBlobStoreIT.computeChecksum()} (the default,
+   * non-Ali harness path) uses for CRC32C, and the format any cross-cloud caller passing
+   * {@code ChecksumMethod.CRC32C} would supply.
+   */
+  private static String computeCrc32cBase64(byte[] content) {
+    CRC32C crc32c = new CRC32C();
+    crc32c.update(content);
+    long v = crc32c.getValue();
+    byte[] out = new byte[4];
+    out[0] = (byte) (v >> 24);
+    out[1] = (byte) (v >> 16);
+    out[2] = (byte) (v >> 8);
+    out[3] = (byte) v;
+    return Base64.getEncoder().encodeToString(out);
+  }
+}

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliKmsManagedKeySmokeIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliKmsManagedKeySmokeIT.java
@@ -1,0 +1,262 @@
+package com.salesforce.multicloudj.blob.ali;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.aliyun.sdk.service.oss2.OSSClient;
+import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
+import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
+import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
+import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
+import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
+import com.aliyun.sdk.service.oss2.transport.BinaryData;
+import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Standalone smoke test that probes UNCONFIRMED OSS server-side behavior for the gap #2
+ * ("useKmsManagedKey") feasibility question: what does OSS do when a PutObject sets
+ * {@code x-oss-server-side-encryption: KMS} but does NOT supply
+ * {@code x-oss-server-side-encryption-key-id}?
+ *
+ * <p>Context: the multicloudj driver wires an explicit {@code kmsKeyId} today, but ignores the
+ * {@code useKmsManagedKey=true} (KMS-with-no-explicit-key) flag that AWS honors. The OSS SDK lets
+ * us build such a request (the key-id setter is independent and optional), and the OSS REST API
+ * docs confirm the key-id header is NOT required with KMS — but NO doc states what key OSS uses
+ * when it is omitted. Three outcomes are possible and undocumented:
+ * <ol>
+ *   <li>OSS encrypts with a default / service-managed CMK (the AWS-equivalent we want), or</li>
+ *   <li>OSS rejects the request (e.g. 400 demanding a key-id), or</li>
+ *   <li>some other behavior.</li>
+ * </ol>
+ * This test exercises the raw {@link OSSClient} to establish ground truth BEFORE we invest in any
+ * driver wiring. Mirrors the standalone real-bucket approach of the other Ali smoke ITs.
+ *
+ * <p>Probes (each PUTs, then HEADs to read back the encryption response headers):
+ * <ul>
+ *   <li><b>Case A</b> — SSE=KMS, NO key id. The crux. Observe: does the PUT succeed? If so, what
+ *       are the {@code x-oss-server-side-encryption} / {@code -key-id} headers on HEAD?</li>
+ *   <li><b>Case B</b> — SSE=KMS, WITH an explicit key id (control). Only meaningful if a real CMK
+ *       id is supplied via {@code ALI_SMOKE_KMS_KEY_ID}; skipped/best-effort otherwise.</li>
+ *   <li><b>Case C</b> — no SSE headers at all (baseline). Shows whether the bucket applies a
+ *       default encryption (so we can distinguish bucket-default from request-driven KMS).</li>
+ * </ul>
+ *
+ * <p>This test makes NO assertions about the encryption outcome (that is exactly what we are
+ * trying to discover); it only asserts the object was created where the PUT is expected to
+ * succeed, and prints the observed headers for inspection. Gated on
+ * {@code ALIBABA_CLOUD_ACCESS_KEY_ID} so it never runs in CI/replay. Uses the non-versioned
+ * conformance bucket and cleans up after itself.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfEnvironmentVariable(named = "ALIBABA_CLOUD_ACCESS_KEY_ID", matches = ".+")
+public class AliKmsManagedKeySmokeIT {
+
+  private static final String ENDPOINT = "https://oss-cn-shanghai.aliyuncs.com";
+  private static final String BUCKET = "chameleon-multicloudj-test";
+  private static final String REGION = "cn-shanghai";
+  private static final String SSE_KMS = "KMS";
+
+  private OSSClient rawClient;
+  private String runId;
+
+  @BeforeAll
+  void setup() {
+    StsCredentials creds =
+        new StsCredentials(
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+            System.getenv("ALIBABA_CLOUD_SECURITY_TOKEN"));
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(creds)
+            .build();
+    CredentialsProvider rawCreds =
+        OSSCredentialsProvider.getCredentialsProvider(credentialsOverrider, REGION);
+    rawClient =
+        OSSClient.newBuilder()
+            .region(REGION)
+            .endpoint(ENDPOINT)
+            .credentialsProvider(rawCreds)
+            .build();
+    runId = UUID.randomUUID().toString();
+  }
+
+  @AfterAll
+  void teardown() throws Exception {
+    if (rawClient != null) {
+      rawClient.close();
+    }
+  }
+
+  /**
+   * Case A — the crux: SSE=KMS header set, NO key id. Print whether the PUT succeeds and what
+   * encryption headers OSS reports on HEAD. This tells us whether "useKmsManagedKey" is honored
+   * by OSS (default/managed CMK) or rejected.
+   */
+  @Test
+  void ssekms_noKeyId_behavior() {
+    String key = keyFor("kms-no-keyid");
+    byte[] content = "kms managed-key smoke — no key id".getBytes(StandardCharsets.UTF_8);
+
+    System.out.println("=== Case A: PutObject SSE=KMS, NO key-id ===");
+    boolean created = false;
+    try {
+      var result = rawClient.putObject(
+          PutObjectRequest.newBuilder()
+              .bucket(BUCKET)
+              .key(key)
+              .serverSideEncryption(SSE_KMS)
+              .body(BinaryData.fromBytes(content))
+              .build(),
+          OperationOptions.defaults());
+      created = true;
+      System.out.println("  PUT RESULT: 200 OK, etag=" + result.eTag());
+      printEncryptionHeaders(key);
+      assertNotNull(result.eTag());
+    } catch (Exception e) {
+      System.out.println("  PUT RESULT: rejected — " + e.getClass().getSimpleName()
+          + ": " + e.getMessage());
+      System.out.println("  >> Interpretation: OSS does NOT apply a default CMK for SSE=KMS"
+          + " without a key id; useKmsManagedKey would be a NO-OP / error on Ali.");
+    } finally {
+      if (created) {
+        safeDelete(key);
+      }
+    }
+  }
+
+  /**
+   * Case B — control: SSE=KMS WITH an explicit key id. Only runs a meaningful request when a real
+   * CMK id is provided via ALI_SMOKE_KMS_KEY_ID; otherwise prints a skip note (we don't want to
+   * guess a key id and conflate a bad-key error with the no-key behavior in Case A).
+   */
+  @Test
+  void ssekms_withKeyId_control() {
+    String kmsKeyId = System.getenv("ALI_SMOKE_KMS_KEY_ID");
+    if (kmsKeyId == null || kmsKeyId.isEmpty()) {
+      System.out.println("=== Case B: SKIPPED (set ALI_SMOKE_KMS_KEY_ID to a real CMK id"
+          + " to run the explicit-key control) ===");
+      return;
+    }
+    String key = keyFor("kms-with-keyid");
+    byte[] content = "kms managed-key smoke — explicit key".getBytes(StandardCharsets.UTF_8);
+
+    System.out.println("=== Case B: PutObject SSE=KMS, WITH key-id=" + kmsKeyId + " ===");
+    boolean created = false;
+    try {
+      var result = rawClient.putObject(
+          PutObjectRequest.newBuilder()
+              .bucket(BUCKET)
+              .key(key)
+              .serverSideEncryption(SSE_KMS)
+              .serverSideEncryptionKeyId(kmsKeyId)
+              .body(BinaryData.fromBytes(content))
+              .build(),
+          OperationOptions.defaults());
+      created = true;
+      System.out.println("  PUT RESULT: 200 OK, etag=" + result.eTag());
+      printEncryptionHeaders(key);
+    } catch (Exception e) {
+      System.out.println("  PUT RESULT: rejected — " + e.getClass().getSimpleName()
+          + ": " + e.getMessage());
+    } finally {
+      if (created) {
+        safeDelete(key);
+      }
+    }
+  }
+
+  /**
+   * Case C — baseline: no SSE headers at all. Reveals whether the bucket has default encryption,
+   * so Case A's observed headers can be attributed to the request vs. a pre-existing bucket policy.
+   */
+  @Test
+  void noSse_baseline() {
+    String key = keyFor("no-sse");
+    byte[] content = "kms managed-key smoke — baseline no sse".getBytes(StandardCharsets.UTF_8);
+
+    System.out.println("=== Case C: PutObject with NO SSE headers (baseline) ===");
+    boolean created = false;
+    try {
+      var result = rawClient.putObject(
+          PutObjectRequest.newBuilder()
+              .bucket(BUCKET)
+              .key(key)
+              .body(BinaryData.fromBytes(content))
+              .build(),
+          OperationOptions.defaults());
+      created = true;
+      System.out.println("  PUT RESULT: 200 OK, etag=" + result.eTag());
+      printEncryptionHeaders(key);
+    } catch (Exception e) {
+      System.out.println("  PUT RESULT: rejected — " + e.getClass().getSimpleName()
+          + ": " + e.getMessage());
+    } finally {
+      if (created) {
+        safeDelete(key);
+      }
+    }
+  }
+
+  // ============================ helpers ============================
+
+  /** HEADs the object and prints the encryption-related response headers. */
+  private void printEncryptionHeaders(String key) {
+    try {
+      HeadObjectResult head = rawClient.headObject(
+          HeadObjectRequest.newBuilder().bucket(BUCKET).key(key).build(),
+          OperationOptions.defaults());
+      System.out.println("  object        = oss://" + BUCKET + "/" + key);
+      System.out.println("  HEAD x-oss-server-side-encryption        = "
+          + head.serverSideEncryption());
+      System.out.println("  HEAD x-oss-server-side-encryption-key-id = "
+          + head.serverSideEncryptionKeyId());
+      // Dump ALL response headers so we can see everything OSS stamped on the object,
+      // not just the encryption pair.
+      Map<String, String> headers = head.headers();
+      System.out.println("  --- all HEAD response headers (" + headers.size() + ") ---");
+      headers.forEach((k, v) -> System.out.println("    " + k + " = " + v));
+      // Dump user metadata (x-oss-meta-*) if any.
+      Map<String, String> userMeta = head.metadata();
+      System.out.println("  --- user metadata (" + (userMeta == null ? 0 : userMeta.size())
+          + ") ---");
+      if (userMeta != null) {
+        userMeta.forEach((k, v) -> System.out.println("    meta: " + k + " = " + v));
+      }
+    } catch (Exception e) {
+      System.out.println("  HEAD failed: " + e.getClass().getSimpleName()
+          + ": " + e.getMessage());
+    }
+  }
+
+  private String keyFor(String label) {
+    return "kms-managed-smoke/" + runId + "/" + label;
+  }
+
+  private void safeDelete(String key) {
+    // Set ALI_SMOKE_KEEP_OBJECTS=1 to skip cleanup and leave the created objects in the bucket
+    // for manual inspection (no debugger / breakpoint needed). Remember to delete them afterward.
+    String keep = System.getenv("ALI_SMOKE_KEEP_OBJECTS");
+    if (keep != null && !keep.isEmpty()) {
+      System.out.println("  KEEP: leaving object for inspection -> oss://" + BUCKET + "/" + key);
+      return;
+    }
+    try {
+      rawClient.deleteObject(
+          DeleteObjectRequest.newBuilder().bucket(BUCKET).key(key).build(),
+          OperationOptions.defaults());
+    } catch (Exception ignored) {
+      // best-effort
+    }
+  }
+}

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliMd5ValidationSmokeIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliMd5ValidationSmokeIT.java
@@ -1,0 +1,289 @@
+package com.salesforce.multicloudj.blob.ali;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.aliyun.sdk.service.oss2.OSSClient;
+import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.PresignOptions;
+import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
+import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
+import com.aliyun.sdk.service.oss2.models.PresignResult;
+import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
+import com.aliyun.sdk.service.oss2.transport.BinaryData;
+import com.aliyun.sdk.service.oss2.utils.Md5Utils;
+import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Standalone smoke test that proves the PROPOSED FIX for the OSS checksum-binding gap:
+ * {@code Content-MD5} is the only OSS request header that triggers server-side body validation
+ * (and rejection with 400 InvalidDigest on mismatch), on BOTH the regular PutObject path and the
+ * presigned-URL path.
+ *
+ * <p>Context: {@code AliChecksumHeaderSmokeIT} proved that {@code x-oss-hash-crc64ecma} as a
+ * request header is inert (OSS ignores it; wrong/mismatched values still return 200 OK). The
+ * remediation is to route a caller-supplied digest to {@code Content-MD5} instead. The multicloudj
+ * driver does not yet support an MD5 {@code ChecksumMethod}, so this test exercises the underlying
+ * OSS SDK directly (raw {@link OSSClient}) to confirm the mechanism BEFORE we invest in the
+ * cross-cloud enum + driver wiring. This mirrors the standalone, real-bucket approach of
+ * {@code AliObjectLockSmokeIT}.
+ *
+ * <p>Expected results (4 cases):
+ * <ul>
+ *   <li><b>putObject, correct MD5</b> → 200 OK</li>
+ *   <li><b>putObject, wrong MD5</b> → rejected (InvalidDigest / 400)</li>
+ *   <li><b>presign, replay matching body</b> → 200 OK (signature valid, body matches MD5)</li>
+ *   <li><b>presign, replay with mismatched body</b> → rejected (InvalidDigest / 400)</li>
+ * </ul>
+ *
+ * <p>If all four behave as expected, the MD5-based fix is sound for both codepaths. Gated on
+ * {@code ALIBABA_CLOUD_ACCESS_KEY_ID} so it never runs in CI/replay. Uses the non-versioned
+ * conformance bucket and cleans up after itself.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfEnvironmentVariable(named = "ALIBABA_CLOUD_ACCESS_KEY_ID", matches = ".+")
+public class AliMd5ValidationSmokeIT {
+
+  private static final String ENDPOINT = "https://oss-cn-shanghai.aliyuncs.com";
+  private static final String BUCKET = "chameleon-multicloudj-test";
+  private static final String REGION = "cn-shanghai";
+
+  private OSSClient rawClient;
+  private String runId;
+
+  @BeforeAll
+  void setup() {
+    StsCredentials creds =
+        new StsCredentials(
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+            System.getenv("ALIBABA_CLOUD_SECURITY_TOKEN"));
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(creds)
+            .build();
+    CredentialsProvider rawCreds =
+        OSSCredentialsProvider.getCredentialsProvider(credentialsOverrider, REGION);
+    rawClient =
+        OSSClient.newBuilder()
+            .region(REGION)
+            .endpoint(ENDPOINT)
+            .credentialsProvider(rawCreds)
+            .build();
+    runId = UUID.randomUUID().toString();
+  }
+
+  @AfterAll
+  void teardown() throws Exception {
+    if (rawClient != null) {
+      rawClient.close();
+    }
+  }
+
+  // ============================ PutObject path ============================
+
+  /**
+   * Case 1: regular PutObject with a CORRECT Content-MD5 should succeed.
+   */
+  @Test
+  void putObject_correctMd5_succeeds() {
+    String key = keyFor("put-correct-md5");
+    byte[] content = "md5 validation smoke — correct".getBytes(StandardCharsets.UTF_8);
+    String md5 = Md5Utils.md5AsBase64(content);
+
+    System.out.println("=== Case 1: putObject + correct Content-MD5 ===");
+    System.out.println("  Content-MD5 = " + md5);
+    try {
+      var result = rawClient.putObject(
+          PutObjectRequest.newBuilder()
+              .bucket(BUCKET)
+              .key(key)
+              .contentMd5(md5)
+              .body(BinaryData.fromBytes(content))
+              .build(),
+          OperationOptions.defaults());
+      System.out.println("  RESULT: 200 OK, etag=" + result.eTag());
+      assertNotNull(result.eTag());
+    } finally {
+      safeDelete(key);
+    }
+  }
+
+  /**
+   * Case 2: regular PutObject with a WRONG Content-MD5 must be rejected by OSS.
+   * This is the proof that Content-MD5 IS server-validated (unlike x-oss-hash-crc64ecma).
+   */
+  @Test
+  void putObject_wrongMd5_rejected() {
+    String key = keyFor("put-wrong-md5");
+    byte[] content = "md5 validation smoke — body".getBytes(StandardCharsets.UTF_8);
+    byte[] otherContent = "a completely different body".getBytes(StandardCharsets.UTF_8);
+    String wrongMd5 = Md5Utils.md5AsBase64(otherContent); // valid MD5, wrong for `content`
+
+    System.out.println("=== Case 2: putObject + WRONG Content-MD5 ===");
+    System.out.println("  Content-MD5 (of other body) = " + wrongMd5);
+    try {
+      rawClient.putObject(
+          PutObjectRequest.newBuilder()
+              .bucket(BUCKET)
+              .key(key)
+              .contentMd5(wrongMd5)
+              .body(BinaryData.fromBytes(content))
+              .build(),
+          OperationOptions.defaults());
+      // If we reach here, OSS accepted a mismatched MD5 — the fix premise would be wrong.
+      System.out.println("  RESULT: 200 OK — UNEXPECTED. OSS did NOT validate Content-MD5.");
+      fail("Expected OSS to reject mismatched Content-MD5, but the upload succeeded");
+    } catch (AssertionError ae) {
+      throw ae;
+    } catch (Exception e) {
+      System.out.println("  RESULT: rejected as expected — " + e.getClass().getSimpleName()
+          + ": " + e.getMessage());
+      assertTrue(messageMentionsDigest(e),
+          "Expected an InvalidDigest-style rejection; got: " + e.getMessage());
+    } finally {
+      safeDelete(key);
+    }
+  }
+
+  // ============================ Presign path ============================
+
+  /**
+   * Case 3: presign a PutObject WITH Content-MD5, then replay via raw HTTP sending the MATCHING
+   * body. Signature is valid (MD5 header replayed) and body matches → 200 OK.
+   */
+  @Test
+  void presign_replayMatchingBody_succeeds() throws Exception {
+    String key = keyFor("presign-match");
+    byte[] content = "presign md5 smoke — signed body".getBytes(StandardCharsets.UTF_8);
+    String md5 = Md5Utils.md5AsBase64(content);
+
+    System.out.println("=== Case 3: presign(Content-MD5) + replay MATCHING body ===");
+    PresignResult presign = rawClient.presign(
+        PutObjectRequest.newBuilder()
+            .bucket(BUCKET)
+            .key(key)
+            .contentMd5(md5)
+            .build(),
+        PresignOptions.newBuilder().expiration(Duration.ofHours(1)).build());
+
+    Map<String, String> signedHeaders = presign.signedHeaders().orElse(Map.of());
+    System.out.println("  url           = " + presign.url());
+    System.out.println("  signedHeaders = " + signedHeaders);
+    assertTrue(signedHeaders.keySet().stream()
+            .anyMatch(h -> h.equalsIgnoreCase("Content-MD5")),
+        "Content-MD5 should appear in signedHeaders the uploader must replay");
+
+    try {
+      int code = httpPut(new URL(presign.url()), signedHeaders, content);
+      System.out.println("  RESULT: HTTP " + code + (code == 200 ? " OK" : ""));
+      assertEquals(200, code, "Matching body with replayed signed headers should succeed");
+    } finally {
+      safeDelete(key);
+    }
+  }
+
+  /**
+   * Case 4: presign a PutObject WITH Content-MD5, replay the signed headers BUT send a different
+   * body. The signature is still valid (we replay the signed Content-MD5 verbatim), so this is
+   * NOT a 403 SignatureDoesNotMatch — it is OSS validating the body against the signed MD5 and
+   * rejecting with 400 InvalidDigest. This is the crux: the presigned MD5 is a real binding.
+   */
+  @Test
+  void presign_replayMismatchedBody_rejected() throws Exception {
+    String key = keyFor("presign-mismatch");
+    byte[] signedBody = "presign md5 smoke — the body I signed".getBytes(StandardCharsets.UTF_8);
+    byte[] tamperedBody = "presign md5 smoke — a tampered body".getBytes(StandardCharsets.UTF_8);
+    String md5 = Md5Utils.md5AsBase64(signedBody);
+
+    System.out.println("=== Case 4: presign(Content-MD5) + replay MISMATCHED body ===");
+    PresignResult presign = rawClient.presign(
+        PutObjectRequest.newBuilder()
+            .bucket(BUCKET)
+            .key(key)
+            .contentMd5(md5)
+            .build(),
+        PresignOptions.newBuilder().expiration(Duration.ofHours(1)).build());
+
+    Map<String, String> signedHeaders = presign.signedHeaders().orElse(Map.of());
+    System.out.println("  signedHeaders = " + signedHeaders);
+
+    try {
+      // Replay the EXACT signed headers (incl. the signed Content-MD5) but send a different body.
+      int code = httpPut(new URL(presign.url()), signedHeaders, tamperedBody);
+      if (code == 200) {
+        System.out.println("  RESULT: HTTP 200 — UNEXPECTED. OSS accepted a body that does not "
+            + "match the signed Content-MD5.");
+        fail("Expected OSS to reject the tampered body via Content-MD5, but it returned 200");
+      }
+      System.out.println("  RESULT: HTTP " + code + " — rejected as expected "
+          + "(400 InvalidDigest = body vs signed MD5 mismatch; 403 would mean signature issue)");
+      // A 400 is the integrity rejection we want. Document whatever non-200 we observe.
+      assertNotEquals(200, code);
+    } finally {
+      safeDelete(key);
+    }
+  }
+
+  // ============================ helpers ============================
+
+  private String keyFor(String label) {
+    return "md5-smoke/" + runId + "/" + label;
+  }
+
+  /** Issues a raw HTTP PUT replaying the given (signed) headers with the given body. */
+  private static int httpPut(URL url, Map<String, String> headers, byte[] body)
+      throws IOException {
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    try {
+      conn.setRequestMethod("PUT");
+      conn.setDoOutput(true);
+      for (Map.Entry<String, String> h : headers.entrySet()) {
+        conn.setRequestProperty(h.getKey(), h.getValue());
+      }
+      try (OutputStream os = conn.getOutputStream()) {
+        os.write(body);
+      }
+      return conn.getResponseCode();
+    } finally {
+      conn.disconnect();
+    }
+  }
+
+  private static boolean messageMentionsDigest(Exception e) {
+    String m = (e.getMessage() == null ? "" : e.getMessage()).toLowerCase();
+    Throwable cause = e.getCause();
+    String cm = (cause == null || cause.getMessage() == null)
+        ? "" : cause.getMessage().toLowerCase();
+    return m.contains("digest") || m.contains("400") || m.contains("md5")
+        || cm.contains("digest") || cm.contains("400") || cm.contains("md5");
+  }
+
+  private void safeDelete(String key) {
+    try {
+      rawClient.deleteObject(
+          DeleteObjectRequest.newBuilder().bucket(BUCKET).key(key).build(),
+          OperationOptions.defaults());
+    } catch (Exception ignored) {
+      // best-effort
+    }
+  }
+}

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliMetadataObjectLockSmokeIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliMetadataObjectLockSmokeIT.java
@@ -1,0 +1,202 @@
+package com.salesforce.multicloudj.blob.ali;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.aliyun.sdk.service.oss2.OSSClient;
+import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
+import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
+import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
+import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration;
+import com.salesforce.multicloudj.blob.driver.RetentionMode;
+import com.salesforce.multicloudj.blob.driver.UploadRequest;
+import com.salesforce.multicloudj.blob.driver.UploadResponse;
+import com.salesforce.multicloudj.common.ali.AliConstants;
+import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Standalone direct test that empirically determines whether Alibaba OSS returns object-lock
+ * (retention + legal hold) information in <code>HeadObject</code> response headers, the way S3
+ * does via <code>x-amz-object-lock-mode</code> / <code>x-amz-object-lock-retain-until-date</code>
+ * / <code>x-amz-object-lock-legal-hold</code>.
+ *
+ * <p>This is a feasibility probe for the planned <code>objectLockInfo</code> in
+ * <code>BlobMetadata.fromGetMetadata()</code> on Ali (gap #4 in the feature gap analysis):
+ * <ul>
+ *   <li>If OSS DOES return lock info on HEAD, the implementation can read it directly from the
+ *       response headers — one round trip, cheap.</li>
+ *   <li>If OSS does NOT, the implementation must follow up the HEAD with separate
+ *       <code>GetObjectRetention</code> + <code>GetObjectLegalHold</code> calls — up to 3 round
+ *       trips per <code>getMetadata()</code>, with attendant latency cost.</li>
+ * </ul>
+ * The bytecode of {@link HeadObjectResult} has no typed accessor for retention/lock fields, so
+ * the only way to learn the answer is to inspect the raw response headers from a real HEAD against
+ * a versioned + WORM-enabled bucket holding a locked object — which is what this test does.
+ *
+ * <p>This hits the real OSS service directly (gated on <code>ALIBABA_CLOUD_ACCESS_KEY_ID</code>,
+ * so it never runs in CI/replay). Uses GOVERNANCE retention so the locked object can be cleaned
+ * up with a bypass delete after the probe.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfEnvironmentVariable(named = "ALIBABA_CLOUD_ACCESS_KEY_ID", matches = ".+")
+public class AliMetadataObjectLockSmokeIT {
+
+  private static final String ENDPOINT = "https://oss-cn-shanghai.aliyuncs.com";
+  // Must be a versioned bucket with object lock / WORM enabled.
+  private static final String BUCKET = "chameleon-multicloudj-test-versioned";
+  private static final String REGION = "cn-shanghai";
+
+  private BucketClient client;
+  // Raw OSS client — used both for the HeadObject call (so the headers map is observable
+  // unmodified by the multicloudj transformer) and for the bypass-governance-retention delete
+  // during teardown.
+  private OSSClient rawClient;
+  private String key;
+  private String lockedVersionId;
+
+  @BeforeAll
+  void setup() {
+    StsCredentials creds =
+        new StsCredentials(
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+            System.getenv("ALIBABA_CLOUD_SECURITY_TOKEN"));
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(creds)
+            .build();
+
+    client =
+        BucketClient.builder(AliConstants.PROVIDER_ID)
+            .withBucket(BUCKET)
+            .withRegion(REGION)
+            .withEndpoint(URI.create(ENDPOINT))
+            .withCredentialsOverrider(credentialsOverrider)
+            .build();
+
+    CredentialsProvider rawCreds =
+        OSSCredentialsProvider.getCredentialsProvider(credentialsOverrider, REGION);
+    rawClient =
+        OSSClient.newBuilder()
+            .region(REGION)
+            .endpoint(ENDPOINT)
+            .credentialsProvider(rawCreds)
+            .build();
+
+    key = "metadata-objectlock-smoke/" + UUID.randomUUID() + "/object";
+  }
+
+  @AfterAll
+  void teardown() throws Exception {
+    if (rawClient != null && lockedVersionId != null) {
+      try {
+        rawClient.deleteObject(
+            DeleteObjectRequest.newBuilder()
+                .bucket(BUCKET)
+                .key(key)
+                .versionId(lockedVersionId)
+                .header("x-oss-bypass-governance-retention", "true")
+                .build(),
+            OperationOptions.defaults());
+      } catch (Exception e) {
+        System.out.printf("  teardown: failed to clean up %s (version %s): %s%n",
+            key, lockedVersionId, e.getMessage());
+      }
+    }
+    if (rawClient != null) {
+      rawClient.close();
+    }
+    if (client != null) {
+      client.close();
+    }
+  }
+
+  @Test
+  void headObject_onLockedObject_responseHeaders() throws Exception {
+    // 1. Upload an object with GOVERNANCE retention + legal hold applied at write time. This
+    //    exercises both retention surfaces on a single object so the HEAD response can be
+    //    inspected for either signal.
+    byte[] content = "metadata objectlock smoke".getBytes(StandardCharsets.UTF_8);
+    Instant retainUntil =
+        Instant.now().plus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS);
+    UploadResponse uploadResponse;
+    try (ByteArrayInputStream in = new ByteArrayInputStream(content)) {
+      uploadResponse = client.upload(
+          new UploadRequest.Builder()
+              .withKey(key)
+              .withContentLength(content.length)
+              .withObjectLock(
+                  ObjectLockConfiguration.builder()
+                      .mode(RetentionMode.GOVERNANCE)
+                      .retainUntilDate(retainUntil)
+                      .legalHold(true)
+                      .build())
+              .build(),
+          in);
+    }
+    lockedVersionId = uploadResponse.getVersionId();
+    assertNotNull(lockedVersionId, "Versioned bucket should return a versionId for cleanup");
+    System.out.printf("  uploaded GOVERNANCE+legalHold-locked object %s (version %s)%n",
+        key, lockedVersionId);
+
+    // 2. Raw HeadObject — observe what OSS returns. The typed HeadObjectResult has no retention
+    //    accessor (verified via javap on alibabacloud-oss-v2:0.4.0), so the question is purely
+    //    about the raw response headers map.
+    HeadObjectResult headResult = rawClient.headObject(
+        HeadObjectRequest.newBuilder().bucket(BUCKET).key(key).build(),
+        OperationOptions.defaults());
+    assertEquals(200, headResult.statusCode(), "HEAD on locked object should succeed");
+
+    System.out.printf("  HeadObject statusCode=%d%n", headResult.statusCode());
+    Map<String, String> headers = headResult.headers();
+    System.out.println("  HeadObject response headers (full dump):");
+    if (headers != null) {
+      headers.forEach((k, v) -> System.out.printf("    %s: %s%n", k, v));
+    } else {
+      System.out.println("    (null)");
+    }
+
+    // 3. Look specifically for any retention/lock/hold-related header. The substrings cover
+    //    every plausible spelling Alibaba might use (the SDK has no documented constants).
+    boolean anyLockHeader = headers != null && headers.entrySet().stream()
+        .anyMatch(e -> {
+          String name = e.getKey() == null ? "" : e.getKey().toLowerCase();
+          return name.contains("retention")
+              || name.contains("legal-hold")
+              || name.contains("legalhold")
+              || name.contains("object-lock")
+              || name.contains("objectlock")
+              || name.contains("worm");
+        });
+
+    System.out.printf(
+        "  Any retention/legal-hold/object-lock header present on HEAD? %s%n", anyLockHeader);
+    System.out.println(
+        "  Verdict for gap #4 implementation: "
+            + (anyLockHeader
+                ? "OSS surfaces lock info on HEAD — single-call impl is feasible."
+                : "OSS does NOT surface lock info on HEAD — impl needs follow-up "
+                    + "GetObjectRetention + GetObjectLegalHold calls."));
+
+    // No assertion on the verdict itself — this is a probe to inform implementation. The key
+    // assertion is that the HEAD succeeded and we observed the headers.
+    assertNotNull(headers, "HEAD response should expose a headers map even if it's empty");
+  }
+}

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliObjectLockSmokeIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliObjectLockSmokeIT.java
@@ -1,0 +1,469 @@
+package com.salesforce.multicloudj.blob.ali;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.aliyun.sdk.service.oss2.OSSClient;
+import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
+import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration;
+import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
+import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
+import com.salesforce.multicloudj.blob.driver.RetentionMode;
+import com.salesforce.multicloudj.blob.driver.UploadRequest;
+import com.salesforce.multicloudj.blob.driver.UploadResponse;
+import com.salesforce.multicloudj.common.ali.AliConstants;
+import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Standalone smoke test that verifies the OSS object lock (WORM) feature is enabled and working
+ * end-to-end against a real bucket, BEFORE investing in the full object-lock conformance suite.
+ *
+ * <p>Unlike the WireMock-backed conformance tests, this hits the real OSS service directly. It is
+ * gated on {@code ALIBABA_CLOUD_ACCESS_KEY_ID} so it never runs in CI/replay.
+ *
+ * <p><b>Requires:</b> {@link #BUCKET} must be a versioned bucket with object lock / WORM enabled.
+ * If WORM is NOT enabled, the upload-with-lock or the enforcement check (step 3) will fail — which
+ * is exactly the signal this test is meant to surface.
+ *
+ * <p>Uses GOVERNANCE mode (not COMPLIANCE) on purpose: a COMPLIANCE lock cannot be shortened or
+ * bypassed by anyone until expiry, which would leave an undeletable object behind. GOVERNANCE
+ * supports bypass, so the test can clean up after itself and remain repeatable.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfEnvironmentVariable(named = "ALIBABA_CLOUD_ACCESS_KEY_ID", matches = ".+")
+public class AliObjectLockSmokeIT {
+
+  private static final String ENDPOINT = "https://oss-cn-shanghai.aliyuncs.com";
+  // Must be a versioned bucket with object lock / WORM enabled.
+  private static final String BUCKET = "chameleon-multicloudj-test-versioned";
+  private static final String REGION = "cn-shanghai";
+
+  private BucketClient client;
+  // Raw OSS client used only for teardown cleanup of retained/held versions, which
+  // require the bypass-governance-retention header on the delete itself (OSS bypass cannot
+  // set a past retain date, so "shorten then delete" is not viable for synchronous cleanup).
+  private OSSClient rawClient;
+  private String key;
+  private String controlKey;
+  private String legalHoldKey;
+  private String lockedVersionId;
+  private String controlVersionId;
+  private String legalHoldVersionId;
+
+  @BeforeAll
+  void setup() {
+    StsCredentials creds =
+        new StsCredentials(
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+            System.getenv("ALIBABA_CLOUD_SECURITY_TOKEN"));
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(creds)
+            .build();
+
+    client =
+        BucketClient.builder(AliConstants.PROVIDER_ID)
+            .withBucket(BUCKET)
+            .withRegion(REGION)
+            .withEndpoint(URI.create(ENDPOINT))
+            .withCredentialsOverrider(credentialsOverrider)
+            .build();
+
+    CredentialsProvider rawCreds =
+        OSSCredentialsProvider.getCredentialsProvider(credentialsOverrider, REGION);
+    rawClient =
+        OSSClient.newBuilder()
+            .region(REGION)
+            .endpoint(ENDPOINT)
+            .credentialsProvider(rawCreds)
+            .build();
+
+    String runId = UUID.randomUUID().toString();
+    key = "objectlock-smoke/" + runId + "/locked";
+    controlKey = "objectlock-smoke/" + runId + "/control-no-lock";
+    legalHoldKey = "objectlock-smoke/" + runId + "/legal-hold";
+  }
+
+  @AfterAll
+  void teardown() throws Exception {
+    // Best-effort cleanup of the locked object. The version still carries a future GOVERNANCE
+    // retain-until date, and OSS bypass cannot set a past date, so we cannot "shorten then
+    // delete". Instead delete the version directly with the bypass-governance-retention header
+    // (the same mechanism the OSS console's "permanent delete" uses). This requires the raw
+    // OSS client because the multicloudj delete() API does not expose the bypass flag.
+    if (rawClient != null && lockedVersionId != null) {
+      try {
+        rawClient.deleteObject(
+            DeleteObjectRequest.newBuilder()
+                .bucket(BUCKET)
+                .key(key)
+                .versionId(lockedVersionId)
+                .header("x-oss-bypass-governance-retention", "true")
+                .build(),
+            OperationOptions.defaults());
+      } catch (Exception e) {
+        System.out.printf("  teardown: failed to clean up locked object %s (version %s): %s%n",
+            key, lockedVersionId, e.getMessage());
+      }
+    }
+
+    if (client != null) {
+      // Best-effort cleanup of the control object — delete the specific version so the
+      // underlying version is removed rather than just adding a delete marker on the
+      // versioned bucket. Guard on controlVersionId to avoid creating a delete marker
+      // when the wormRoundTrip test didn't run.
+      try {
+        if (controlVersionId != null) {
+          client.delete(controlKey, controlVersionId);
+        }
+      } catch (Exception ignored) {
+        // ignore
+      }
+      // Legal hold object: hold was cleared by the test; delete the specific version.
+      try {
+        if (legalHoldVersionId != null) {
+          client.delete(legalHoldKey, legalHoldVersionId);
+        }
+      } catch (Exception ignored) {
+        // ignore
+      }
+      client.close();
+    }
+    if (rawClient != null) {
+      rawClient.close();
+    }
+  }
+
+  @Test
+  void wormRoundTrip() throws Exception {
+    byte[] content = "worm smoke test".getBytes(StandardCharsets.UTF_8);
+    // OSS stores retention timestamps at (at most) millisecond precision, so truncate to
+    // seconds to keep the round-trip comparison exact (Instant.now() carries micro/nanos).
+    Instant retainUntil =
+        Instant.now().plus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS);
+
+    // 0. Control upload: a second blob with NO object lock, for side-by-side comparison
+    //    against the locked object in the OSS console.
+    byte[] controlContent = "control no-lock blob".getBytes(StandardCharsets.UTF_8);
+    try (ByteArrayInputStream in = new ByteArrayInputStream(controlContent)) {
+      UploadResponse controlResponse = client.upload(
+          new UploadRequest.Builder()
+              .withKey(controlKey)
+              .withContentLength(controlContent.length)
+              .build(),
+          in);
+      controlVersionId = controlResponse.getVersionId();
+    }
+
+    // 1. Upload with GOVERNANCE retention applied at write time.
+    UploadResponse uploadResponse;
+    try (ByteArrayInputStream in = new ByteArrayInputStream(content)) {
+      uploadResponse = client.upload(
+          new UploadRequest.Builder()
+              .withKey(key)
+              .withContentLength(content.length)
+              .withObjectLock(
+                  ObjectLockConfiguration.builder()
+                      .mode(RetentionMode.GOVERNANCE)
+                      .retainUntilDate(retainUntil)
+                      .legalHold(false)
+                      .build())
+              .build(),
+          in);
+    }
+    // Retention is bound to this specific object VERSION. On a versioned bucket a
+    // delete without a versionId only writes a delete marker (and always succeeds);
+    // retention only blocks deleting the locked version itself.
+    lockedVersionId = uploadResponse.getVersionId();
+    System.out.printf("  locked versionId = %s%n", lockedVersionId);
+
+    // 2. Read the lock back on both objects and print for live console comparison.
+    ObjectLockInfo info = client.getObjectLock(key, null);
+    printLockState("LOCKED   blob", key, info);
+
+    ObjectLockInfo controlInfo = readLockStateQuietly(controlKey);
+    printLockState("CONTROL  blob (no lock)", controlKey, controlInfo);
+
+    assertNotNull(info, "getObjectLock should return non-null for a locked object");
+    assertEquals(RetentionMode.GOVERNANCE, info.getMode());
+    assertNotNull(info.getRetainUntilDate(), "retainUntilDate should be set");
+
+    // 3. Enforcement check: deleting the locked object VERSION without bypass must fail.
+    //    This is the real proof that WORM is enabled and enforced on the bucket.
+    assertThrows(
+        Exception.class,
+        () -> client.delete(key, lockedVersionId),
+        "Locked object version should not be deletable without governance bypass");
+
+    // 4. Extend retention — proves updateObjectRetention works.
+    Instant extended = retainUntil.plus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS);
+    client.updateObjectRetention(
+        key,
+        null,
+        ObjectRetentionConfig.builder()
+            .mode(RetentionMode.GOVERNANCE)
+            .retainUntilDate(extended)
+            .build());
+    // OSS may return the retain-until at coarser (e.g. millisecond) precision than sent,
+    // so compare truncated to seconds rather than exact-equals.
+    Instant actual = client.getObjectLock(key, null).getRetainUntilDate();
+    assertEquals(
+        extended,
+        actual.truncatedTo(ChronoUnit.SECONDS),
+        "Retention should reflect the extended date (compared at second precision)");
+
+    // 5. Shorten with bypass so cleanup can delete it — proves bypass works.
+    client.updateObjectRetention(
+        key,
+        null,
+        ObjectRetentionConfig.builder()
+            .mode(RetentionMode.GOVERNANCE)
+            .retainUntilDate(Instant.now().plusSeconds(1))
+            .bypassGovernanceRetention(Boolean.TRUE)
+            .build());
+
+    // Both objects are left in place for live inspection in the OSS console; the
+    // @AfterAll teardown performs the final cleanup of both the locked and control blobs.
+  }
+
+  @Test
+  void legalHoldRoundTrip() throws Exception {
+    byte[] content = "legal hold smoke test".getBytes(StandardCharsets.UTF_8);
+
+    // 1. Upload a plain object (no retention, no legal hold at upload time).
+    UploadRequest uploadRequest = new UploadRequest.Builder()
+        .withKey(legalHoldKey)
+        .withContentLength(content.length)
+        .build();
+    UploadResponse uploadResponse =
+        client.upload(uploadRequest, new ByteArrayInputStream(content));
+    legalHoldVersionId = uploadResponse.getVersionId();
+    assertNotNull(legalHoldVersionId, "Versioned bucket should return a versionId");
+    System.out.printf("  legalHold test: uploaded %s (version %s)%n",
+        legalHoldKey, legalHoldVersionId);
+
+    // 2. Verify no legal hold initially.
+    ObjectLockInfo infoBeforeHold = readLockStateQuietly(legalHoldKey);
+    if (infoBeforeHold != null) {
+      assertFalse(infoBeforeHold.isLegalHold(),
+          "Freshly uploaded object should have no legal hold");
+    }
+    System.out.println("  legalHold test: confirmed no hold initially");
+
+    // 3. Set legal hold ON.
+    client.updateLegalHold(legalHoldKey, legalHoldVersionId, true);
+    System.out.println("  legalHold test: set legal hold ON");
+
+    // 4. Read back — verify legal hold is ON.
+    ObjectLockInfo infoWithHold = client.getObjectLock(legalHoldKey, legalHoldVersionId);
+    assertNotNull(infoWithHold, "getObjectLock should return non-null after setting hold");
+    assertTrue(infoWithHold.isLegalHold(), "Legal hold should be ON after setting it");
+    printLockState("after setLegalHold(true)", legalHoldKey, infoWithHold);
+
+    // 5. Enforcement: deleting the held version should fail.
+    assertThrows(Exception.class,
+        () -> client.delete(legalHoldKey, legalHoldVersionId),
+        "Delete should fail while legal hold is ON");
+    System.out.println("  legalHold test: delete correctly rejected (hold is ON)");
+
+    // 6. Clear legal hold.
+    client.updateLegalHold(legalHoldKey, legalHoldVersionId, false);
+    System.out.println("  legalHold test: cleared legal hold");
+
+    // 7. Verify legal hold is OFF.
+    ObjectLockInfo infoAfterClear = client.getObjectLock(legalHoldKey, legalHoldVersionId);
+    assertNotNull(infoAfterClear);
+    assertFalse(infoAfterClear.isLegalHold(), "Legal hold should be OFF after clearing");
+    printLockState("after setLegalHold(false)", legalHoldKey, infoAfterClear);
+
+    // 8. Delete should now succeed (no hold, no retention).
+    client.delete(legalHoldKey, legalHoldVersionId);
+    legalHoldVersionId = null; // prevent double-delete in teardown
+    System.out.println("  legalHold test: delete succeeded after clearing hold");
+  }
+
+  @Test
+  void uploadWithLegalHoldAtWriteTime() throws Exception {
+    // Validates the upload-time ObjectLockConfiguration.legalHold(true) path,
+    // which applies legal hold via a separate API call after the PutObject.
+    byte[] content = "upload-time legal hold".getBytes(StandardCharsets.UTF_8);
+    String uploadHoldKey = legalHoldKey + "-at-upload";
+    String uploadHoldVersionId = null;
+
+    try {
+      ObjectLockConfiguration lockConfig = ObjectLockConfiguration.builder()
+          .legalHold(true)
+          .build();
+      UploadRequest uploadRequest = new UploadRequest.Builder()
+          .withKey(uploadHoldKey)
+          .withContentLength(content.length)
+          .withObjectLock(lockConfig)
+          .build();
+      UploadResponse response =
+          client.upload(uploadRequest, new ByteArrayInputStream(content));
+      uploadHoldVersionId = response.getVersionId();
+      System.out.printf("  uploadWithHold: uploaded %s (version %s)%n",
+          uploadHoldKey, uploadHoldVersionId);
+
+      // Verify hold applied at upload time.
+      ObjectLockInfo info = client.getObjectLock(uploadHoldKey, uploadHoldVersionId);
+      assertNotNull(info);
+      assertTrue(info.isLegalHold(),
+          "Legal hold should be ON when set at upload time");
+      printLockState("upload-time legal hold", uploadHoldKey, info);
+
+      // Enforcement: delete should fail.
+      String vid = uploadHoldVersionId;
+      assertThrows(Exception.class,
+          () -> client.delete(uploadHoldKey, vid),
+          "Delete should fail with legal hold set at upload time");
+      System.out.println("  uploadWithHold: delete correctly rejected");
+    } finally {
+      // Clean up: clear hold, then delete.
+      if (uploadHoldVersionId != null) {
+        try {
+          client.updateLegalHold(uploadHoldKey, uploadHoldVersionId, false);
+          client.delete(uploadHoldKey, uploadHoldVersionId);
+          System.out.println("  uploadWithHold: cleaned up");
+        } catch (Exception e) {
+          System.out.printf("  uploadWithHold: cleanup failed: %s%n", e.getMessage());
+        }
+      }
+    }
+  }
+
+  @Test
+  void shortRetentionPeriodAcceptance() throws Exception {
+    // Validates whether OSS accepts a retention period of less than 1 day.
+    // Uploads two objects: one GOVERNANCE, one COMPLIANCE, both with retainUntilDate
+    // set to 5 minutes from now. If OSS enforces a minimum retention period (e.g. 1 day),
+    // the upload or putObjectRetention call will throw.
+    byte[] content = "short retention test".getBytes(StandardCharsets.UTF_8);
+    Instant fiveMinutesFromNow =
+        Instant.now().plus(5, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS);
+
+    String govKey = key + "-short-gov";
+    String compKey = key + "-short-comp";
+    String govVersionId = null;
+    String compVersionId = null;
+
+    try {
+      // Upload with GOVERNANCE + 5 min retention
+      ObjectLockConfiguration govLock = ObjectLockConfiguration.builder()
+          .mode(RetentionMode.GOVERNANCE)
+          .retainUntilDate(fiveMinutesFromNow)
+          .build();
+      UploadResponse govResponse = client.upload(
+          new UploadRequest.Builder()
+              .withKey(govKey)
+              .withContentLength(content.length)
+              .withObjectLock(govLock)
+              .build(),
+          new ByteArrayInputStream(content));
+      govVersionId = govResponse.getVersionId();
+      System.out.printf("  shortRetention: GOVERNANCE uploaded %s (version %s, retainUntil %s)%n",
+          govKey, govVersionId, fiveMinutesFromNow);
+
+      // Verify GOVERNANCE retention was accepted
+      ObjectLockInfo govInfo = client.getObjectLock(govKey, govVersionId);
+      assertNotNull(govInfo);
+      assertEquals(RetentionMode.GOVERNANCE, govInfo.getMode());
+      assertNotNull(govInfo.getRetainUntilDate());
+      printLockState("GOVERNANCE 5-min retention", govKey, govInfo);
+
+      // Upload with COMPLIANCE + 5 min retention
+      ObjectLockConfiguration compLock = ObjectLockConfiguration.builder()
+          .mode(RetentionMode.COMPLIANCE)
+          .retainUntilDate(fiveMinutesFromNow)
+          .build();
+      UploadResponse compResponse = client.upload(
+          new UploadRequest.Builder()
+              .withKey(compKey)
+              .withContentLength(content.length)
+              .withObjectLock(compLock)
+              .build(),
+          new ByteArrayInputStream(content));
+      compVersionId = compResponse.getVersionId();
+      System.out.printf("  shortRetention: COMPLIANCE uploaded %s (version %s, retainUntil %s)%n",
+          compKey, compVersionId, fiveMinutesFromNow);
+
+      // Verify COMPLIANCE retention was accepted
+      ObjectLockInfo compInfo = client.getObjectLock(compKey, compVersionId);
+      assertNotNull(compInfo);
+      assertEquals(RetentionMode.COMPLIANCE, compInfo.getMode());
+      assertNotNull(compInfo.getRetainUntilDate());
+      printLockState("COMPLIANCE 5-min retention", compKey, compInfo);
+
+      System.out.println("  shortRetention: BOTH accepted 5-min retention without error");
+
+    } finally {
+      // Clean up GOVERNANCE object (use bypass to shorten, then delete)
+      if (govVersionId != null) {
+        try {
+          rawClient.deleteObject(
+              DeleteObjectRequest.newBuilder()
+                  .bucket(BUCKET)
+                  .key(govKey)
+                  .versionId(govVersionId)
+                  .header("x-oss-bypass-governance-retention", "true")
+                  .build(),
+              OperationOptions.defaults());
+          System.out.println("  shortRetention: cleaned up GOVERNANCE object");
+        } catch (Exception e) {
+          System.out.printf("  shortRetention: GOVERNANCE cleanup failed: %s%n", e.getMessage());
+        }
+      }
+      // COMPLIANCE object: cannot be deleted until retention expires (5 min).
+      // Leave it — it auto-unlocks after 5 minutes, then can be manually deleted.
+      if (compVersionId != null) {
+        System.out.printf(
+            "  shortRetention: COMPLIANCE object %s (version %s) will unlock at %s"
+                + " — delete manually after expiry%n",
+            compKey, compVersionId, fiveMinutesFromNow);
+      }
+    }
+  }
+
+  private ObjectLockInfo readLockStateQuietly(String objectKey) {
+    try {
+      return client.getObjectLock(objectKey, null);
+    } catch (Exception e) {
+      // Some providers throw when an object has no lock config; treat as "no lock".
+      System.out.printf("  (getObjectLock threw for %s: %s)%n", objectKey, e.getMessage());
+      return null;
+    }
+  }
+
+  private static void printLockState(String label, String objectKey, ObjectLockInfo info) {
+    System.out.println("=== Object lock state: " + label + " ===");
+    System.out.println("  key            = " + objectKey);
+    if (info == null) {
+      System.out.println("  objectLockInfo = <null> (no lock)");
+      return;
+    }
+    System.out.println("  mode           = " + info.getMode());
+    System.out.println("  retainUntil    = " + info.getRetainUntilDate());
+    System.out.println("  legalHold      = " + info.isLegalHold());
+    System.out.println("  useEventBased  = " + info.getUseEventBasedHold());
+  }
+}

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliRetentionModeUpgradeIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliRetentionModeUpgradeIT.java
@@ -1,0 +1,195 @@
+package com.salesforce.multicloudj.blob.ali;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.aliyun.sdk.service.oss2.OSSClient;
+import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
+import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectRetentionRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult;
+import com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType;
+import com.aliyun.sdk.service.oss2.models.PutObjectRetentionRequest;
+import com.aliyun.sdk.service.oss2.models.Retention;
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration;
+import com.salesforce.multicloudj.blob.driver.RetentionMode;
+import com.salesforce.multicloudj.blob.driver.UploadRequest;
+import com.salesforce.multicloudj.blob.driver.UploadResponse;
+import com.salesforce.multicloudj.common.ali.AliConstants;
+import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Standalone direct test that empirically confirms Alibaba OSS does NOT support upgrading an
+ * object's retention mode from GOVERNANCE to COMPLIANCE — the single scenario behind the skipped
+ * conformance test
+ * {@code testUpdateObjectRetention_modeUpgrade_governanceToCompliance_withBypass_succeeds}.
+ *
+ * <p>This hits the real OSS service directly (gated on {@code ALIBABA_CLOUD_ACCESS_KEY_ID}, so it
+ * never runs in CI/replay). It deliberately uses the <b>raw {@link OSSClient}</b> for the upgrade
+ * attempt rather than the multicloudj client: the multicloudj sync path now guards this transition
+ * and throws {@code UnSupportedOperationException} before reaching OSS, which would mask the
+ * server's actual response. Driving the SDK directly proves the platform limitation itself —
+ * OSS rejects the mode change with an HTTP 409 (FileImmutable) even when the
+ * {@code x-oss-bypass-governance-retention} header / bypass flag is supplied.
+ *
+ * <p><b>Requires:</b> {@link #BUCKET} must be a versioned bucket with object lock / WORM enabled.
+ * Uses GOVERNANCE for the initial lock so the object can be cleaned up via a bypass delete.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfEnvironmentVariable(named = "ALIBABA_CLOUD_ACCESS_KEY_ID", matches = ".+")
+public class AliRetentionModeUpgradeIT {
+
+  private static final String ENDPOINT = "https://oss-cn-shanghai.aliyuncs.com";
+  // Must be a versioned bucket with object lock / WORM enabled.
+  private static final String BUCKET = "chameleon-multicloudj-test-versioned";
+  private static final String REGION = "cn-shanghai";
+
+  private static final Instant RETAIN_UNTIL =
+      Instant.now().plus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS);
+  private static final Instant UPGRADE_RETAIN_UNTIL =
+      RETAIN_UNTIL.plus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS);
+
+  private BucketClient client;
+  // Raw OSS client: used both to attempt the upgrade (bypassing our guard) and to clean up the
+  // GOVERNANCE-locked version with the bypass-governance-retention header.
+  private OSSClient rawClient;
+  private String key;
+  private String lockedVersionId;
+
+  @BeforeAll
+  void setup() {
+    StsCredentials creds =
+        new StsCredentials(
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"),
+            System.getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"),
+            System.getenv("ALIBABA_CLOUD_SECURITY_TOKEN"));
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(creds)
+            .build();
+
+    client =
+        BucketClient.builder(AliConstants.PROVIDER_ID)
+            .withBucket(BUCKET)
+            .withRegion(REGION)
+            .withEndpoint(URI.create(ENDPOINT))
+            .withCredentialsOverrider(credentialsOverrider)
+            .build();
+
+    CredentialsProvider rawCreds =
+        OSSCredentialsProvider.getCredentialsProvider(credentialsOverrider, REGION);
+    rawClient =
+        OSSClient.newBuilder()
+            .region(REGION)
+            .endpoint(ENDPOINT)
+            .credentialsProvider(rawCreds)
+            .build();
+
+    key = "retention-mode-upgrade/" + UUID.randomUUID() + "/object";
+  }
+
+  @AfterAll
+  void teardown() throws Exception {
+    // The version still carries a future GOVERNANCE retain-until date. OSS bypass cannot set a
+    // past date, so delete the version directly with the bypass-governance-retention header.
+    if (rawClient != null && lockedVersionId != null) {
+      try {
+        rawClient.deleteObject(
+            DeleteObjectRequest.newBuilder()
+                .bucket(BUCKET)
+                .key(key)
+                .versionId(lockedVersionId)
+                .header("x-oss-bypass-governance-retention", "true")
+                .build(),
+            OperationOptions.defaults());
+      } catch (Exception e) {
+        System.out.printf("  teardown: failed to clean up %s (version %s): %s%n",
+            key, lockedVersionId, e.getMessage());
+      }
+    }
+    if (rawClient != null) {
+      rawClient.close();
+    }
+    if (client != null) {
+      client.close();
+    }
+  }
+
+  @Test
+  void governanceToComplianceUpgrade_isRejectedByOss() throws Exception {
+    // 1. Upload an object with GOVERNANCE retention applied at write time (via multicloudj).
+    byte[] content = "mode-upgrade test".getBytes(StandardCharsets.UTF_8);
+    UploadResponse uploadResponse;
+    try (ByteArrayInputStream in = new ByteArrayInputStream(content)) {
+      uploadResponse = client.upload(
+          new UploadRequest.Builder()
+              .withKey(key)
+              .withContentLength(content.length)
+              .withObjectLock(
+                  ObjectLockConfiguration.builder()
+                      .mode(RetentionMode.GOVERNANCE)
+                      .retainUntilDate(RETAIN_UNTIL)
+                      .legalHold(false)
+                      .build())
+              .build(),
+          in);
+    }
+    lockedVersionId = uploadResponse.getVersionId();
+    assertNotNull(lockedVersionId, "Versioned bucket should return a versionId for cleanup");
+    System.out.printf("  uploaded GOVERNANCE-locked object %s (version %s)%n",
+        key, lockedVersionId);
+
+    // 2. Read back the current retention via the RAW OSS client and inspect the values OSS
+    //    returns. Confirms the GOVERNANCE lock is actually in place before the upgrade attempt,
+    //    and lets the operator eyeball the exact mode/retainUntilDate format OSS reports.
+    GetObjectRetentionResult currentRetention = rawClient.getObjectRetention(
+        GetObjectRetentionRequest.newBuilder()
+            .bucket(BUCKET)
+            .key(key)
+            .build(),
+        OperationOptions.defaults());
+    assertNotNull(currentRetention.retention(),
+        "OSS should report retention for the GOVERNANCE-locked object");
+    Retention current = currentRetention.retention();
+    System.out.printf("  getObjectRetention before upgrade: mode=%s, retainUntilDate=%s%n",
+        current.mode(), current.retainUntilDate());
+
+    // 3. Attempt GOVERNANCE -> COMPLIANCE upgrade via the RAW OSS client, WITH bypass.
+    //    We bypass the multicloudj guard on purpose to observe OSS's own response.
+    Retention complianceRetention = Retention.newBuilder()
+        .mode(ObjectRetentionModeType.COMPLIANCE)
+        .retainUntilDate(DateTimeFormatter.ISO_INSTANT.format(UPGRADE_RETAIN_UNTIL))
+        .build();
+    PutObjectRetentionRequest upgradeRequest = PutObjectRetentionRequest.newBuilder()
+        .bucket(BUCKET)
+        .key(key)
+        .retention(complianceRetention)
+        .bypassGovernanceRetention(true)
+        .build();
+
+    // 4. OSS must reject the mode change. Even with bypass, OSS treats the object version's
+    //    retention mode as immutable and returns HTTP 409 (FileImmutable). We assert that the
+    //    call throws; the printed exception lets the operator eyeball the exact status/code.
+    Exception ex = assertThrows(Exception.class,
+        () -> rawClient.putObjectRetention(upgradeRequest, OperationOptions.defaults()),
+        "OSS should reject a GOVERNANCE -> COMPLIANCE mode upgrade even with bypass");
+    System.out.printf("  OSS rejected mode upgrade as expected: %s: %s%n",
+        ex.getClass().getName(), ex.getMessage());
+  }
+}

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -1143,4 +1143,54 @@ public class AliTransformerTest {
         "an unparseable retain-until-date must fall back to null rather than throw");
     assertTrue(info.isLegalHold());
   }
+
+  @Test
+  void testToHttpClientOptionsAllNullKeepsSdkDefaults() {
+    // When no inputs are supplied, the produced options must match the OSS SDK defaults so a
+    // client built from them behaves identically to the SDK's own default client.
+    var defaults = com.aliyun.sdk.service.oss2.transport.HttpClientOptions.custom().build();
+
+    var options = AliTransformer.toHttpClientOptions(null, null, null, null);
+
+    assertNotNull(options);
+    assertEquals(defaults.maxConnections(), options.maxConnections());
+    assertEquals(defaults.keepAliveTimeout(), options.keepAliveTimeout());
+    assertEquals(defaults.readWriteTimeout(), options.readWriteTimeout());
+    assertEquals(defaults.connectTimeout(), options.connectTimeout());
+    assertNull(options.proxyHost());
+  }
+
+  @Test
+  void testToHttpClientOptionsAppliesMaxConnectionsAndIdleTimeout() {
+    var options = AliTransformer.toHttpClientOptions(
+        null, null, 42, Duration.ofSeconds(75));
+
+    assertEquals(42, options.maxConnections());
+    assertEquals(Duration.ofSeconds(75), options.keepAliveTimeout());
+  }
+
+  @Test
+  void testToHttpClientOptionsPreservesProxyHostAndReadWriteTimeout() {
+    // Supplying a custom client bypasses the SDK's own option derivation, so the transport
+    // fields the driver otherwise sets (proxyHost, readWriteTimeout) must survive.
+    var options = AliTransformer.toHttpClientOptions(
+        "proxy.example.com:8080", Duration.ofSeconds(20), 10, Duration.ofSeconds(50));
+
+    assertEquals("proxy.example.com:8080", options.proxyHost());
+    assertEquals(Duration.ofSeconds(20), options.readWriteTimeout());
+    assertEquals(10, options.maxConnections());
+    assertEquals(Duration.ofSeconds(50), options.keepAliveTimeout());
+  }
+
+  @Test
+  void testToHttpClientOptionsOnlyIdleTimeoutLeavesMaxConnectionsDefault() {
+    var defaults = com.aliyun.sdk.service.oss2.transport.HttpClientOptions.custom().build();
+
+    var options = AliTransformer.toHttpClientOptions(
+        null, null, null, Duration.ofSeconds(90));
+
+    assertEquals(Duration.ofSeconds(90), options.keepAliveTimeout());
+    assertEquals(defaults.maxConnections(), options.maxConnections(),
+        "maxConnections must keep the SDK default when only idle timeout is set");
+  }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -88,6 +88,7 @@ import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
+import com.salesforce.multicloudj.common.retries.RetryConfig;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.CredentialsType;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
@@ -1747,5 +1748,49 @@ public class AliAsyncBlobStoreTest {
   void testBuildClients_withoutConnectionPoolConfig_buildsSuccessfully() {
     // Neither knob set — both sub-clients use the SDK default (no behavior change).
     assertDoesNotThrow(() -> newRealClientBuilder().build());
+  }
+
+  @Test
+  void testBuildClients_withConnectionPoolConfigAndNoProxy_buildsSuccessfully() {
+    // Covers the proxyHost==null branch of the explicit-HttpClient path on both sub-clients
+    // (no proxy endpoint set).
+    StsCredentials creds = new StsCredentials("key-1", "secret-1", "token-1");
+    CredentialsOverrider credsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(creds)
+            .build();
+    AliAsyncBlobStore.Builder builder = new AliAsyncBlobStore.Builder();
+    builder.withBucket(BUCKET);
+    builder.withRegion(REGION);
+    builder.withEndpoint(URI.create("https://test.example.com"));
+    builder.withCredentialsOverrider(credsOverrider);
+    builder.withMaxConnections(64);
+    builder.withIdleConnectionTimeout(Duration.ofSeconds(45));
+    assertNotNull(builder.build());
+  }
+
+  @Test
+  void testBuildClients_withAttemptTimeout_usesReadWriteTimeoutBranch() {
+    // No connection-pool knobs but RetryConfig.attemptTimeout set — exercises the
+    // attemptTimeout-precedence path and the else-if readWriteTimeout fallback on both sub-clients.
+    AliAsyncBlobStore.Builder builder = newRealClientBuilder();
+    builder.withRetryConfig(RetryConfig.builder().maxAttempts(3).attemptTimeout(5000L).build());
+    assertDoesNotThrow(builder::build);
+  }
+
+  @Test
+  void testBuildClients_withSocketTimeoutOnly_usesReadWriteTimeoutBranch() {
+    // No connection-pool knobs, no attemptTimeout, but socketTimeout set — exercises the
+    // socketTimeout fallback in the readWriteTimeout resolution on both sub-clients.
+    AliAsyncBlobStore.Builder builder = newRealClientBuilder();
+    builder.withSocketTimeout(Duration.ofSeconds(30));
+    assertDoesNotThrow(builder::build);
+  }
+
+  @Test
+  void testBuildClients_withOnlyIdleConnectionTimeout_buildsSuccessfully() {
+    AliAsyncBlobStore.Builder builder = newRealClientBuilder();
+    builder.withIdleConnectionTimeout(Duration.ofSeconds(45));
+    assertNotNull(builder.build());
   }
 }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -1,6 +1,7 @@
 package com.salesforce.multicloudj.blob.ali.async;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -61,6 +62,7 @@ import com.aliyun.sdk.service.oss2.transfermanager.DownloadError;
 import com.aliyun.sdk.service.oss2.transfermanager.DownloadResult;
 import com.aliyun.sdk.service.oss2.transfermanager.Downloader;
 import com.salesforce.multicloudj.blob.ali.AliTransformerSupplier;
+import com.salesforce.multicloudj.blob.async.driver.AsyncBlobStore;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
@@ -86,8 +88,12 @@ import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
+import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -1705,5 +1711,41 @@ public class AliAsyncBlobStoreTest {
     ExecutionException ex = assertThrows(ExecutionException.class,
         () -> store.deleteDirectory("dir/").get());
     assertNotNull(ex.getCause());
+  }
+
+  // No withAsyncClient()/withSyncClient() — exercises the real client-construction path for both
+  // the async and sync sub-clients. Setters are called as statements (not chained) because the
+  // base BlobStoreBuilder setters return BlobStoreBuilder, not the Ali subtype.
+  private AliAsyncBlobStore.Builder newRealClientBuilder() {
+    StsCredentials creds = new StsCredentials("key-1", "secret-1", "token-1");
+    CredentialsOverrider credsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(creds)
+            .build();
+    AliAsyncBlobStore.Builder builder = new AliAsyncBlobStore.Builder();
+    builder.withBucket(BUCKET);
+    builder.withRegion(REGION);
+    builder.withEndpoint(URI.create("https://test.example.com"));
+    builder.withProxyEndpoint(URI.create("http://proxy.example.com:80"));
+    builder.withCredentialsOverrider(credsOverrider);
+    return builder;
+  }
+
+  @Test
+  void testBuildClients_withConnectionPoolConfig_buildsSuccessfully() {
+    // Setting maxConnections/idleConnectionTimeout routes both sub-clients through the explicit-
+    // HttpClient path (Apache5AsyncHttpClientBuilder / Apache5HttpClientBuilder). Verify both
+    // build without error.
+    AliAsyncBlobStore.Builder builder = newRealClientBuilder();
+    builder.withMaxConnections(64);
+    builder.withIdleConnectionTimeout(Duration.ofSeconds(45));
+    AsyncBlobStore built = builder.build();
+    assertNotNull(built);
+  }
+
+  @Test
+  void testBuildClients_withoutConnectionPoolConfig_buildsSuccessfully() {
+    // Neither knob set — both sub-clients use the SDK default (no behavior change).
+    assertDoesNotThrow(() -> newRealClientBuilder().build());
   }
 }


### PR DESCRIPTION
## Summary
The cloud-agnostic `BlobStoreBuilder` accepts `withMaxConnections(Integer)` and `withIdleConnectionTimeout(Duration)`, and AWS/GCP wire both into their HTTP clients. The Ali OSS driver collected both and silently dropped them (sync and async). This wires them into the OSS HTTP client.

## Changes
- **`AliTransformer.toHttpClientOptions(...)`** — shared helper that assembles `HttpClientOptions` from the transport settings MultiCloudJ exposes. Null-guards every field so an unset knob keeps the SDK default; maps `idleConnectionTimeout` → `keepAliveTimeout`. Returns sync/async-agnostic options.
- **`AliBlobStore.buildOSSClient`** and **`AliAsyncBlobStore`** (both async + sync sub-clients) — when either knob is set, build an explicit Apache5 transport client from the options and supply it via `.httpClient(...)`; otherwise leave the SDK to construct its own default client.

## Why a custom HTTP client
`maxConnections` and `keepAliveTimeout` are only settable via the OSS SDK's `HttpClientOptions`, not on the `OSSClient`/`OSSAsyncClient` builders directly. Supplying a client through `.httpClient(...)` bypasses the SDK's own `toHttpClientOptions` derivation, so the two transport fields the driver otherwise sets on the client builder (`proxyHost`, `readWriteTimeout`) are carried forward to preserve existing behavior.

## No behavior change when unset
When neither knob is set, no custom client is supplied at all — the SDK builds its default client exactly as before (byte-identical). Verified against `alibabacloud-oss-v2:0.4.0`.

## Testing
Unit tests only — these are transport-tuning knobs with no observable wire behavior (same treatment as `socketTimeout`):
- `toHttpClientOptions`: default-path (all null → SDK defaults 1024 / 30s), set-path (both propagate), preserve-path (`proxyHost` + `readWriteTimeout` survive).
- Sync + async store builders build successfully with knobs set and unset.
- Full Ali conformance suite in replay unchanged at **119 run / 0 failures / 23 skipped**, confirming the unset path is unaffected. AWS/GCP untouched (Ali-only change).

## Cross-Cloud Compatibility
- AWS: already wires both (`maxConnections` via HTTP client builder; idle via `connectionMaxIdleTime`).
- GCP: already wires both.
- Alibaba: this PR — via `HttpClientOptions.maxConnections` / `keepAliveTimeout`.