### PR TITLE
blobstore: add WireMock recordings for Ali presign v2 conformance tests

### DIFF
--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testpresignv2_backwardcompatibility-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testpresignv2_backwardcompatibility-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "744bda0a-2ea3-4752-9b3c-749c24519efe",
+  "name" : "AliBlobStoreIT_testPresignV2_backwardCompatibility-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/presign-v2/backward-compat",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A3448BB692283333671E432",
+      "x-oss-server-time" : "45",
+      "Server" : "AliyunOSS",
+      "Date" : "Thu, 18 Jun 2026 19:36:27 GMT"
+    }
+  },
+  "uuid" : "744bda0a-2ea3-4752-9b3c-749c24519efe",
+  "persistent" : true,
+  "insertionIndex" : 147
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testpresignv2_contentlengthbinding-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testpresignv2_contentlengthbinding-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "a3a8ba51-34b6-4816-b910-ed29a4ad2949",
+  "name" : "AliBlobStoreIT_testPresignV2_contentLengthBinding-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/presign-v2/content-length-binding",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A3448BE76ADAE3438864F0D",
+      "x-oss-server-time" : "47",
+      "Server" : "AliyunOSS",
+      "Date" : "Thu, 18 Jun 2026 19:36:30 GMT"
+    }
+  },
+  "uuid" : "a3a8ba51-34b6-4816-b910-ed29a4ad2949",
+  "persistent" : true,
+  "insertionIndex" : 151
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testpresignv2_contenttypebinding-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testpresignv2_contenttypebinding-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "7d8bbd52-0777-40dd-9339-f706c4374da5",
+  "name" : "AliBlobStoreIT_testPresignV2_contentTypeBinding-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/presign-v2/content-type-binding",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A3448BDF40CB63030EEB341",
+      "x-oss-server-time" : "64",
+      "Server" : "AliyunOSS",
+      "Date" : "Thu, 18 Jun 2026 19:36:29 GMT"
+    }
+  },
+  "uuid" : "7d8bbd52-0777-40dd-9339-f706c4374da5",
+  "persistent" : true,
+  "insertionIndex" : 149
+}

--- a/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testpresignv2_signedheadersnonempty-delete-0.json
+++ b/blob/blob-ali/src/test/resources/mappings/aliblobstoreit_testpresignv2_signedheadersnonempty-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "0d5e24df-aae2-48a5-b8fc-52baa3f52b56",
+  "name" : "AliBlobStoreIT_testPresignV2_signedHeadersNonEmpty-DELETE-0",
+  "request" : {
+    "url" : "/conformance-tests/presign-v2/signed-headers-present",
+    "method" : "DELETE",
+    "headers" : {
+      "Host" : {
+        "equalTo" : "chameleon-multicloudj-test.oss-cn-shanghai.aliyuncs.com"
+      }
+    }
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "x-oss-request-id" : "6A3448BFBA2045303450E420",
+      "x-oss-server-time" : "4",
+      "Server" : "AliyunOSS",
+      "Date" : "Thu, 18 Jun 2026 19:36:31 GMT"
+    }
+  },
+  "uuid" : "0d5e24df-aae2-48a5-b8fc-52baa3f52b56",
+  "persistent" : true,
+  "insertionIndex" : 153
+}


### PR DESCRIPTION
## Summary
Follow-up to #495 (PR review feedback): adds the WireMock mapping files for the 4 enabled Ali presign v2 conformance tests, so the Ali file set is complete and consistent with AWS/GCP.

## Background
A reviewer on #495 asked about the missing mapping files. The 4 presign v2 tests assert presigned-URL **generation** only — `presign()` makes no network call, and the actual upload runs only in record mode — so replay never needed a stub to pass. The single recorded stub per test is the cleanup `DELETE` issued by each test's `finally` block (`safeDeleteBlobs`), which was previously unmatched-and-swallowed in replay. Recording it explicitly matches how AWS/GCP carry these files.

## Changes
Adds 4 mapping files (one cleanup-DELETE stub each):
- `testPresignV2_contentLengthBinding`
- `testPresignV2_contentTypeBinding`
- `testPresignV2_signedHeadersNonEmpty`
- `testPresignV2_backwardCompatibility`

No code changes.

## Testing
Full Ali conformance suite in replay (no credentials): **119 run / 0 failures / 19 skipped** — unchanged from the post-#495 baseline. All 4 presign v2 tests run and pass. No credentials in the recordings.