### PR TITLE
blobstore: replace inline fully-qualified class names with imports in Ali blob tests

### DIFF
--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -17,13 +17,56 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.aliyun.sdk.service.oss2.OSSClient;
+import com.aliyun.sdk.service.oss2.OperationOptions;
+import com.aliyun.sdk.service.oss2.PresignOptions;
 import com.aliyun.sdk.service.oss2.exceptions.OperationException;
 import com.aliyun.sdk.service.oss2.exceptions.ServiceException;
+import com.aliyun.sdk.service.oss2.models.AbortMultipartUploadRequest;
+import com.aliyun.sdk.service.oss2.models.CommonPrefix;
+import com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest;
+import com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult;
+import com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml;
+import com.aliyun.sdk.service.oss2.models.CopyObjectRequest;
+import com.aliyun.sdk.service.oss2.models.CopyObjectResult;
+import com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest;
+import com.aliyun.sdk.service.oss2.models.DeleteObjectRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectLegalHoldResult;
+import com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectResult;
+import com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult;
+import com.aliyun.sdk.service.oss2.models.GetObjectTaggingRequest;
+import com.aliyun.sdk.service.oss2.models.GetObjectTaggingResult;
 import com.aliyun.sdk.service.oss2.models.HeadObjectRequest;
 import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
+import com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload;
+import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest;
+import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult;
+import com.aliyun.sdk.service.oss2.models.LegalHold;
 import com.aliyun.sdk.service.oss2.models.ListObjectVersionsRequest;
 import com.aliyun.sdk.service.oss2.models.ListObjectVersionsResult;
+import com.aliyun.sdk.service.oss2.models.ListObjectsV2Request;
+import com.aliyun.sdk.service.oss2.models.ListObjectsV2Result;
+import com.aliyun.sdk.service.oss2.models.ListPartsRequest;
+import com.aliyun.sdk.service.oss2.models.ListPartsResult;
+import com.aliyun.sdk.service.oss2.models.ObjectIdentifier;
+import com.aliyun.sdk.service.oss2.models.ObjectLegalHoldStatusType;
+import com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType;
+import com.aliyun.sdk.service.oss2.models.ObjectSummary;
 import com.aliyun.sdk.service.oss2.models.ObjectVersion;
+import com.aliyun.sdk.service.oss2.models.Part;
+import com.aliyun.sdk.service.oss2.models.PresignResult;
+import com.aliyun.sdk.service.oss2.models.PutObjectLegalHoldResult;
+import com.aliyun.sdk.service.oss2.models.PutObjectRequest;
+import com.aliyun.sdk.service.oss2.models.PutObjectResult;
+import com.aliyun.sdk.service.oss2.models.PutObjectRetentionResult;
+import com.aliyun.sdk.service.oss2.models.PutObjectTaggingRequest;
+import com.aliyun.sdk.service.oss2.models.Retention;
+import com.aliyun.sdk.service.oss2.models.Tag;
+import com.aliyun.sdk.service.oss2.models.TagSet;
+import com.aliyun.sdk.service.oss2.models.Tagging;
+import com.aliyun.sdk.service.oss2.models.UploadPartRequest;
+import com.aliyun.sdk.service.oss2.models.UploadPartResult;
 import com.aliyun.sdk.service.oss2.paginator.ListObjectVersionsIterable;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobInfo;
@@ -41,13 +84,22 @@ import com.salesforce.multicloudj.blob.driver.ListBlobsRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartPart;
 import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
+import com.salesforce.multicloudj.blob.driver.MultipartUploadResponse;
+import com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration;
+import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
+import com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig;
 import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
+import com.salesforce.multicloudj.blob.driver.RetentionMode;
+import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.ali.AliConstants;
+import com.salesforce.multicloudj.common.exceptions.ArchiveInfo;
+import com.salesforce.multicloudj.common.exceptions.FailedPreconditionException;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
 import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
 import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
@@ -142,7 +194,7 @@ public class AliBlobStoreTest {
   void testDoUploadInputStream() {
     doReturn(buildTestPutObjectResult())
         .when(mockOssClient).putObject(
-            any(com.aliyun.sdk.service.oss2.models.PutObjectRequest.class), any());
+            any(PutObjectRequest.class), any());
     verifyUploadTestResults(ali.doUpload(getTestUploadRequest(), mock(InputStream.class)));
   }
 
@@ -150,7 +202,7 @@ public class AliBlobStoreTest {
   void testDoUploadByteArray() {
     doReturn(buildTestPutObjectResult())
         .when(mockOssClient).putObject(
-            any(com.aliyun.sdk.service.oss2.models.PutObjectRequest.class), any());
+            any(PutObjectRequest.class), any());
     verifyUploadTestResults(ali.doUpload(getTestUploadRequest(), new byte[1024]));
   }
 
@@ -158,7 +210,7 @@ public class AliBlobStoreTest {
   void testDoUploadFile() throws IOException {
     doReturn(buildTestPutObjectResult())
         .when(mockOssClient).putObject(
-            any(com.aliyun.sdk.service.oss2.models.PutObjectRequest.class), any());
+            any(PutObjectRequest.class), any());
     Path path = null;
     try {
       path = Files.createTempFile("tempFile", ".txt");
@@ -181,7 +233,7 @@ public class AliBlobStoreTest {
   void testDoUploadPath() throws IOException {
     doReturn(buildTestPutObjectResult())
         .when(mockOssClient).putObject(
-            any(com.aliyun.sdk.service.oss2.models.PutObjectRequest.class), any());
+            any(PutObjectRequest.class), any());
     Path path = Files.createTempFile("tempFile", ".txt");
     try (BufferedWriter writer = Files.newBufferedWriter(path)) {
       writer.write(new char[1024]);
@@ -192,10 +244,10 @@ public class AliBlobStoreTest {
   void verifyUploadTestResults(UploadResponse uploadResponse) {
 
     // Verify the parameters passed into the OSS SDK
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.PutObjectRequest> putObjectRequestCaptor =
-        ArgumentCaptor.forClass(com.aliyun.sdk.service.oss2.models.PutObjectRequest.class);
+    ArgumentCaptor<PutObjectRequest> putObjectRequestCaptor =
+        ArgumentCaptor.forClass(PutObjectRequest.class);
     verify(mockOssClient, times(1)).putObject(putObjectRequestCaptor.capture(), any());
-    com.aliyun.sdk.service.oss2.models.PutObjectRequest actualRequest =
+    PutObjectRequest actualRequest =
         putObjectRequestCaptor.getValue();
     assertEquals("object-1", actualRequest.key());
     assertEquals("bucket-1", actualRequest.bucket());
@@ -213,7 +265,7 @@ public class AliBlobStoreTest {
     Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
     doReturn(buildTestGetObjectResult(now))
         .when(mockOssClient).getObject(
-            any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class), any());
+            any(GetObjectRequest.class), any());
     verifyDownloadTestResults(
         ali.doDownload(getTestDownloadRequest(), mock(OutputStream.class)), now);
   }
@@ -223,7 +275,7 @@ public class AliBlobStoreTest {
     Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
     doReturn(buildTestGetObjectResult(now))
         .when(mockOssClient).getObject(
-            any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class), any());
+            any(GetObjectRequest.class), any());
     verifyDownloadTestResults(ali.doDownload(getTestDownloadRequest()), now);
   }
 
@@ -232,7 +284,7 @@ public class AliBlobStoreTest {
     Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
     doReturn(buildTestGetObjectResult(now))
         .when(mockOssClient).getObject(
-            any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class), any());
+            any(GetObjectRequest.class), any());
     ByteArray byteArray = new ByteArray();
     verifyDownloadTestResults(ali.doDownload(getTestDownloadRequest(), byteArray), now);
     assertEquals("downloadedData", new String(byteArray.getBytes()));
@@ -243,7 +295,7 @@ public class AliBlobStoreTest {
     Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
     doReturn(buildTestGetObjectResult(now))
         .when(mockOssClient).getObject(
-            any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class), any());
+            any(GetObjectRequest.class), any());
     Path path = Path.of("tempFile.txt");
     try {
       Files.deleteIfExists(path);
@@ -264,7 +316,7 @@ public class AliBlobStoreTest {
     Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
     doReturn(buildTestGetObjectResult(now))
         .when(mockOssClient).getObject(
-            any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class), any());
+            any(GetObjectRequest.class), any());
     Path path = Path.of("tempPath.txt");
     try {
       Files.deleteIfExists(path);
@@ -283,10 +335,10 @@ public class AliBlobStoreTest {
   void verifyDownloadTestResults(DownloadResponse response, Instant now) {
 
     // Verify the parameters passed into the OSS SDK
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.GetObjectRequest> getObjectRequestCaptor =
-        ArgumentCaptor.forClass(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class);
+    ArgumentCaptor<GetObjectRequest> getObjectRequestCaptor =
+        ArgumentCaptor.forClass(GetObjectRequest.class);
     verify(mockOssClient, times(1)).getObject(getObjectRequestCaptor.capture(), any());
-    com.aliyun.sdk.service.oss2.models.GetObjectRequest actualGetObjectRequest =
+    GetObjectRequest actualGetObjectRequest =
         getObjectRequestCaptor.getValue();
     assertEquals("object-1", actualGetObjectRequest.key());
     assertEquals("bucket-1", actualGetObjectRequest.bucket());
@@ -307,18 +359,18 @@ public class AliBlobStoreTest {
   void testDoDelete() {
     ali.doDelete("object-1", "version-1");
 
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.DeleteObjectRequest> captor =
-        ArgumentCaptor.forClass(com.aliyun.sdk.service.oss2.models.DeleteObjectRequest.class);
+    ArgumentCaptor<DeleteObjectRequest> captor =
+        ArgumentCaptor.forClass(DeleteObjectRequest.class);
     verify(mockOssClient, times(1)).deleteObject(captor.capture(),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
-    com.aliyun.sdk.service.oss2.models.DeleteObjectRequest actual = captor.getValue();
+        any(OperationOptions.class));
+    DeleteObjectRequest actual = captor.getValue();
     assertEquals("bucket-1", actual.bucket());
     assertEquals("object-1", actual.key());
     assertEquals("version-1", actual.versionId());
 
     ali.doDelete("object-1", null);
     verify(mockOssClient, times(2)).deleteObject(captor.capture(),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
+        any(OperationOptions.class));
     actual = captor.getValue();
     assertEquals("bucket-1", actual.bucket());
     assertEquals("object-1", actual.key());
@@ -335,14 +387,14 @@ public class AliBlobStoreTest {
             new BlobIdentifier("object-4", null));
     ali.doDelete(objects);
 
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest> captor =
+    ArgumentCaptor<DeleteMultipleObjectsRequest> captor =
         ArgumentCaptor.forClass(
-            com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest.class);
+            DeleteMultipleObjectsRequest.class);
     verify(mockOssClient, times(1)).deleteMultipleObjects(captor.capture(),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
-    com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest actual = captor.getValue();
+        any(OperationOptions.class));
+    DeleteMultipleObjectsRequest actual = captor.getValue();
     assertEquals("bucket-1", actual.bucket());
-    List<com.aliyun.sdk.service.oss2.models.ObjectIdentifier> ids = actual.delete().objects();
+    List<ObjectIdentifier> ids = actual.delete().objects();
     assertEquals(4, ids.size());
     assertEquals("object-1", ids.get(0).key());
     assertEquals("version-1", ids.get(0).versionId());
@@ -360,8 +412,8 @@ public class AliBlobStoreTest {
     // Empty list should not call deleteMultipleObjects
     ali.doDelete(List.of());
     verify(mockOssClient, times(3)).deleteMultipleObjects(
-        any(com.aliyun.sdk.service.oss2.models.DeleteMultipleObjectsRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
+        any(DeleteMultipleObjectsRequest.class),
+        any(OperationOptions.class));
   }
 
   @Test
@@ -371,22 +423,22 @@ public class AliBlobStoreTest {
         java.time.ZonedDateTime.ofInstant(now, java.time.ZoneOffset.UTC)
             .format(java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME);
 
-    com.aliyun.sdk.service.oss2.models.CopyObjectResult mockCopyResult =
-        mock(com.aliyun.sdk.service.oss2.models.CopyObjectResult.class);
+    CopyObjectResult mockCopyResult =
+        mock(CopyObjectResult.class);
     when(mockCopyResult.versionId()).thenReturn("copyVersion-1");
     when(mockCopyResult.eTag()).thenReturn("\"eTag-1\"");
     when(mockCopyResult.lastModified()).thenReturn(null);
     when(mockOssClient.copyObject(
-        any(com.aliyun.sdk.service.oss2.models.CopyObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+        any(CopyObjectRequest.class),
+        any(OperationOptions.class)))
         .thenReturn(mockCopyResult);
 
-    com.aliyun.sdk.service.oss2.models.HeadObjectResult mockHeadResult =
-        mock(com.aliyun.sdk.service.oss2.models.HeadObjectResult.class);
+    HeadObjectResult mockHeadResult =
+        mock(HeadObjectResult.class);
     when(mockHeadResult.lastModified()).thenReturn(lastModifiedRfc);
     when(mockOssClient.headObject(
-        any(com.aliyun.sdk.service.oss2.models.HeadObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+        any(HeadObjectRequest.class),
+        any(OperationOptions.class)))
         .thenReturn(mockHeadResult);
 
     CopyRequest copyRequest =
@@ -404,10 +456,10 @@ public class AliBlobStoreTest {
     assertEquals("eTag-1", copyResponse.getETag());
     assertEquals(now, copyResponse.getLastModified());
 
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.CopyObjectRequest> captor =
-        ArgumentCaptor.forClass(com.aliyun.sdk.service.oss2.models.CopyObjectRequest.class);
+    ArgumentCaptor<CopyObjectRequest> captor =
+        ArgumentCaptor.forClass(CopyObjectRequest.class);
     verify(mockOssClient, times(1)).copyObject(captor.capture(), any());
-    com.aliyun.sdk.service.oss2.models.CopyObjectRequest actual = captor.getValue();
+    CopyObjectRequest actual = captor.getValue();
     assertEquals("bucket-1", actual.sourceBucket());
     assertEquals("src-object-1", actual.sourceKey());
     assertEquals("version-1", actual.sourceVersionId());
@@ -422,22 +474,22 @@ public class AliBlobStoreTest {
         java.time.ZonedDateTime.ofInstant(now, java.time.ZoneOffset.UTC)
             .format(java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME);
 
-    com.aliyun.sdk.service.oss2.models.CopyObjectResult mockCopyResult =
-        mock(com.aliyun.sdk.service.oss2.models.CopyObjectResult.class);
+    CopyObjectResult mockCopyResult =
+        mock(CopyObjectResult.class);
     when(mockCopyResult.versionId()).thenReturn("copyVersion-1");
     when(mockCopyResult.eTag()).thenReturn("\"eTag-1\"");
     when(mockCopyResult.lastModified()).thenReturn(null);
     when(mockOssClient.copyObject(
-        any(com.aliyun.sdk.service.oss2.models.CopyObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+        any(CopyObjectRequest.class),
+        any(OperationOptions.class)))
         .thenReturn(mockCopyResult);
 
-    com.aliyun.sdk.service.oss2.models.HeadObjectResult mockHeadResult =
-        mock(com.aliyun.sdk.service.oss2.models.HeadObjectResult.class);
+    HeadObjectResult mockHeadResult =
+        mock(HeadObjectResult.class);
     when(mockHeadResult.lastModified()).thenReturn(lastModifiedRfc);
     when(mockOssClient.headObject(
-        any(com.aliyun.sdk.service.oss2.models.HeadObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+        any(HeadObjectRequest.class),
+        any(OperationOptions.class)))
         .thenReturn(mockHeadResult);
 
     CopyFromRequest copyFromRequest =
@@ -455,10 +507,10 @@ public class AliBlobStoreTest {
     assertEquals("eTag-1", copyResponse.getETag());
     assertEquals(now, copyResponse.getLastModified());
 
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.CopyObjectRequest> captor =
-        ArgumentCaptor.forClass(com.aliyun.sdk.service.oss2.models.CopyObjectRequest.class);
+    ArgumentCaptor<CopyObjectRequest> captor =
+        ArgumentCaptor.forClass(CopyObjectRequest.class);
     verify(mockOssClient, times(1)).copyObject(captor.capture(), any());
-    com.aliyun.sdk.service.oss2.models.CopyObjectRequest actual = captor.getValue();
+    CopyObjectRequest actual = captor.getValue();
     assertEquals("src-bucket-1", actual.sourceBucket());
     assertEquals("src-object-1", actual.sourceKey());
     assertEquals("version-1", actual.sourceVersionId());
@@ -501,11 +553,11 @@ public class AliBlobStoreTest {
   @Test
   void testDoListEmpty() {
     ListBlobsRequest request = new ListBlobsRequest.Builder().build();
-    com.aliyun.sdk.service.oss2.models.ListObjectsV2Result mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.ListObjectsV2Result.class);
+    ListObjectsV2Result mockResult =
+        mock(ListObjectsV2Result.class);
     when(mockOssClient.listObjectsV2(
-        any(com.aliyun.sdk.service.oss2.models.ListObjectsV2Request.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(ListObjectsV2Request.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     when(mockResult.contents()).thenReturn(List.of());
     when(mockResult.nextContinuationToken()).thenReturn(null);
 
@@ -521,12 +573,12 @@ public class AliBlobStoreTest {
   void testDoList() {
     ListBlobsRequest request =
         new ListBlobsRequest.Builder().withPrefix("abc").withDelimiter("/").build();
-    com.aliyun.sdk.service.oss2.models.ListObjectsV2Result mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.ListObjectsV2Result.class);
+    ListObjectsV2Result mockResult =
+        mock(ListObjectsV2Result.class);
     when(mockOssClient.listObjectsV2(
-        any(com.aliyun.sdk.service.oss2.models.ListObjectsV2Request.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
-    List<com.aliyun.sdk.service.oss2.models.ObjectSummary> list = getObjectSummaryList();
+        any(ListObjectsV2Request.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
+    List<ObjectSummary> list = getObjectSummaryList();
     when(mockResult.contents()).thenReturn(list);
     when(mockResult.nextContinuationToken()).thenReturn(null);
 
@@ -550,13 +602,13 @@ public class AliBlobStoreTest {
   private static final java.time.Instant BASE_LAST_MODIFIED =
       java.time.Instant.parse("2026-01-01T00:00:00Z");
 
-  private List<com.aliyun.sdk.service.oss2.models.ObjectSummary> getObjectSummaryList() {
-    List<com.aliyun.sdk.service.oss2.models.ObjectSummary> list = new ArrayList<>();
+  private List<ObjectSummary> getObjectSummaryList() {
+    List<ObjectSummary> list = new ArrayList<>();
     IntStream.range(1, 100)
         .forEach(
             (i) -> {
-              com.aliyun.sdk.service.oss2.models.ObjectSummary summary =
-                  com.aliyun.sdk.service.oss2.models.ObjectSummary.newBuilder()
+              ObjectSummary summary =
+                  ObjectSummary.newBuilder()
                       .key("key-" + i)
                       .size((long) i)
                       .lastModified(BASE_LAST_MODIFIED.plusSeconds(i))
@@ -576,12 +628,12 @@ public class AliBlobStoreTest {
             .withMaxResults(50)
             .build();
 
-    com.aliyun.sdk.service.oss2.models.ListObjectsV2Result mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.ListObjectsV2Result.class);
+    ListObjectsV2Result mockResult =
+        mock(ListObjectsV2Result.class);
     when(mockOssClient.listObjectsV2(
-        any(com.aliyun.sdk.service.oss2.models.ListObjectsV2Request.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
-    List<com.aliyun.sdk.service.oss2.models.ObjectSummary> list = getObjectSummaryList();
+        any(ListObjectsV2Request.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
+    List<ObjectSummary> list = getObjectSummaryList();
     when(mockResult.contents()).thenReturn(list);
     when(mockResult.commonPrefixes()).thenReturn(List.of());
     when(mockResult.isTruncated()).thenReturn(true);
@@ -590,11 +642,11 @@ public class AliBlobStoreTest {
     ListBlobsPageResponse response = ali.listPage(request);
 
     // Verify the request is mapped to the SDK
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.ListObjectsV2Request> requestCaptor =
-        ArgumentCaptor.forClass(com.aliyun.sdk.service.oss2.models.ListObjectsV2Request.class);
+    ArgumentCaptor<ListObjectsV2Request> requestCaptor =
+        ArgumentCaptor.forClass(ListObjectsV2Request.class);
     verify(mockOssClient, times(1)).listObjectsV2(requestCaptor.capture(),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
-    com.aliyun.sdk.service.oss2.models.ListObjectsV2Request actualRequest =
+        any(OperationOptions.class));
+    ListObjectsV2Request actualRequest =
         requestCaptor.getValue();
     assertEquals("bucket-1", actualRequest.bucket());
     assertEquals("abc", actualRequest.prefix());
@@ -621,11 +673,11 @@ public class AliBlobStoreTest {
   @Test
   void testDoListPageEmpty() {
     ListBlobsPageRequest request = ListBlobsPageRequest.builder().build();
-    com.aliyun.sdk.service.oss2.models.ListObjectsV2Result mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.ListObjectsV2Result.class);
+    ListObjectsV2Result mockResult =
+        mock(ListObjectsV2Result.class);
     when(mockOssClient.listObjectsV2(
-        any(com.aliyun.sdk.service.oss2.models.ListObjectsV2Request.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(ListObjectsV2Request.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     when(mockResult.contents()).thenReturn(List.of());
     when(mockResult.commonPrefixes()).thenReturn(List.of());
     when(mockResult.isTruncated()).thenReturn(false);
@@ -645,15 +697,15 @@ public class AliBlobStoreTest {
     ListBlobsPageRequest request =
         ListBlobsPageRequest.builder().withDelimiter("/").build();
 
-    com.aliyun.sdk.service.oss2.models.ListObjectsV2Result mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.ListObjectsV2Result.class);
+    ListObjectsV2Result mockResult =
+        mock(ListObjectsV2Result.class);
     when(mockOssClient.listObjectsV2(
-        any(com.aliyun.sdk.service.oss2.models.ListObjectsV2Request.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(ListObjectsV2Request.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     when(mockResult.contents()).thenReturn(List.of());
     when(mockResult.commonPrefixes()).thenReturn(List.of(
-        com.aliyun.sdk.service.oss2.models.CommonPrefix.newBuilder().prefix("dir1/").build(),
-        com.aliyun.sdk.service.oss2.models.CommonPrefix.newBuilder().prefix("dir2/").build()));
+        CommonPrefix.newBuilder().prefix("dir1/").build(),
+        CommonPrefix.newBuilder().prefix("dir2/").build()));
     when(mockResult.isTruncated()).thenReturn(false);
     when(mockResult.nextContinuationToken()).thenReturn(null);
 
@@ -670,20 +722,20 @@ public class AliBlobStoreTest {
     ListBlobsPageRequest request =
         ListBlobsPageRequest.builder().withDelimiter("/").build();
 
-    com.aliyun.sdk.service.oss2.models.ObjectSummary summary =
-        com.aliyun.sdk.service.oss2.models.ObjectSummary.newBuilder()
+    ObjectSummary summary =
+        ObjectSummary.newBuilder()
             .key("root.txt")
             .size(100L)
             .build();
 
-    com.aliyun.sdk.service.oss2.models.ListObjectsV2Result mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.ListObjectsV2Result.class);
+    ListObjectsV2Result mockResult =
+        mock(ListObjectsV2Result.class);
     when(mockOssClient.listObjectsV2(
-        any(com.aliyun.sdk.service.oss2.models.ListObjectsV2Request.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(ListObjectsV2Request.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     when(mockResult.contents()).thenReturn(List.of(summary));
     when(mockResult.commonPrefixes()).thenReturn(List.of(
-        com.aliyun.sdk.service.oss2.models.CommonPrefix.newBuilder().prefix("dir1/").build()));
+        CommonPrefix.newBuilder().prefix("dir1/").build()));
     when(mockResult.isTruncated()).thenReturn(false);
     when(mockResult.nextContinuationToken()).thenReturn(null);
 
@@ -700,16 +752,16 @@ public class AliBlobStoreTest {
     ListBlobsPageRequest request =
         ListBlobsPageRequest.builder().withDelimiter("/").withMaxResults(5).build();
 
-    com.aliyun.sdk.service.oss2.models.ListObjectsV2Result mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.ListObjectsV2Result.class);
+    ListObjectsV2Result mockResult =
+        mock(ListObjectsV2Result.class);
     when(mockOssClient.listObjectsV2(
-        any(com.aliyun.sdk.service.oss2.models.ListObjectsV2Request.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(ListObjectsV2Request.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     when(mockResult.contents()).thenReturn(List.of());
     when(mockResult.commonPrefixes()).thenReturn(List.of(
-        com.aliyun.sdk.service.oss2.models.CommonPrefix.newBuilder().prefix("a/").build(),
-        com.aliyun.sdk.service.oss2.models.CommonPrefix.newBuilder().prefix("b/").build(),
-        com.aliyun.sdk.service.oss2.models.CommonPrefix.newBuilder().prefix("c/").build()));
+        CommonPrefix.newBuilder().prefix("a/").build(),
+        CommonPrefix.newBuilder().prefix("b/").build(),
+        CommonPrefix.newBuilder().prefix("c/").build()));
     when(mockResult.isTruncated()).thenReturn(false);
     when(mockResult.nextContinuationToken()).thenReturn(null);
 
@@ -726,17 +778,17 @@ public class AliBlobStoreTest {
     ListBlobsPageRequest request =
         ListBlobsPageRequest.builder().withDelimiter("/").build();
 
-    com.aliyun.sdk.service.oss2.models.ObjectSummary summary =
-        com.aliyun.sdk.service.oss2.models.ObjectSummary.newBuilder()
+    ObjectSummary summary =
+        ObjectSummary.newBuilder()
             .key("file.txt")
             .size(50L)
             .build();
 
-    com.aliyun.sdk.service.oss2.models.ListObjectsV2Result mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.ListObjectsV2Result.class);
+    ListObjectsV2Result mockResult =
+        mock(ListObjectsV2Result.class);
     when(mockOssClient.listObjectsV2(
-        any(com.aliyun.sdk.service.oss2.models.ListObjectsV2Request.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(ListObjectsV2Request.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     when(mockResult.contents()).thenReturn(List.of(summary));
     when(mockResult.commonPrefixes()).thenReturn(null);
     when(mockResult.isTruncated()).thenReturn(false);
@@ -751,29 +803,29 @@ public class AliBlobStoreTest {
 
   @Test
   void testDoInitiateMultipartUpload() {
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload mockUpload =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload.class);
+    InitiateMultipartUploadResult mockResult =
+        mock(InitiateMultipartUploadResult.class);
+    InitiateMultipartUpload mockUpload =
+        mock(InitiateMultipartUpload.class);
     when(mockResult.initiateMultipartUpload()).thenReturn(mockUpload);
     when(mockUpload.bucket()).thenReturn("bucket-1");
     when(mockUpload.key()).thenReturn("object-1");
     when(mockUpload.uploadId()).thenReturn("mpu-id");
     when(mockOssClient.initiateMultipartUpload(
-        any(com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(InitiateMultipartUploadRequest.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     Map<String, String> metadata = Map.of("key-1", "value-1");
     MultipartUploadRequest request =
         new MultipartUploadRequest.Builder().withKey("object-1").withMetadata(metadata).build();
 
     ali.initiateMultipartUpload(request);
 
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest> captor =
+    ArgumentCaptor<InitiateMultipartUploadRequest> captor =
         ArgumentCaptor.forClass(
-            com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest.class);
+            InitiateMultipartUploadRequest.class);
     verify(mockOssClient, times(1)).initiateMultipartUpload(captor.capture(),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest actualRequest =
+        any(OperationOptions.class));
+    InitiateMultipartUploadRequest actualRequest =
         captor.getValue();
     assertEquals("object-1", actualRequest.key());
     assertEquals("bucket-1", actualRequest.bucket());
@@ -782,17 +834,17 @@ public class AliBlobStoreTest {
 
   @Test
   void testDoInitiateMultipartUploadWithKms() {
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload mockUpload =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload.class);
+    InitiateMultipartUploadResult mockResult =
+        mock(InitiateMultipartUploadResult.class);
+    InitiateMultipartUpload mockUpload =
+        mock(InitiateMultipartUpload.class);
     when(mockResult.initiateMultipartUpload()).thenReturn(mockUpload);
     when(mockUpload.bucket()).thenReturn("bucket-1");
     when(mockUpload.key()).thenReturn("object-1");
     when(mockUpload.uploadId()).thenReturn("mpu-id");
     when(mockOssClient.initiateMultipartUpload(
-        any(com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(InitiateMultipartUploadRequest.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     Map<String, String> metadata = Map.of("key-1", "value-1");
     String kmsKeyId = "test-kms-key-id";
     MultipartUploadRequest request =
@@ -804,12 +856,12 @@ public class AliBlobStoreTest {
 
     MultipartUpload response = ali.initiateMultipartUpload(request);
 
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest> captor =
+    ArgumentCaptor<InitiateMultipartUploadRequest> captor =
         ArgumentCaptor.forClass(
-            com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest.class);
+            InitiateMultipartUploadRequest.class);
     verify(mockOssClient, times(1)).initiateMultipartUpload(captor.capture(),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadRequest actualRequest =
+        any(OperationOptions.class));
+    InitiateMultipartUploadRequest actualRequest =
         captor.getValue();
     assertEquals("object-1", actualRequest.key());
     assertEquals("bucket-1", actualRequest.bucket());
@@ -823,12 +875,12 @@ public class AliBlobStoreTest {
 
   @Test
   void testDoUploadMultipartPart() {
-    com.aliyun.sdk.service.oss2.models.UploadPartResult mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.UploadPartResult.class);
+    UploadPartResult mockResult =
+        mock(UploadPartResult.class);
     when(mockResult.eTag()).thenReturn("\"etag\"");
     when(mockOssClient.uploadPart(
-        any(com.aliyun.sdk.service.oss2.models.UploadPartRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(UploadPartRequest.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     MultipartUpload multipartUpload =
         MultipartUpload.builder().bucket("bucket-1").key("object-1").id("mpu-id").build();
     byte[] content = "This is test data".getBytes(StandardCharsets.UTF_8);
@@ -836,11 +888,11 @@ public class AliBlobStoreTest {
 
     ali.uploadMultipartPart(multipartUpload, multipartPart);
 
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.UploadPartRequest> captor =
-        ArgumentCaptor.forClass(com.aliyun.sdk.service.oss2.models.UploadPartRequest.class);
+    ArgumentCaptor<UploadPartRequest> captor =
+        ArgumentCaptor.forClass(UploadPartRequest.class);
     verify(mockOssClient, times(1)).uploadPart(captor.capture(),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
-    com.aliyun.sdk.service.oss2.models.UploadPartRequest actualRequest = captor.getValue();
+        any(OperationOptions.class));
+    UploadPartRequest actualRequest = captor.getValue();
     assertEquals("object-1", actualRequest.key());
     assertEquals("bucket-1", actualRequest.bucket());
     assertEquals("mpu-id", actualRequest.uploadId());
@@ -849,33 +901,33 @@ public class AliBlobStoreTest {
 
   @Test
   void testDoCompleteMultipartUpload() {
-    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml mockXml =
-        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml.class);
+    CompleteMultipartUploadResult mockResult =
+        mock(CompleteMultipartUploadResult.class);
+    CompleteMultipartUploadResultXml mockXml =
+        mock(CompleteMultipartUploadResultXml.class);
     when(mockResult.completeMultipartUpload()).thenReturn(mockXml);
     when(mockXml.eTag()).thenReturn("\"result-etag\"");
     when(mockOssClient.completeMultipartUpload(
-        any(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(CompleteMultipartUploadRequest.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     MultipartUpload multipartUpload =
         MultipartUpload.builder().bucket("bucket-1").key("object-1").id("mpu-id").build();
-    List<com.salesforce.multicloudj.blob.driver.UploadPartResponse> listOfParts =
-        List.of(new com.salesforce.multicloudj.blob.driver.UploadPartResponse(1, "etag", 0));
+    List<UploadPartResponse> listOfParts =
+        List.of(new UploadPartResponse(1, "etag", 0));
 
     ali.completeMultipartUpload(multipartUpload, listOfParts);
 
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest> captor =
+    ArgumentCaptor<CompleteMultipartUploadRequest> captor =
         ArgumentCaptor.forClass(
-            com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest.class);
+            CompleteMultipartUploadRequest.class);
     verify(mockOssClient, times(1)).completeMultipartUpload(captor.capture(),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
-    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest actualRequest =
+        any(OperationOptions.class));
+    CompleteMultipartUploadRequest actualRequest =
         captor.getValue();
     assertEquals("object-1", actualRequest.key());
     assertEquals("bucket-1", actualRequest.bucket());
     assertEquals("mpu-id", actualRequest.uploadId());
-    List<com.aliyun.sdk.service.oss2.models.Part> parts =
+    List<Part> parts =
         actualRequest.completeMultipartUpload().parts();
     assertEquals(1, parts.size());
     assertEquals(1L, parts.get(0).partNumber());
@@ -888,22 +940,22 @@ public class AliBlobStoreTest {
     // on CompleteMultipartUploadResult.hashCRC64(). That should flow through to
     // MultipartUploadResponse.checksumValue so callers receive a composite checksum, matching
     // the cross-cloud contract (AWS surfaces SHA256/CRC32C; GCP surfaces CRC32C).
-    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml mockXml =
-        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml.class);
+    CompleteMultipartUploadResult mockResult =
+        mock(CompleteMultipartUploadResult.class);
+    CompleteMultipartUploadResultXml mockXml =
+        mock(CompleteMultipartUploadResultXml.class);
     when(mockResult.completeMultipartUpload()).thenReturn(mockXml);
     when(mockXml.eTag()).thenReturn("\"result-etag\"");
     when(mockResult.hashCRC64()).thenReturn("14870085893817539781");
     when(mockOssClient.completeMultipartUpload(
-        any(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(CompleteMultipartUploadRequest.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     MultipartUpload multipartUpload =
         MultipartUpload.builder().bucket("bucket-1").key("object-1").id("mpu-id").build();
-    List<com.salesforce.multicloudj.blob.driver.UploadPartResponse> listOfParts =
-        List.of(new com.salesforce.multicloudj.blob.driver.UploadPartResponse(1, "etag", 0));
+    List<UploadPartResponse> listOfParts =
+        List.of(new UploadPartResponse(1, "etag", 0));
 
-    com.salesforce.multicloudj.blob.driver.MultipartUploadResponse response =
+    MultipartUploadResponse response =
         ali.completeMultipartUpload(multipartUpload, listOfParts);
 
     assertEquals("result-etag", response.getEtag());
@@ -915,22 +967,22 @@ public class AliBlobStoreTest {
   void testDoCompleteMultipartUpload_nullHashCRC64_leavesChecksumValueNull() {
     // Best-effort: when OSS doesn't return a hashCRC64 (null), checksumValue stays null rather
     // than being set to the literal string "null".
-    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml mockXml =
-        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml.class);
+    CompleteMultipartUploadResult mockResult =
+        mock(CompleteMultipartUploadResult.class);
+    CompleteMultipartUploadResultXml mockXml =
+        mock(CompleteMultipartUploadResultXml.class);
     when(mockResult.completeMultipartUpload()).thenReturn(mockXml);
     when(mockXml.eTag()).thenReturn("\"result-etag\"");
     when(mockResult.hashCRC64()).thenReturn(null);
     when(mockOssClient.completeMultipartUpload(
-        any(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(CompleteMultipartUploadRequest.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     MultipartUpload multipartUpload =
         MultipartUpload.builder().bucket("bucket-1").key("object-1").id("mpu-id").build();
-    List<com.salesforce.multicloudj.blob.driver.UploadPartResponse> listOfParts =
-        List.of(new com.salesforce.multicloudj.blob.driver.UploadPartResponse(1, "etag", 0));
+    List<UploadPartResponse> listOfParts =
+        List.of(new UploadPartResponse(1, "etag", 0));
 
-    com.salesforce.multicloudj.blob.driver.MultipartUploadResponse response =
+    MultipartUploadResponse response =
         ali.completeMultipartUpload(multipartUpload, listOfParts);
 
     assertEquals("result-etag", response.getEtag());
@@ -939,22 +991,22 @@ public class AliBlobStoreTest {
 
   @Test
   void testDoListMultipartUpload() {
-    com.aliyun.sdk.service.oss2.models.ListPartsResult mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.ListPartsResult.class);
+    ListPartsResult mockResult =
+        mock(ListPartsResult.class);
     when(mockResult.parts()).thenReturn(List.of());
     when(mockOssClient.listParts(
-        any(com.aliyun.sdk.service.oss2.models.ListPartsRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(ListPartsRequest.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     MultipartUpload multipartUpload =
         MultipartUpload.builder().bucket("bucket-1").key("object-1").id("mpu-id").build();
 
     ali.listMultipartUpload(multipartUpload);
 
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.ListPartsRequest> captor =
-        ArgumentCaptor.forClass(com.aliyun.sdk.service.oss2.models.ListPartsRequest.class);
+    ArgumentCaptor<ListPartsRequest> captor =
+        ArgumentCaptor.forClass(ListPartsRequest.class);
     verify(mockOssClient, times(1)).listParts(captor.capture(),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
-    com.aliyun.sdk.service.oss2.models.ListPartsRequest actualRequest = captor.getValue();
+        any(OperationOptions.class));
+    ListPartsRequest actualRequest = captor.getValue();
     assertEquals("object-1", actualRequest.key());
     assertEquals("bucket-1", actualRequest.bucket());
     assertEquals("mpu-id", actualRequest.uploadId());
@@ -967,12 +1019,12 @@ public class AliBlobStoreTest {
 
     ali.abortMultipartUpload(multipartUpload);
 
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.AbortMultipartUploadRequest> captor =
+    ArgumentCaptor<AbortMultipartUploadRequest> captor =
         ArgumentCaptor.forClass(
-            com.aliyun.sdk.service.oss2.models.AbortMultipartUploadRequest.class);
+            AbortMultipartUploadRequest.class);
     verify(mockOssClient, times(1)).abortMultipartUpload(captor.capture(),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class));
-    com.aliyun.sdk.service.oss2.models.AbortMultipartUploadRequest actualRequest =
+        any(OperationOptions.class));
+    AbortMultipartUploadRequest actualRequest =
         captor.getValue();
     assertEquals("object-1", actualRequest.key());
     assertEquals("bucket-1", actualRequest.bucket());
@@ -981,20 +1033,20 @@ public class AliBlobStoreTest {
 
   @Test
   void testDoGetTags() {
-    com.aliyun.sdk.service.oss2.models.Tag tag1 =
-        com.aliyun.sdk.service.oss2.models.Tag.newBuilder().key("key1").value("value1").build();
-    com.aliyun.sdk.service.oss2.models.Tag tag2 =
-        com.aliyun.sdk.service.oss2.models.Tag.newBuilder().key("key2").value("value2").build();
-    com.aliyun.sdk.service.oss2.models.TagSet tagSet =
-        com.aliyun.sdk.service.oss2.models.TagSet.newBuilder()
+    Tag tag1 =
+        Tag.newBuilder().key("key1").value("value1").build();
+    Tag tag2 =
+        Tag.newBuilder().key("key2").value("value2").build();
+    TagSet tagSet =
+        TagSet.newBuilder()
             .tags(List.of(tag1, tag2)).build();
-    com.aliyun.sdk.service.oss2.models.Tagging tagging =
-        com.aliyun.sdk.service.oss2.models.Tagging.newBuilder().tagSet(tagSet).build();
-    com.aliyun.sdk.service.oss2.models.GetObjectTaggingResult mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.GetObjectTaggingResult.class);
+    Tagging tagging =
+        Tagging.newBuilder().tagSet(tagSet).build();
+    GetObjectTaggingResult mockResult =
+        mock(GetObjectTaggingResult.class);
     when(mockResult.tagging()).thenReturn(tagging);
     when(mockOssClient.getObjectTagging(
-        any(com.aliyun.sdk.service.oss2.models.GetObjectTaggingRequest.class), any()))
+        any(GetObjectTaggingRequest.class), any()))
         .thenReturn(mockResult);
 
     Map<String, String> tagsResult = ali.getTags("object-1");
@@ -1007,33 +1059,33 @@ public class AliBlobStoreTest {
     Map<String, String> tags = Map.of("key1", "value1", "key2", "value2");
     ali.setTags("object-1", tags);
 
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.PutObjectTaggingRequest> requestCaptor =
+    ArgumentCaptor<PutObjectTaggingRequest> requestCaptor =
         ArgumentCaptor.forClass(
-            com.aliyun.sdk.service.oss2.models.PutObjectTaggingRequest.class);
+            PutObjectTaggingRequest.class);
     verify(mockOssClient, times(1)).putObjectTagging(requestCaptor.capture(), any());
 
-    com.aliyun.sdk.service.oss2.models.PutObjectTaggingRequest actualRequest =
+    PutObjectTaggingRequest actualRequest =
         requestCaptor.getValue();
     assertEquals("bucket-1", actualRequest.bucket());
     assertEquals("object-1", actualRequest.key());
-    List<com.aliyun.sdk.service.oss2.models.Tag> actualTags =
+    List<Tag> actualTags =
         actualRequest.tagging().tagSet().tags();
     Map<String, String> actualTagMap = actualTags.stream()
         .collect(java.util.stream.Collectors.toMap(
-            com.aliyun.sdk.service.oss2.models.Tag::key,
-            com.aliyun.sdk.service.oss2.models.Tag::value));
+            Tag::key,
+            Tag::value));
     assertEquals(tags, actualTagMap);
   }
 
   @Test
   void testDoGeneratePresignedUploadUrl() {
-    com.aliyun.sdk.service.oss2.models.PresignResult mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.PresignResult.class);
+    PresignResult mockResult =
+        mock(PresignResult.class);
     doReturn("https://bucket-1.oss-cn-shanghai.aliyuncs.com/object-1?signed=true")
         .when(mockResult).url();
     doReturn(mockResult).when(mockOssClient).presign(
-        any(com.aliyun.sdk.service.oss2.models.PutObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.PresignOptions.class));
+        any(PutObjectRequest.class),
+        any(PresignOptions.class));
 
     UploadRequest uploadRequest = getTestUploadRequest();
     Duration duration = Duration.ofHours(12);
@@ -1049,11 +1101,11 @@ public class AliBlobStoreTest {
     PresignedUrlResponse result = ali.doPresign(presignedUploadRequest);
 
     assertNotNull(result);
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.PutObjectRequest> requestCaptor =
-        ArgumentCaptor.forClass(com.aliyun.sdk.service.oss2.models.PutObjectRequest.class);
+    ArgumentCaptor<PutObjectRequest> requestCaptor =
+        ArgumentCaptor.forClass(PutObjectRequest.class);
     verify(mockOssClient, times(1)).presign(requestCaptor.capture(),
-        any(com.aliyun.sdk.service.oss2.PresignOptions.class));
-    com.aliyun.sdk.service.oss2.models.PutObjectRequest actualRequest = requestCaptor.getValue();
+        any(PresignOptions.class));
+    PutObjectRequest actualRequest = requestCaptor.getValue();
     assertEquals("bucket-1", actualRequest.bucket());
     assertEquals("object-1", actualRequest.key());
     assertEquals("tag-1=tag-value-1", actualRequest.tagging());
@@ -1062,13 +1114,13 @@ public class AliBlobStoreTest {
 
   @Test
   void testDoGeneratePresignedDownloadUrl() {
-    com.aliyun.sdk.service.oss2.models.PresignResult mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.PresignResult.class);
+    PresignResult mockResult =
+        mock(PresignResult.class);
     doReturn("https://bucket-1.oss-cn-shanghai.aliyuncs.com/object-1?signed=true")
         .when(mockResult).url();
     doReturn(mockResult).when(mockOssClient).presign(
-        any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.PresignOptions.class));
+        any(GetObjectRequest.class),
+        any(PresignOptions.class));
 
     Duration duration = Duration.ofHours(12);
     PresignedUrlRequest presignedDownloadRequest =
@@ -1081,11 +1133,11 @@ public class AliBlobStoreTest {
     PresignedUrlResponse result = ali.doPresign(presignedDownloadRequest);
 
     assertNotNull(result);
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.GetObjectRequest> requestCaptor =
-        ArgumentCaptor.forClass(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class);
+    ArgumentCaptor<GetObjectRequest> requestCaptor =
+        ArgumentCaptor.forClass(GetObjectRequest.class);
     verify(mockOssClient, times(1)).presign(requestCaptor.capture(),
-        any(com.aliyun.sdk.service.oss2.PresignOptions.class));
-    com.aliyun.sdk.service.oss2.models.GetObjectRequest actualRequest = requestCaptor.getValue();
+        any(PresignOptions.class));
+    GetObjectRequest actualRequest = requestCaptor.getValue();
     assertEquals("bucket-1", actualRequest.bucket());
     assertEquals("object-1", actualRequest.key());
   }
@@ -1093,15 +1145,15 @@ public class AliBlobStoreTest {
   @Test
   void testDoDoesObjectExist() {
     doReturn(true).when(mockOssClient).doesObjectExist(
-        any(com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest.class));
+        any(GetObjectMetaRequest.class));
 
     boolean result = ali.doDoesObjectExist("object-1", "version-1");
 
-    ArgumentCaptor<com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest> requestCaptor =
+    ArgumentCaptor<GetObjectMetaRequest> requestCaptor =
         ArgumentCaptor.forClass(
-            com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest.class);
+            GetObjectMetaRequest.class);
     verify(mockOssClient, times(1)).doesObjectExist(requestCaptor.capture());
-    com.aliyun.sdk.service.oss2.models.GetObjectMetaRequest actualRequest =
+    GetObjectMetaRequest actualRequest =
         requestCaptor.getValue();
     assertEquals("bucket-1", actualRequest.bucket());
     assertEquals("object-1", actualRequest.key());
@@ -1140,9 +1192,9 @@ public class AliBlobStoreTest {
         .build();
   }
 
-  private com.aliyun.sdk.service.oss2.models.PutObjectResult buildTestPutObjectResult() {
-    com.aliyun.sdk.service.oss2.models.PutObjectResult result =
-        mock(com.aliyun.sdk.service.oss2.models.PutObjectResult.class);
+  private PutObjectResult buildTestPutObjectResult() {
+    PutObjectResult result =
+        mock(PutObjectResult.class);
     doReturn("version-1").when(result).versionId();
     doReturn("\"etag\"").when(result).eTag();
     return result;
@@ -1156,14 +1208,14 @@ public class AliBlobStoreTest {
         .build();
   }
 
-  private com.aliyun.sdk.service.oss2.models.GetObjectResult buildTestGetObjectResult(
+  private GetObjectResult buildTestGetObjectResult(
       Instant now) {
     Map<String, String> metadataMap = Map.of("key1", "value1", "key2", "value2");
     InputStream inputStream = new ByteArrayInputStream("downloadedData".getBytes());
     String lastModifiedStr = ZonedDateTime.ofInstant(now, ZoneOffset.UTC)
         .format(DateTimeFormatter.RFC_1123_DATE_TIME);
-    com.aliyun.sdk.service.oss2.models.GetObjectResult result =
-        mock(com.aliyun.sdk.service.oss2.models.GetObjectResult.class);
+    GetObjectResult result =
+        mock(GetObjectResult.class);
     doReturn("version-1").when(result).versionId();
     doReturn("etag1").when(result).eTag();
     doReturn(lastModifiedStr).when(result).lastModified();
@@ -1180,28 +1232,28 @@ public class AliBlobStoreTest {
     String key = "test-key";
     String versionId = "version-1";
 
-    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult retentionResult =
-        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
-            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
-                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.GOVERNANCE)
+    GetObjectRetentionResult retentionResult =
+        GetObjectRetentionResult.newBuilder()
+            .retention(Retention.newBuilder()
+                .mode(ObjectRetentionModeType.GOVERNANCE)
                 .retainUntilDate("2030-01-01T00:00:00Z")
                 .build())
             .build();
-    com.aliyun.sdk.service.oss2.models.GetObjectLegalHoldResult legalHoldResult =
-        com.aliyun.sdk.service.oss2.models.GetObjectLegalHoldResult.newBuilder()
-            .legalHold(com.aliyun.sdk.service.oss2.models.LegalHold.newBuilder()
-                .status(com.aliyun.sdk.service.oss2.models.ObjectLegalHoldStatusType.ON)
+    GetObjectLegalHoldResult legalHoldResult =
+        GetObjectLegalHoldResult.newBuilder()
+            .legalHold(LegalHold.newBuilder()
+                .status(ObjectLegalHoldStatusType.ON)
                 .build())
             .build();
 
     when(mockOssClient.getObjectRetention(any(), any())).thenReturn(retentionResult);
     when(mockOssClient.getObjectLegalHold(any(), any())).thenReturn(legalHoldResult);
 
-    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+    ObjectLockInfo info =
         ali.getObjectLock(key, versionId);
 
     assertEquals(
-        com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE, info.getMode());
+        RetentionMode.GOVERNANCE, info.getMode());
     assertEquals(Instant.parse("2030-01-01T00:00:00Z"), info.getRetainUntilDate());
     assertTrue(info.isLegalHold());
   }
@@ -1211,10 +1263,10 @@ public class AliBlobStoreTest {
     String key = "test-key";
     String versionId = "version-1";
 
-    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult retentionResult =
-        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
-            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
-                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.GOVERNANCE)
+    GetObjectRetentionResult retentionResult =
+        GetObjectRetentionResult.newBuilder()
+            .retention(Retention.newBuilder()
+                .mode(ObjectRetentionModeType.GOVERNANCE)
                 .retainUntilDate("2030-01-01T00:00:00Z")
                 .build())
             .build();
@@ -1229,11 +1281,11 @@ public class AliBlobStoreTest {
         new OperationException("GetObjectLegalHold", serviceException);
     when(mockOssClient.getObjectLegalHold(any(), any())).thenThrow(operationException);
 
-    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+    ObjectLockInfo info =
         ali.getObjectLock(key, versionId);
 
     assertEquals(
-        com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE, info.getMode());
+        RetentionMode.GOVERNANCE, info.getMode());
     assertEquals(Instant.parse("2030-01-01T00:00:00Z"), info.getRetainUntilDate());
     assertFalse(info.isLegalHold());
   }
@@ -1245,7 +1297,7 @@ public class AliBlobStoreTest {
 
     when(mockOssClient.putObjectLegalHold(any(), any()))
         .thenReturn(
-            com.aliyun.sdk.service.oss2.models.PutObjectLegalHoldResult.newBuilder().build());
+            PutObjectLegalHoldResult.newBuilder().build());
 
     ali.updateLegalHold(key, versionId, true);
 
@@ -1257,10 +1309,10 @@ public class AliBlobStoreTest {
     String key = "test-key";
     String versionId = "version-1";
 
-    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult currentResult =
-        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
-            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
-                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.GOVERNANCE)
+    GetObjectRetentionResult currentResult =
+        GetObjectRetentionResult.newBuilder()
+            .retention(Retention.newBuilder()
+                .mode(ObjectRetentionModeType.GOVERNANCE)
                 .retainUntilDate("2030-01-01T00:00:00Z")
                 .build())
             .build();
@@ -1268,11 +1320,11 @@ public class AliBlobStoreTest {
     when(mockOssClient.getObjectRetention(any(), any())).thenReturn(currentResult);
     when(mockOssClient.putObjectRetention(any(), any()))
         .thenReturn(
-            com.aliyun.sdk.service.oss2.models.PutObjectRetentionResult.newBuilder().build());
+            PutObjectRetentionResult.newBuilder().build());
 
-    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
-        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
-            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+    ObjectRetentionConfig config =
+        ObjectRetentionConfig.builder()
+            .mode(RetentionMode.GOVERNANCE)
             .retainUntilDate(Instant.parse("2031-01-01T00:00:00Z"))
             .bypassGovernanceRetention(false)
             .build();
@@ -1291,18 +1343,18 @@ public class AliBlobStoreTest {
     String key = "test-key";
     String versionId = "version-1";
 
-    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult currentResult =
-        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
-            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
-                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.GOVERNANCE)
+    GetObjectRetentionResult currentResult =
+        GetObjectRetentionResult.newBuilder()
+            .retention(Retention.newBuilder()
+                .mode(ObjectRetentionModeType.GOVERNANCE)
                 .retainUntilDate("2030-01-01T00:00:00Z")
                 .build())
             .build();
     when(mockOssClient.getObjectRetention(any(), any())).thenReturn(currentResult);
 
-    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
-        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
-            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.COMPLIANCE)
+    ObjectRetentionConfig config =
+        ObjectRetentionConfig.builder()
+            .mode(RetentionMode.COMPLIANCE)
             .retainUntilDate(Instant.parse("2031-01-01T00:00:00Z"))
             .bypassGovernanceRetention(true)
             .build();
@@ -1322,21 +1374,21 @@ public class AliBlobStoreTest {
     String key = "test-key";
     String versionId = "version-1";
 
-    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult currentResult =
-        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
-            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
-                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.GOVERNANCE)
+    GetObjectRetentionResult currentResult =
+        GetObjectRetentionResult.newBuilder()
+            .retention(Retention.newBuilder()
+                .mode(ObjectRetentionModeType.GOVERNANCE)
                 .retainUntilDate("2030-01-01T00:00:00Z")
                 .build())
             .build();
     when(mockOssClient.getObjectRetention(any(), any())).thenReturn(currentResult);
     when(mockOssClient.putObjectRetention(any(), any()))
         .thenReturn(
-            com.aliyun.sdk.service.oss2.models.PutObjectRetentionResult.newBuilder().build());
+            PutObjectRetentionResult.newBuilder().build());
 
-    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
-        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
-            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+    ObjectRetentionConfig config =
+        ObjectRetentionConfig.builder()
+            .mode(RetentionMode.GOVERNANCE)
             .retainUntilDate(Instant.parse("2031-01-01T00:00:00Z"))
             .build();
 
@@ -1354,24 +1406,24 @@ public class AliBlobStoreTest {
     String key = "test-key";
     String versionId = "version-1";
 
-    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult currentResult =
-        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
-            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
-                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.COMPLIANCE)
+    GetObjectRetentionResult currentResult =
+        GetObjectRetentionResult.newBuilder()
+            .retention(Retention.newBuilder()
+                .mode(ObjectRetentionModeType.COMPLIANCE)
                 .retainUntilDate("2030-01-01T00:00:00Z")
                 .build())
             .build();
     when(mockOssClient.getObjectRetention(any(), any())).thenReturn(currentResult);
 
-    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
-        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
-            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+    ObjectRetentionConfig config =
+        ObjectRetentionConfig.builder()
+            .mode(RetentionMode.GOVERNANCE)
             .retainUntilDate(Instant.parse("2031-01-01T00:00:00Z"))
             .bypassGovernanceRetention(true)
             .build();
 
     assertThrows(
-        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        FailedPreconditionException.class,
         () -> ali.updateObjectRetention(key, versionId, config));
 
     // Rejected by the shared rules before reaching OSS — not via the upgrade guard.
@@ -1416,7 +1468,7 @@ public class AliBlobStoreTest {
         new OperationException("GetObjectLegalHold", legalHoldException);
     when(mockOssClient.getObjectLegalHold(any(), any())).thenThrow(legalHoldOpException);
 
-    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+    ObjectLockInfo info =
         ali.getObjectLock(key, versionId);
 
     assertNull(info.getMode());
@@ -1439,15 +1491,15 @@ public class AliBlobStoreTest {
         new OperationException("GetObjectRetention", serviceException);
     when(mockOssClient.getObjectRetention(any(), any())).thenThrow(operationException);
 
-    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
-        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
-            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+    ObjectRetentionConfig config =
+        ObjectRetentionConfig.builder()
+            .mode(RetentionMode.GOVERNANCE)
             .retainUntilDate(Instant.parse("2031-01-01T00:00:00Z"))
             .bypassGovernanceRetention(false)
             .build();
 
     assertThrows(
-        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        FailedPreconditionException.class,
         () -> ali.updateObjectRetention(key, versionId, config));
   }
 
@@ -1458,24 +1510,24 @@ public class AliBlobStoreTest {
 
     // Object currently has COMPLIANCE mode with retain-until 2035. Attempting to shorten
     // the date should throw FailedPreconditionException regardless of bypass flag.
-    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult currentResult =
-        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
-            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
-                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.COMPLIANCE)
+    GetObjectRetentionResult currentResult =
+        GetObjectRetentionResult.newBuilder()
+            .retention(Retention.newBuilder()
+                .mode(ObjectRetentionModeType.COMPLIANCE)
                 .retainUntilDate("2035-01-01T00:00:00Z")
                 .build())
             .build();
     when(mockOssClient.getObjectRetention(any(), any())).thenReturn(currentResult);
 
-    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
-        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
-            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.COMPLIANCE)
+    ObjectRetentionConfig config =
+        ObjectRetentionConfig.builder()
+            .mode(RetentionMode.COMPLIANCE)
             .retainUntilDate(Instant.parse("2030-01-01T00:00:00Z"))
             .bypassGovernanceRetention(true)
             .build();
 
     assertThrows(
-        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        FailedPreconditionException.class,
         () -> ali.updateObjectRetention(key, versionId, config));
   }
 
@@ -1486,24 +1538,24 @@ public class AliBlobStoreTest {
 
     // Object currently has GOVERNANCE mode with retain-until 2035. Attempting to shorten
     // without bypass=true should throw FailedPreconditionException.
-    com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult currentResult =
-        com.aliyun.sdk.service.oss2.models.GetObjectRetentionResult.newBuilder()
-            .retention(com.aliyun.sdk.service.oss2.models.Retention.newBuilder()
-                .mode(com.aliyun.sdk.service.oss2.models.ObjectRetentionModeType.GOVERNANCE)
+    GetObjectRetentionResult currentResult =
+        GetObjectRetentionResult.newBuilder()
+            .retention(Retention.newBuilder()
+                .mode(ObjectRetentionModeType.GOVERNANCE)
                 .retainUntilDate("2035-01-01T00:00:00Z")
                 .build())
             .build();
     when(mockOssClient.getObjectRetention(any(), any())).thenReturn(currentResult);
 
-    com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig config =
-        com.salesforce.multicloudj.blob.driver.ObjectRetentionConfig.builder()
-            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+    ObjectRetentionConfig config =
+        ObjectRetentionConfig.builder()
+            .mode(RetentionMode.GOVERNANCE)
             .retainUntilDate(Instant.parse("2030-01-01T00:00:00Z"))
             .bypassGovernanceRetention(false)
             .build();
 
     assertThrows(
-        com.salesforce.multicloudj.common.exceptions.FailedPreconditionException.class,
+        FailedPreconditionException.class,
         () -> ali.updateObjectRetention(key, versionId, config));
   }
 
@@ -1511,26 +1563,26 @@ public class AliBlobStoreTest {
   void testDoCompleteMultipartUpload_withObjectLock_appliesRetentionAndLegalHold() {
     // Verify that completing a multipart upload with an ObjectLockConfiguration
     // triggers putObjectRetention and putObjectLegalHold calls.
-    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml mockXml =
-        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml.class);
+    CompleteMultipartUploadResult mockResult =
+        mock(CompleteMultipartUploadResult.class);
+    CompleteMultipartUploadResultXml mockXml =
+        mock(CompleteMultipartUploadResultXml.class);
     when(mockResult.completeMultipartUpload()).thenReturn(mockXml);
     when(mockResult.versionId()).thenReturn("ver-123");
     when(mockXml.eTag()).thenReturn("\"result-etag\"");
     when(mockOssClient.completeMultipartUpload(
-        any(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(CompleteMultipartUploadRequest.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
     when(mockOssClient.putObjectRetention(any(), any()))
         .thenReturn(
-            com.aliyun.sdk.service.oss2.models.PutObjectRetentionResult.newBuilder().build());
+            PutObjectRetentionResult.newBuilder().build());
     when(mockOssClient.putObjectLegalHold(any(), any()))
         .thenReturn(
-            com.aliyun.sdk.service.oss2.models.PutObjectLegalHoldResult.newBuilder().build());
+            PutObjectLegalHoldResult.newBuilder().build());
 
-    com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration lockConfig =
-        com.salesforce.multicloudj.blob.driver.ObjectLockConfiguration.builder()
-            .mode(com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE)
+    ObjectLockConfiguration lockConfig =
+        ObjectLockConfiguration.builder()
+            .mode(RetentionMode.GOVERNANCE)
             .retainUntilDate(Instant.parse("2100-01-01T00:00:00Z"))
             .legalHold(true)
             .build();
@@ -1539,8 +1591,8 @@ public class AliBlobStoreTest {
         .bucket("bucket-1").key("object-1").id("mpu-id")
         .objectLock(lockConfig)
         .build();
-    List<com.salesforce.multicloudj.blob.driver.UploadPartResponse> listOfParts =
-        List.of(new com.salesforce.multicloudj.blob.driver.UploadPartResponse(1, "etag", 0));
+    List<UploadPartResponse> listOfParts =
+        List.of(new UploadPartResponse(1, "etag", 0));
 
     ali.completeMultipartUpload(multipartUpload, listOfParts);
 
@@ -1553,21 +1605,21 @@ public class AliBlobStoreTest {
   void testDoCompleteMultipartUpload_withoutObjectLock_doesNotApplyRetention() {
     // Verify that completing a multipart upload WITHOUT ObjectLockConfiguration
     // does NOT call putObjectRetention or putObjectLegalHold.
-    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult mockResult =
-        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml mockXml =
-        mock(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadResultXml.class);
+    CompleteMultipartUploadResult mockResult =
+        mock(CompleteMultipartUploadResult.class);
+    CompleteMultipartUploadResultXml mockXml =
+        mock(CompleteMultipartUploadResultXml.class);
     when(mockResult.completeMultipartUpload()).thenReturn(mockXml);
     when(mockXml.eTag()).thenReturn("\"result-etag\"");
     when(mockOssClient.completeMultipartUpload(
-        any(com.aliyun.sdk.service.oss2.models.CompleteMultipartUploadRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class))).thenReturn(mockResult);
+        any(CompleteMultipartUploadRequest.class),
+        any(OperationOptions.class))).thenReturn(mockResult);
 
     MultipartUpload multipartUpload = MultipartUpload.builder()
         .bucket("bucket-1").key("object-1").id("mpu-id")
         .build();
-    List<com.salesforce.multicloudj.blob.driver.UploadPartResponse> listOfParts =
-        List.of(new com.salesforce.multicloudj.blob.driver.UploadPartResponse(1, "etag", 0));
+    List<UploadPartResponse> listOfParts =
+        List.of(new UploadPartResponse(1, "etag", 0));
 
     ali.completeMultipartUpload(multipartUpload, listOfParts);
 
@@ -1716,8 +1768,8 @@ public class AliBlobStoreTest {
     when(service.headers()).thenReturn(headers);
     OperationException op = mock(OperationException.class);
     when(op.getCause()).thenReturn(service);
-    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+    when(mockOssClient.getObject(any(GetObjectRequest.class),
+        any(OperationOptions.class)))
         .thenThrow(op);
 
     // 2. ListObjectVersions (paginated) returns one prior ObjectVersion. Use the prior version's
@@ -1735,11 +1787,11 @@ public class AliBlobStoreTest {
     DownloadRequest request = DownloadRequest.builder()
         .withKey(key).withCheckArchived(true).build();
 
-    com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException ex = assertThrows(
-        com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException.class,
+    ResourceNotFoundException ex = assertThrows(
+        ResourceNotFoundException.class,
         () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
 
-    com.salesforce.multicloudj.common.exceptions.ArchiveInfo info = ex.getArchiveInfo();
+    ArchiveInfo info = ex.getArchiveInfo();
     assertNotNull(info, "ArchiveInfo should be populated when a delete marker is detected");
     assertTrue(info.isArchived());
     assertEquals(priorVersionId, info.getVersionId());
@@ -1760,8 +1812,8 @@ public class AliBlobStoreTest {
     when(service.headers()).thenReturn(headers);
     OperationException op = mock(OperationException.class);
     when(op.getCause()).thenReturn(service);
-    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+    when(mockOssClient.getObject(any(GetObjectRequest.class),
+        any(OperationOptions.class)))
         .thenThrow(op);
 
     // checkArchived defaults to false on DownloadRequest.
@@ -1791,8 +1843,8 @@ public class AliBlobStoreTest {
     when(service.headers()).thenReturn(new java.util.HashMap<>()); // no delete-marker header
     OperationException op = mock(OperationException.class);
     when(op.getCause()).thenReturn(service);
-    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+    when(mockOssClient.getObject(any(GetObjectRequest.class),
+        any(OperationOptions.class)))
         .thenThrow(op);
 
     DownloadRequest request = DownloadRequest.builder()
@@ -1823,8 +1875,8 @@ public class AliBlobStoreTest {
     when(service.headers()).thenReturn(headers);
     OperationException op = mock(OperationException.class);
     when(op.getCause()).thenReturn(service);
-    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+    when(mockOssClient.getObject(any(GetObjectRequest.class),
+        any(OperationOptions.class)))
         .thenThrow(op);
 
     // ListObjectVersions paging blows up.
@@ -1839,7 +1891,7 @@ public class AliBlobStoreTest {
     Exception thrown = assertThrows(Exception.class,
         () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
     assertFalse(
-        thrown instanceof com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException,
+        thrown instanceof ResourceNotFoundException,
         "listObjectVersions failure must not be reported as an archived ResourceNotFoundException");
   }
 
@@ -1858,8 +1910,8 @@ public class AliBlobStoreTest {
     when(service.headers()).thenReturn(headers);
     OperationException op = mock(OperationException.class);
     when(op.getCause()).thenReturn(service);
-    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+    when(mockOssClient.getObject(any(GetObjectRequest.class),
+        any(OperationOptions.class)))
         .thenThrow(op);
 
     ListObjectVersionsResult emptyPage = mock(ListObjectVersionsResult.class);
@@ -1875,7 +1927,7 @@ public class AliBlobStoreTest {
     Exception thrown = assertThrows(Exception.class,
         () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
     assertFalse(
-        thrown instanceof com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException,
+        thrown instanceof ResourceNotFoundException,
         "An empty versions page must not produce an archived ResourceNotFoundException");
   }
 
@@ -1894,8 +1946,8 @@ public class AliBlobStoreTest {
     when(service.headers()).thenReturn(headers);
     OperationException op = mock(OperationException.class);
     when(op.getCause()).thenReturn(service);
-    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+    when(mockOssClient.getObject(any(GetObjectRequest.class),
+        any(OperationOptions.class)))
         .thenThrow(op);
 
     // A version for a DIFFERENT (sibling) key — the exact-key match must skip it.
@@ -1914,7 +1966,7 @@ public class AliBlobStoreTest {
     Exception thrown = assertThrows(Exception.class,
         () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
     assertFalse(
-        thrown instanceof com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException,
+        thrown instanceof ResourceNotFoundException,
         "An unresolved versionId must not produce an archived ResourceNotFoundException");
   }
 
@@ -1934,8 +1986,8 @@ public class AliBlobStoreTest {
     when(service.headers()).thenReturn(headers);
     OperationException op = mock(OperationException.class);
     when(op.getCause()).thenReturn(service);
-    when(mockOssClient.getObject(any(com.aliyun.sdk.service.oss2.models.GetObjectRequest.class),
-        any(com.aliyun.sdk.service.oss2.OperationOptions.class)))
+    when(mockOssClient.getObject(any(GetObjectRequest.class),
+        any(OperationOptions.class)))
         .thenThrow(op);
 
     ObjectVersion sibling = mock(ObjectVersion.class);
@@ -1957,10 +2009,10 @@ public class AliBlobStoreTest {
     DownloadRequest request = DownloadRequest.builder()
         .withKey(key).withCheckArchived(true).build();
 
-    com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException ex = assertThrows(
-        com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException.class,
+    ResourceNotFoundException ex = assertThrows(
+        ResourceNotFoundException.class,
         () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
-    com.salesforce.multicloudj.common.exceptions.ArchiveInfo info = ex.getArchiveInfo();
+    ArchiveInfo info = ex.getArchiveInfo();
     assertNotNull(info);
     assertTrue(info.isArchived());
     assertEquals(priorVersionId, info.getVersionId());

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -9,6 +9,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
+import com.aliyun.sdk.service.oss2.models.CopyObjectResult;
+import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
+import com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload;
+import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult;
+import com.aliyun.sdk.service.oss2.models.ListObjectsV2Request;
+import com.aliyun.sdk.service.oss2.models.ListPartsResult;
+import com.aliyun.sdk.service.oss2.models.Part;
+import com.aliyun.sdk.service.oss2.models.PutObjectResult;
+import com.aliyun.sdk.service.oss2.models.UploadPartResult;
+import com.aliyun.sdk.service.oss2.transport.BinaryData;
+import com.aliyun.sdk.service.oss2.transport.HttpClientOptions;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.ChecksumMethod;
@@ -19,8 +30,10 @@ import com.salesforce.multicloudj.blob.driver.ListBlobsRequest;
 import com.salesforce.multicloudj.blob.driver.MultipartPart;
 import com.salesforce.multicloudj.blob.driver.MultipartUpload;
 import com.salesforce.multicloudj.blob.driver.MultipartUploadRequest;
+import com.salesforce.multicloudj.blob.driver.ObjectLockInfo;
 import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
+import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
@@ -53,8 +66,8 @@ public class AliTransformerTest {
 
     var request =
         UploadRequest.builder().withKey(key).withMetadata(metadata).withTags(tags).build();
-    com.aliyun.sdk.service.oss2.transport.BinaryData body =
-        com.aliyun.sdk.service.oss2.transport.BinaryData.fromBytes("data".getBytes());
+    BinaryData body =
+        BinaryData.fromBytes("data".getBytes());
 
     var actual = transformer.toPutObjectRequest(request, body);
     assertEquals(BUCKET, actual.bucket());
@@ -71,8 +84,8 @@ public class AliTransformerTest {
 
     var request =
         UploadRequest.builder().withKey(key).withMetadata(metadata).withKmsKeyId(kmsKeyId).build();
-    com.aliyun.sdk.service.oss2.transport.BinaryData body =
-        com.aliyun.sdk.service.oss2.transport.BinaryData.fromBytes("data".getBytes());
+    BinaryData body =
+        BinaryData.fromBytes("data".getBytes());
 
     var actual = transformer.toPutObjectRequest(request, body);
     assertEquals(BUCKET, actual.bucket());
@@ -88,8 +101,8 @@ public class AliTransformerTest {
     var metadata = Map.of("some-key", "some-value");
 
     var request = UploadRequest.builder().withKey(key).withMetadata(metadata).build();
-    com.aliyun.sdk.service.oss2.transport.BinaryData body =
-        com.aliyun.sdk.service.oss2.transport.BinaryData.fromBytes("data".getBytes());
+    BinaryData body =
+        BinaryData.fromBytes("data".getBytes());
 
     var actual = transformer.toPutObjectRequest(request, body);
     assertEquals(BUCKET, actual.bucket());
@@ -102,8 +115,8 @@ public class AliTransformerTest {
   void testToPutObjectRequest_useKmsManagedKey_setsKmsWithoutKeyId() {
     var request =
         UploadRequest.builder().withKey("some-key").withUseKmsManagedKey(true).build();
-    com.aliyun.sdk.service.oss2.transport.BinaryData body =
-        com.aliyun.sdk.service.oss2.transport.BinaryData.fromBytes("data".getBytes());
+    BinaryData body =
+        BinaryData.fromBytes("data".getBytes());
 
     var actual = transformer.toPutObjectRequest(request, body);
 
@@ -120,8 +133,8 @@ public class AliTransformerTest {
             .withKmsKeyId(kmsKeyId)
             .withUseKmsManagedKey(true)
             .build();
-    com.aliyun.sdk.service.oss2.transport.BinaryData body =
-        com.aliyun.sdk.service.oss2.transport.BinaryData.fromBytes("data".getBytes());
+    BinaryData body =
+        BinaryData.fromBytes("data".getBytes());
 
     var actual = transformer.toPutObjectRequest(request, body);
 
@@ -136,8 +149,8 @@ public class AliTransformerTest {
             .withKey("some-key")
             .withMetadata(Map.of("some-key", "some-value"))
             .build();
-    com.aliyun.sdk.service.oss2.models.PutObjectResult result =
-        mock(com.aliyun.sdk.service.oss2.models.PutObjectResult.class);
+    PutObjectResult result =
+        mock(PutObjectResult.class);
     doReturn("\"etag\"").when(result).eTag();
     doReturn("version-1").when(result).versionId();
 
@@ -205,8 +218,8 @@ public class AliTransformerTest {
 
   @Test
   void testToCopyResponse_withLastModifiedHeader() {
-    com.aliyun.sdk.service.oss2.models.CopyObjectResult result =
-        mock(com.aliyun.sdk.service.oss2.models.CopyObjectResult.class);
+    CopyObjectResult result =
+        mock(CopyObjectResult.class);
     doReturn("v2").when(result).versionId();
     doReturn("\"etag\"").when(result).eTag();
     doReturn("Fri, 15 May 2026 10:30:00 GMT").when(result).lastModified();
@@ -221,8 +234,8 @@ public class AliTransformerTest {
 
   @Test
   void testToCopyResponse_withNullLastModifiedHeader() {
-    com.aliyun.sdk.service.oss2.models.CopyObjectResult result =
-        mock(com.aliyun.sdk.service.oss2.models.CopyObjectResult.class);
+    CopyObjectResult result =
+        mock(CopyObjectResult.class);
     doReturn("v2").when(result).versionId();
     doReturn("\"etag\"").when(result).eTag();
     doReturn(null).when(result).lastModified();
@@ -277,10 +290,10 @@ public class AliTransformerTest {
 
   @Test
   void testToMultipartUpload() {
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult result =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload upload =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload.class);
+    InitiateMultipartUploadResult result =
+        mock(InitiateMultipartUploadResult.class);
+    InitiateMultipartUpload upload =
+        mock(InitiateMultipartUpload.class);
     doReturn(upload).when(result).initiateMultipartUpload();
     doReturn(BUCKET).when(upload).bucket();
     doReturn("key").when(upload).key();
@@ -300,10 +313,10 @@ public class AliTransformerTest {
 
   @Test
   void testToMultipartUploadWithKms() {
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult result =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload upload =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload.class);
+    InitiateMultipartUploadResult result =
+        mock(InitiateMultipartUploadResult.class);
+    InitiateMultipartUpload upload =
+        mock(InitiateMultipartUpload.class);
     doReturn(upload).when(result).initiateMultipartUpload();
     doReturn(BUCKET).when(upload).bucket();
     doReturn("key").when(upload).key();
@@ -327,10 +340,10 @@ public class AliTransformerTest {
     // OSS's native object checksum is CRC64-ECMA. When checksumming is enabled without an explicit
     // algorithm, the stored MultipartUpload should reflect CRC64 so the value surfaced at
     // completion is honestly labeled.
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult result =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload upload =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload.class);
+    InitiateMultipartUploadResult result =
+        mock(InitiateMultipartUploadResult.class);
+    InitiateMultipartUpload upload =
+        mock(InitiateMultipartUpload.class);
     doReturn(upload).when(result).initiateMultipartUpload();
     doReturn(BUCKET).when(upload).bucket();
     doReturn("key").when(upload).key();
@@ -346,10 +359,10 @@ public class AliTransformerTest {
 
   @Test
   void testToMultipartUpload_explicitCrc64_preserved() {
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult result =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload upload =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload.class);
+    InitiateMultipartUploadResult result =
+        mock(InitiateMultipartUploadResult.class);
+    InitiateMultipartUpload upload =
+        mock(InitiateMultipartUpload.class);
     doReturn(upload).when(result).initiateMultipartUpload();
     doReturn(BUCKET).when(upload).bucket();
     doReturn("key").when(upload).key();
@@ -365,10 +378,10 @@ public class AliTransformerTest {
 
   @Test
   void testToMultipartUpload_checksumDisabled_algorithmStaysNull() {
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult result =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload upload =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload.class);
+    InitiateMultipartUploadResult result =
+        mock(InitiateMultipartUploadResult.class);
+    InitiateMultipartUpload upload =
+        mock(InitiateMultipartUpload.class);
     doReturn(upload).when(result).initiateMultipartUpload();
     doReturn(BUCKET).when(upload).bucket();
     doReturn("key").when(upload).key();
@@ -423,8 +436,8 @@ public class AliTransformerTest {
     byte[] content = "Test data".getBytes();
     InputStream inputStream = new ByteArrayInputStream(content);
     MultipartPart mpp = new MultipartPart(1, inputStream, content.length);
-    com.aliyun.sdk.service.oss2.models.UploadPartResult result =
-        mock(com.aliyun.sdk.service.oss2.models.UploadPartResult.class);
+    UploadPartResult result =
+        mock(UploadPartResult.class);
     doReturn("\"etag\"").when(result).eTag();
 
     var actual = transformer.toUploadPartResponse(mpp, result);
@@ -467,13 +480,13 @@ public class AliTransformerTest {
 
   @Test
   void testToListUploadPartResponse() {
-    com.aliyun.sdk.service.oss2.models.ListPartsResult result =
-        mock(com.aliyun.sdk.service.oss2.models.ListPartsResult.class);
-    com.aliyun.sdk.service.oss2.models.Part part2 =
-        com.aliyun.sdk.service.oss2.models.Part.newBuilder()
+    ListPartsResult result =
+        mock(ListPartsResult.class);
+    Part part2 =
+        Part.newBuilder()
             .partNumber(2L).eTag("\"etag2\"").size(50L).build();
-    com.aliyun.sdk.service.oss2.models.Part part1 =
-        com.aliyun.sdk.service.oss2.models.Part.newBuilder()
+    Part part1 =
+        Part.newBuilder()
             .partNumber(1L).eTag("\"etag1\"").size(100L).build();
     doReturn(List.of(part2, part1)).when(result).parts();
 
@@ -710,7 +723,7 @@ public class AliTransformerTest {
             .withMaxResults(100)
             .build();
 
-    com.aliyun.sdk.service.oss2.models.ListObjectsV2Request actual =
+    ListObjectsV2Request actual =
         transformer.toListObjectsRequest(request);
     assertEquals(BUCKET, actual.bucket());
     assertEquals(request.getDelimiter(), actual.delimiter());
@@ -724,7 +737,7 @@ public class AliTransformerTest {
     ListBlobsRequest request =
         new ListBlobsRequest.Builder().withPrefix("abc").withDelimiter("/").build();
 
-    com.aliyun.sdk.service.oss2.models.ListObjectsV2Request actual =
+    ListObjectsV2Request actual =
         transformer.toListObjectsRequest(request, "cont-token");
     assertEquals(BUCKET, actual.bucket());
     assertEquals("abc", actual.prefix());
@@ -737,7 +750,7 @@ public class AliTransformerTest {
     ListBlobsRequest request =
         new ListBlobsRequest.Builder().withPrefix("xyz").build();
 
-    com.aliyun.sdk.service.oss2.models.ListObjectsV2Request actual =
+    ListObjectsV2Request actual =
         transformer.toListObjectsRequest(request, null);
     assertEquals(BUCKET, actual.bucket());
     assertEquals("xyz", actual.prefix());
@@ -763,8 +776,8 @@ public class AliTransformerTest {
     UploadRequest uploadRequest =
         UploadRequest.builder().withKey("test-key").withStorageClass("IA").build();
 
-    com.aliyun.sdk.service.oss2.transport.BinaryData body =
-        com.aliyun.sdk.service.oss2.transport.BinaryData.fromBytes("test data".getBytes());
+    BinaryData body =
+        BinaryData.fromBytes("test data".getBytes());
     var result = transformer.toPutObjectRequest(uploadRequest, body);
 
     assertEquals(BUCKET, result.bucket());
@@ -781,8 +794,8 @@ public class AliTransformerTest {
             .withChecksumAlgorithm(ChecksumMethod.SHA256)
             .build();
 
-    com.aliyun.sdk.service.oss2.transport.BinaryData body =
-        com.aliyun.sdk.service.oss2.transport.BinaryData.fromBytes("data".getBytes());
+    BinaryData body =
+        BinaryData.fromBytes("data".getBytes());
     var result = transformer.toPutObjectRequest(uploadRequest, body);
 
     assertEquals("abc123sha256value", result.headers().get("x-oss-content-sha256"));
@@ -797,8 +810,8 @@ public class AliTransformerTest {
             .withChecksumValue("12345678901234")
             .build();
 
-    com.aliyun.sdk.service.oss2.transport.BinaryData body =
-        com.aliyun.sdk.service.oss2.transport.BinaryData.fromBytes("data".getBytes());
+    BinaryData body =
+        BinaryData.fromBytes("data".getBytes());
     var result = transformer.toPutObjectRequest(uploadRequest, body);
 
     assertEquals("12345678901234", result.headers().get("x-oss-hash-crc64ecma"));
@@ -807,10 +820,10 @@ public class AliTransformerTest {
 
   @Test
   void testToMultipartUpload_WithChecksumAlgorithm() {
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult result =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult.class);
-    com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload upload =
-        mock(com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload.class);
+    InitiateMultipartUploadResult result =
+        mock(InitiateMultipartUploadResult.class);
+    InitiateMultipartUpload upload =
+        mock(InitiateMultipartUpload.class);
     doReturn(upload).when(result).initiateMultipartUpload();
     doReturn(BUCKET).when(upload).bucket();
     doReturn("key").when(upload).key();
@@ -833,8 +846,8 @@ public class AliTransformerTest {
     UploadRequest uploadRequest =
         UploadRequest.builder().withKey("test-key").withContentType("text/plain").build();
 
-    com.aliyun.sdk.service.oss2.transport.BinaryData body =
-        com.aliyun.sdk.service.oss2.transport.BinaryData.fromBytes("data".getBytes());
+    BinaryData body =
+        BinaryData.fromBytes("data".getBytes());
     var result = transformer.toPutObjectRequest(uploadRequest, body);
 
     assertEquals(BUCKET, result.bucket());
@@ -989,17 +1002,17 @@ public class AliTransformerTest {
             "x-oss-object-worm-mode", "GOVERNANCE",
             "x-oss-object-worm-retain-until-date", "2026-06-10T23:49:51.000Z",
             "x-oss-object-worm-legal-hold", "ON");
-    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
-        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+    HeadObjectResult result =
+        HeadObjectResult.newBuilder()
             .headers(headers)
             .build();
 
     BlobMetadata metadata = transformer.toBlobMetadata("k", result);
 
-    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info = metadata.getObjectLockInfo();
+    ObjectLockInfo info = metadata.getObjectLockInfo();
     assertNotNull(info, "objectLockInfo should be populated when worm headers are present");
     assertEquals(
-        com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE, info.getMode());
+        RetentionMode.GOVERNANCE, info.getMode());
     assertEquals(Instant.parse("2026-06-10T23:49:51.000Z"), info.getRetainUntilDate());
     assertTrue(info.isLegalHold());
     // OSS has no event-based-hold concept; AWS leaves it null too.
@@ -1013,17 +1026,17 @@ public class AliTransformerTest {
         Map.of(
             "x-oss-object-worm-mode", "COMPLIANCE",
             "x-oss-object-worm-retain-until-date", "2030-01-01T00:00:00.000Z");
-    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
-        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+    HeadObjectResult result =
+        HeadObjectResult.newBuilder()
             .headers(headers)
             .build();
 
-    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+    ObjectLockInfo info =
         transformer.toBlobMetadata("k", result).getObjectLockInfo();
 
     assertNotNull(info);
     assertEquals(
-        com.salesforce.multicloudj.blob.driver.RetentionMode.COMPLIANCE, info.getMode());
+        RetentionMode.COMPLIANCE, info.getMode());
     assertEquals(Instant.parse("2030-01-01T00:00:00.000Z"), info.getRetainUntilDate());
     assertFalse(info.isLegalHold());
   }
@@ -1033,12 +1046,12 @@ public class AliTransformerTest {
     // OSS allows legal hold without retention. The transformer must still surface
     // objectLockInfo with mode=null and legalHold=true so callers can act on the hold.
     Map<String, String> headers = Map.of("x-oss-object-worm-legal-hold", "ON");
-    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
-        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+    HeadObjectResult result =
+        HeadObjectResult.newBuilder()
             .headers(headers)
             .build();
 
-    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+    ObjectLockInfo info =
         transformer.toBlobMetadata("k", result).getObjectLockInfo();
 
     assertNotNull(info,
@@ -1057,8 +1070,8 @@ public class AliTransformerTest {
             "Content-Type", "application/octet-stream",
             "ETag", "\"abc\"",
             "x-oss-storage-class", "Standard");
-    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
-        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+    HeadObjectResult result =
+        HeadObjectResult.newBuilder()
             .headers(headers)
             .build();
 
@@ -1077,17 +1090,17 @@ public class AliTransformerTest {
             "X-OSS-Object-Worm-Mode", "GOVERNANCE",
             "X-OSS-Object-Worm-Retain-Until-Date", "2026-06-10T23:49:51.000Z",
             "X-OSS-Object-Worm-Legal-Hold", "on");
-    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
-        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+    HeadObjectResult result =
+        HeadObjectResult.newBuilder()
             .headers(headers)
             .build();
 
-    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+    ObjectLockInfo info =
         transformer.toBlobMetadata("k", result).getObjectLockInfo();
 
     assertNotNull(info);
     assertEquals(
-        com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE, info.getMode());
+        RetentionMode.GOVERNANCE, info.getMode());
     assertTrue(info.isLegalHold(),
         "legal-hold value comparison should be case-insensitive (\"on\" -> true)");
   }
@@ -1102,12 +1115,12 @@ public class AliTransformerTest {
             "x-oss-object-worm-mode", "UNKNOWN_MODE",
             "x-oss-object-worm-retain-until-date", "2026-06-10T23:49:51.000Z",
             "x-oss-object-worm-legal-hold", "ON");
-    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
-        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+    HeadObjectResult result =
+        HeadObjectResult.newBuilder()
             .headers(headers)
             .build();
 
-    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+    ObjectLockInfo info =
         transformer.toBlobMetadata("k", result).getObjectLockInfo();
 
     assertNotNull(info,
@@ -1128,17 +1141,17 @@ public class AliTransformerTest {
             "x-oss-object-worm-mode", "GOVERNANCE",
             "x-oss-object-worm-retain-until-date", "not-a-valid-date",
             "x-oss-object-worm-legal-hold", "ON");
-    com.aliyun.sdk.service.oss2.models.HeadObjectResult result =
-        com.aliyun.sdk.service.oss2.models.HeadObjectResult.newBuilder()
+    HeadObjectResult result =
+        HeadObjectResult.newBuilder()
             .headers(headers)
             .build();
 
-    com.salesforce.multicloudj.blob.driver.ObjectLockInfo info =
+    ObjectLockInfo info =
         transformer.toBlobMetadata("k", result).getObjectLockInfo();
 
     assertNotNull(info);
     assertEquals(
-        com.salesforce.multicloudj.blob.driver.RetentionMode.GOVERNANCE, info.getMode());
+        RetentionMode.GOVERNANCE, info.getMode());
     assertNull(info.getRetainUntilDate(),
         "an unparseable retain-until-date must fall back to null rather than throw");
     assertTrue(info.isLegalHold());
@@ -1148,7 +1161,7 @@ public class AliTransformerTest {
   void testToHttpClientOptionsAllNullKeepsSdkDefaults() {
     // When no inputs are supplied, the produced options must match the OSS SDK defaults so a
     // client built from them behaves identically to the SDK's own default client.
-    var defaults = com.aliyun.sdk.service.oss2.transport.HttpClientOptions.custom().build();
+    var defaults = HttpClientOptions.custom().build();
 
     var options = AliTransformer.toHttpClientOptions(null, null, null, null);
 
@@ -1184,7 +1197,7 @@ public class AliTransformerTest {
 
   @Test
   void testToHttpClientOptionsOnlyIdleTimeoutLeavesMaxConnectionsDefault() {
-    var defaults = com.aliyun.sdk.service.oss2.transport.HttpClientOptions.custom().build();
+    var defaults = HttpClientOptions.custom().build();
 
     var options = AliTransformer.toHttpClientOptions(
         null, null, null, Duration.ofSeconds(90));


### PR DESCRIPTION
## Summary
Cleans up the scattered inline fully-qualified class names (FQCNs) in the Ali blob unit tests, replacing them with proper `import` statements. Behavior-preserving refactor — only namespace syntax changed, no test logic touched.

This is a follow-up to PR review feedback on #496 (use proper imports for new code; clean up the pre-existing FQCNs in the Ali blob tests).

## Changes
- `AliBlobStoreTest.java` — inline FQCNs → imports
- `AliTransformerTest.java` — inline FQCNs → imports

No name conflicts required keeping any FQCN inline: the OSS SDK (`com.aliyun.sdk.service.oss2.*`) and the multicloudj driver (`com.salesforce.multicloudj.blob.driver.*`) types referenced in each file have distinct simple names within that file, so all could be imported.

## Testing
- Full `blob-ali` unit suite: **242 run / 0 failures**.
- Ali conformance suite in replay (no credentials): **119 run / 0 failures / 19 skipped** — unchanged.
- Checkstyle clean.

No production code changed; no conformance recordings added.