### PR TITLE
blobstore: gcp: skip range setup on full-object downloads and default the connection pool

### DIFF
--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -241,17 +241,7 @@ public class GcpBlobStore extends AbstractBlobStore {
     // ReadChannel streaming (parallelDownload is ignored for this overload).
     try (ReadChannel reader = storage.reader(blobId);
         var channel = Channels.newInputStream(reader)) {
-
-      var range =
-          transformer.computeRange(
-              downloadRequest.getStart(), downloadRequest.getEnd(), blob.getSize());
-      if (range.getLeft() != null) {
-        reader.seek(range.getLeft());
-      }
-      if (range.getRight() != null) {
-        reader.limit(range.getRight());
-      }
-
+      applyRange(reader, downloadRequest, blob);
       ByteStreams.copy(channel, outputStream);
       return transformer.toDownloadResponse(blob);
     } catch (IOException e) {
@@ -279,19 +269,41 @@ public class GcpBlobStore extends AbstractBlobStore {
     Blob blob = getRequiredBlobForDownload(downloadRequest);
     try {
       ReadChannel reader = blob.reader();
-      var range =
-          transformer.computeRange(
-              downloadRequest.getStart(), downloadRequest.getEnd(), blob.getSize());
-      if (range.getLeft() != null) {
-        reader.seek(range.getLeft());
-      }
-      if (range.getRight() != null) {
-        reader.limit(range.getRight());
-      }
+      applyRange(reader, downloadRequest, blob);
       InputStream inputStream = Channels.newInputStream(reader);
       return transformer.toDownloadResponse(blob, inputStream);
     } catch (IOException e) {
       throw new SubstrateSdkException("Failed to create input stream for download", e);
+    }
+  }
+
+  /**
+   * Applies the requested byte range to a {@link ReadChannel} before streaming.
+   *
+   * <p>Full-object downloads skip range setup entirely: with no start or end, {@code computeRange}
+   * would return {@code (null, null)} and neither {@code seek} nor {@code limit} would be applied,
+   * so the emitted GCS GET is identical either way. Short-circuiting here avoids a needless
+   * transformer call and keeps the request byte-for-byte the same as a plain full-object read.
+   *
+   * @param reader the channel to position/limit
+   * @param downloadRequest the request carrying the optional start/end offsets
+   * @param blob the resolved blob, used for its size when resolving a suffix range
+   * @throws IOException if positioning the channel fails
+   */
+  private void applyRange(ReadChannel reader, DownloadRequest downloadRequest, Blob blob)
+      throws IOException {
+    boolean hasRange = downloadRequest.getStart() != null || downloadRequest.getEnd() != null;
+    if (!hasRange) {
+      return;
+    }
+    var range =
+        transformer.computeRange(
+            downloadRequest.getStart(), downloadRequest.getEnd(), blob.getSize());
+    if (range.getLeft() != null) {
+      reader.seek(range.getLeft());
+    }
+    if (range.getRight() != null) {
+      reader.limit(range.getRight());
     }
   }
 
@@ -1500,6 +1512,7 @@ public class GcpBlobStore extends AbstractBlobStore {
 
   @Getter
   public static class Builder extends AbstractBlobStore.Builder<GcpBlobStore, Builder> {
+    private static final int DEFAULT_MAX_CONNECTIONS = 50;
 
     private Storage storage;
     private MultipartUploadClient mpuClient;
@@ -1717,10 +1730,10 @@ public class GcpBlobStore extends AbstractBlobStore {
     private static HttpClientConnectionManager buildConnectionManager(Builder builder) {
       PoolingHttpClientConnectionManager connectionManager =
           new PoolingHttpClientConnectionManager();
-      if (builder.getMaxConnections() != null) {
-        connectionManager.setMaxTotal(builder.getMaxConnections());
-        connectionManager.setDefaultMaxPerRoute(builder.getMaxConnections());
-      }
+      int maxConns = builder.getMaxConnections() != null
+          ? builder.getMaxConnections() : DEFAULT_MAX_CONNECTIONS;
+      connectionManager.setMaxTotal(maxConns);
+      connectionManager.setDefaultMaxPerRoute(maxConns);
       return connectionManager;
     }
 

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -106,6 +106,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
@@ -127,6 +128,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -480,9 +482,6 @@ class GcpBlobStoreTest {
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockTransformer.toDownloadResponse(mockBlob)).thenReturn(expectedResponse);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
 
       ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
@@ -493,6 +492,7 @@ class GcpBlobStoreTest {
       assertEquals(expectedResponse, response);
       verify(mockStorage).reader(mockBlobId);
       verify(mockStorage).get(mockBlobId);
+      verify(mockTransformer, never()).computeRange(any(), any(), anyLong());
       verify(mockTransformer).toDownloadResponse(mockBlob);
     }
   }
@@ -508,9 +508,6 @@ class GcpBlobStoreTest {
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockTransformer.toDownloadResponse(mockBlob)).thenReturn(expectedResponse);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
 
       ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
       DownloadResponse response = gcpBlobStore.doDownload(downloadRequest, outputStream);
@@ -579,9 +576,6 @@ class GcpBlobStoreTest {
 
       when(mockTransformer.toBlobId(downloadRequest)).thenReturn(mockBlobId);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       mockedStatic
           .when(() -> ByteStreams.copy(any(InputStream.class), any(OutputStream.class)))
@@ -612,9 +606,6 @@ class GcpBlobStoreTest {
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockTransformer.toDownloadResponse(mockBlob)).thenReturn(expectedResponse);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
 
       ByteArray byteArray = new ByteArray();
 
@@ -640,9 +631,6 @@ class GcpBlobStoreTest {
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockTransformer.toDownloadResponse(mockBlob)).thenReturn(expectedResponse);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
 
       // When
       DownloadResponse response = gcpBlobStore.doDownload(downloadRequest, testFile.toFile());
@@ -665,9 +653,6 @@ class GcpBlobStoreTest {
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockTransformer.toDownloadResponse(mockBlob)).thenReturn(expectedResponse);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
 
       // When
       DownloadResponse response = gcpBlobStore.doDownload(downloadRequest, testFile);
@@ -695,9 +680,6 @@ class GcpBlobStoreTest {
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockTransformer.toDownloadResponse(mockBlob)).thenReturn(expectedResponse);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
 
       // When
       DownloadResponse response = gcpBlobStore.doDownload(downloadRequest, destinationRoot);
@@ -770,9 +752,6 @@ class GcpBlobStoreTest {
       when(mockTransformer.toBlobId(downloadRequest)).thenReturn(mockBlobId);
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
       mockedStatic
           .when(() -> ByteStreams.copy(any(InputStream.class), any(OutputStream.class)))
           .thenThrow(new IOException("Test exception"));
@@ -1850,9 +1829,6 @@ class GcpBlobStoreTest {
       when(mockTransformer.toBlobId(downloadRequest)).thenReturn(mockBlobId);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockBlob.reader()).thenReturn(mockReadChannel);
-      when(mockBlob.getSize()).thenReturn(100L);
-      when(mockTransformer.computeRange(any(), any(), anyLong()))
-          .thenReturn(new ImmutablePair<>(null, null));
       when(mockTransformer.toDownloadResponse(eq(mockBlob), any(InputStream.class)))
           .thenReturn(expectedResponse);
 
@@ -1862,7 +1838,7 @@ class GcpBlobStoreTest {
       verify(mockTransformer).toBlobId(downloadRequest);
       verify(mockStorage).get(mockBlobId);
       verify(mockBlob).reader();
-      verify(mockTransformer).computeRange(null, null, 100L);
+      verify(mockTransformer, never()).computeRange(any(), any(), anyLong());
       verify(mockTransformer).toDownloadResponse(eq(mockBlob), any(InputStream.class));
     }
   }
@@ -2342,6 +2318,36 @@ class GcpBlobStoreTest {
 
     assertNotNull(store);
     assertEquals(GcpConstants.PROVIDER_ID, store.getProviderId());
+  }
+
+  @Test
+  void testBuildConnectionManager_defaultsPoolWhenMaxConnectionsUnset() throws Exception {
+    GcpBlobStore.Builder builder = new GcpBlobStore.Builder();
+
+    PoolingHttpClientConnectionManager connectionManager = invokeBuildConnectionManager(builder);
+
+    assertEquals(50, connectionManager.getMaxTotal());
+    assertEquals(50, connectionManager.getDefaultMaxPerRoute());
+  }
+
+  @Test
+  void testBuildConnectionManager_usesExplicitMaxConnections() throws Exception {
+    GcpBlobStore.Builder builder =
+        (GcpBlobStore.Builder) new GcpBlobStore.Builder().withMaxConnections(123);
+
+    PoolingHttpClientConnectionManager connectionManager = invokeBuildConnectionManager(builder);
+
+    assertEquals(123, connectionManager.getMaxTotal());
+    assertEquals(123, connectionManager.getDefaultMaxPerRoute());
+  }
+
+  private static PoolingHttpClientConnectionManager invokeBuildConnectionManager(
+      GcpBlobStore.Builder builder) throws Exception {
+    Method method =
+        GcpBlobStore.Builder.class.getDeclaredMethod(
+            "buildConnectionManager", GcpBlobStore.Builder.class);
+    method.setAccessible(true);
+    return (PoolingHttpClientConnectionManager) method.invoke(null, builder);
   }
 
   private static UploadResult makeUploadResult(String key, TransferStatus status, Exception ex) {


### PR DESCRIPTION
## Summary

Two wire-compatible optimizations for the GCS blob store.

Full-object downloads no longer call computeRange/seek/limit; extracted the shared range logic into an `applyRange` helper and short-circuit when the request has no range. No change to GCS wire traffic, WireMock fixtures pass as-is.

`buildConnectionManager` now defaults the Apache pool to 50 (maxTotal + perRoute) instead of leaving the library defaults (20/2). Callers using `withMaxConnections()` are unaffected.

`createFrom` and generation-pinned reads are out of scope; they change GCS wire traffic and require re-recording the WireMock fixtures.

Tested: 165/165 unit, 123/0/0 GcpBlobStoreIT replay, 0 checkstyle violations.