### PR TITLE
blobstore: update the netty dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,14 +61,14 @@
         <mockito-inline.version>5.2.0</mockito-inline.version>
         <wiremock.version>3.13.2</wiremock.version>
         <lombok.version>1.18.36</lombok.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
         <httpasyncclient.version>4.1.5</httpasyncclient.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <eventstream.version>1.0.1</eventstream.version>
         <jmh.version>1.37</jmh.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <jackson.version>2.18.6</jackson.version>
         <aws-sdk.version>2.42.40</aws-sdk.version>
         <commons-codec.version>1.16.0</commons-codec.version>


### PR DESCRIPTION
## Summary
- Bump `netty.version` from `4.1.132.Final` to `4.1.135.Final` to address CVEs surfaced by FOX vulnerability scanning on the `blob-aws` transitive chain (via `software.amazon.awssdk:netty-nio-client`):
  - [GHSA-mj4r-2hfc-f8p6](https://github.com/netty/netty/security/advisories/GHSA-mj4r-2hfc-f8p6) — `netty-codec` (fixed in 4.1.133.Final)
  - [GHSA-57rv-r2g8-2cj3](https://github.com/netty/netty/security/advisories/GHSA-57rv-r2g8-2cj3) — `netty-codec-http` (fixed in 4.1.135.Final)
  - [GHSA-w9fj-cfpg-grvv](https://github.com/netty/netty/security/advisories/GHSA-w9fj-cfpg-grvv) — `netty-codec-http2` (fixed in 4.1.135.Final)
  - [GHSA-3qp7-7mw8-wx86](https://github.com/netty/netty/security/advisories/GHSA-3qp7-7mw8-wx86) — `netty-handler` (fixed in 4.1.135.Final)
- Bump `commons-lang3.version` from `3.18.0` to `3.20.0`.

## Test plan
- [x] `mvn clean install -DskipTests` — all 41 modules build green
- [x] `mvn test` — all unit tests pass
- [x] `mvn dependency:tree -pl blob/blob-aws -Dincludes='io.netty:*'` confirms `netty-codec`, `netty-codec-http`, `netty-codec-http2`, and `netty-handler` all resolve to `4.1.135.Final` on the `blob-aws` classpath