### PR TITLE
blobstore: add the total bytes request when transfer logging is disabled

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -632,6 +632,10 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
 
     List<BlobInfo> blobInfos = Collections.synchronizedList(new ArrayList<>());
     AtomicLong totalBytes = new AtomicLong(0L);
+    // Accumulated during listing — sum of object sizes for blobs that pass the filter.
+    // Drives the response's totalBytesTransferred on the listener-off success path so
+    // callers can avoid the listener's heap cost while still seeing a useful byte total.
+    AtomicLong totalBytesRequested = new AtomicLong(0L);
     List<FailedBlobDownload> failures =
         Collections.synchronizedList(new ArrayList<>());
 
@@ -644,7 +648,7 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
             "Failed to create destination directory: " + targetDir, e);
       }
     }, executorService)
-        // Stage 2: async paginated listing; consumer collects matching blobs.
+        // Stage 2: async paginated listing; consumer collects matching blobs and sums sizes.
         .thenCompose(v -> doList(
             ListBlobsRequest.builder().withPrefix(prefix).build(),
             batch -> {
@@ -654,6 +658,7 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
                   continue;
                 }
                 blobInfos.add(blob);
+                totalBytesRequested.addAndGet(blob.getObjectSize());
               }
             }))
         // Stage 3: create all destination directories upfront, then fan out downloads.
@@ -725,9 +730,33 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
         .thenApply(v -> DirectoryDownloadResponse.builder()
             .failedTransfers(new ArrayList<>(failures))
             .totalBytesTransferred(
-                directoryDownloadRequest.isTransferStatusLoggingEnabled()
-                    ? totalBytes.get() : null)
+                resolveDirectoryTotalBytes(
+                    directoryDownloadRequest.isTransferStatusLoggingEnabled(),
+                    failures.isEmpty(),
+                    totalBytes,
+                    totalBytesRequested))
             .build());
+  }
+
+  /**
+   * Picks the value to populate {@code totalBytesTransferred} in the directory response.
+   *
+   * <p>When transfer-status logging is enabled, the per-file listener has accumulated actual
+   * bytes — use that. When disabled, fall back to the requested total (sum of object sizes
+   * for downloads, sum of file sizes for uploads) on full success, or 0 if any per-file
+   * transfer failed. The shared listener has significant heap cost on large directory
+   * operations, so callers leaving it off still get a usable byte total without paying that
+   * cost.
+   */
+  private static Long resolveDirectoryTotalBytes(
+      boolean loggingEnabled,
+      boolean allTransfersSucceeded,
+      AtomicLong totalBytesTransferred,
+      AtomicLong totalBytesRequested) {
+    if (loggingEnabled) {
+      return totalBytesTransferred.get();
+    }
+    return allTransfersSucceeded ? totalBytesRequested.get() : 0L;
   }
 
   private boolean isFolderMarker(BlobInfo blob) {
@@ -756,6 +785,9 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
     Map<String, String> tags = directoryUploadRequest.getTags();
     var objectLock = directoryUploadRequest.getObjectLock();
     AtomicLong totalBytes = new AtomicLong(0L);
+    // Sum of source-file sizes from the stage-1 stat pass. Drives the response's
+    // totalBytesTransferred on the listener-off success path; see resolveDirectoryTotalBytes.
+    AtomicLong totalBytesRequested = new AtomicLong(0L);
     List<FailedBlobUpload> failures =
         Collections.synchronizedList(new ArrayList<>());
 
@@ -766,6 +798,8 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
           // Compute file sizes upfront so Stage 2 avoids I/O on completion threads.
           Map<Path, Long> fileSizes = paths.stream()
               .collect(Collectors.toMap(p -> p, p -> p.toFile().length()));
+          totalBytesRequested.addAndGet(
+              fileSizes.values().stream().mapToLong(Long::longValue).sum());
           return fileSizes;
         },
         executorService)
@@ -824,8 +858,11 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
         .thenApply(v -> DirectoryUploadResponse.builder()
             .failedTransfers(new ArrayList<>(failures))
             .totalBytesTransferred(
-                directoryUploadRequest.isTransferStatusLoggingEnabled()
-                    ? totalBytes.get() : null)
+                resolveDirectoryTotalBytes(
+                    directoryUploadRequest.isTransferStatusLoggingEnabled(),
+                    failures.isEmpty(),
+                    totalBytes,
+                    totalBytesRequested))
             .build());
   }
 

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -756,7 +756,9 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
     if (loggingEnabled) {
       return totalBytesTransferred.get();
     }
-    return allTransfersSucceeded ? totalBytesRequested.get() : 0L;
+    // Partial failure → null (rather than 0L) so callers can't confuse it with an empty
+    // directory that succeeded. failedTransfers carries the actual error detail.
+    return allTransfersSucceeded ? totalBytesRequested.get() : null;
   }
 
   private boolean isFolderMarker(BlobInfo blob) {

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/OssLoggingTransferListener.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/OssLoggingTransferListener.java
@@ -88,7 +88,7 @@ final class OssLoggingTransferListener implements ProgressListener {
   public void onFinish() {
     if (loggingEnabled) {
       Duration elapsed = Duration.between(startTime, Instant.now());
-      logger.info(
+      logger.debug(
           "substrate SDK transferListener: direction={}, key={}, fileBytes={},"
               + " directoryCumulativeBytes={}, elapsed={}. transfer complete.",
           direction, key, bytesThisFile, cumulativeTotal.get(), elapsed);

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -1257,9 +1257,9 @@ public class AliAsyncBlobStoreTest {
 
     assertNotNull(response);
     assertEquals(1, response.getFailedTransfers().size());
-    // Listener off + at least one failed transfer → report 0 so callers don't read the
-    // requested total as if everything actually moved. Inspect failedTransfers for detail.
-    assertEquals(0L, response.getTotalBytesTransferred());
+    // Listener off + at least one failed transfer → null so callers can't confuse it with an
+    // empty directory that succeeded. failedTransfers carries the actual error detail.
+    assertNull(response.getTotalBytesTransferred());
   }
 
   @Test
@@ -1571,8 +1571,9 @@ public class AliAsyncBlobStoreTest {
 
     assertNotNull(response);
     assertEquals(1, response.getFailedTransfers().size());
-    // Listener off + at least one failed transfer → 0; failedTransfers carries the detail.
-    assertEquals(0L, response.getTotalBytesTransferred());
+    // Listener off + at least one failed transfer → null so callers can't confuse it with an
+    // empty directory that succeeded. failedTransfers carries the actual error detail.
+    assertNull(response.getTotalBytesTransferred());
   }
 
   @Test

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -1196,15 +1196,15 @@ public class AliAsyncBlobStoreTest {
   }
 
   @Test
-  void testUploadDirectoryLoggingDisabledReturnsNullTotal(
+  void testUploadDirectoryLoggingDisabledReturnsRequestedBytesOnSuccess(
       @TempDir Path tempDir) throws Exception {
-    Files.writeString(tempDir.resolve("a.txt"), "alpha");
+    Files.writeString(tempDir.resolve("a.txt"), "alpha"); // 5 bytes
 
     PutObjectResult mockResult = mock(PutObjectResult.class);
     when(mockResult.versionId()).thenReturn(null);
     when(mockResult.eTag()).thenReturn("\"etag\"");
     // No listener should be attached when logging is disabled; assert that and
-    // ensure we never drive progress so the counter stays at zero / null.
+    // ensure we never drive progress so the listener counter stays at zero.
     when(mockAsyncClient.putObjectAsync(
         any(PutObjectRequest.class), any(OperationOptions.class)))
         .thenAnswer(invocation -> {
@@ -1224,7 +1224,42 @@ public class AliAsyncBlobStoreTest {
 
     assertNotNull(response);
     assertEquals(0, response.getFailedTransfers().size());
-    assertNull(response.getTotalBytesTransferred());
+    // Listener off + zero failures → fall back to sum of source-file sizes.
+    assertEquals(5L, response.getTotalBytesTransferred());
+  }
+
+  @Test
+  void testUploadDirectoryLoggingDisabledReturnsZeroOnPartialFailure(
+      @TempDir Path tempDir) throws Exception {
+    Files.writeString(tempDir.resolve("ok.txt"), "alpha"); // 5 bytes
+    Files.writeString(tempDir.resolve("bad.txt"), "beta-bytes"); // 10 bytes
+
+    PutObjectResult mockResult = mock(PutObjectResult.class);
+    when(mockResult.versionId()).thenReturn(null);
+    when(mockResult.eTag()).thenReturn("\"etag\"");
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenAnswer(invocation -> {
+          PutObjectRequest req = invocation.getArgument(0);
+          if (req.key().endsWith("bad.txt")) {
+            return CompletableFuture.failedFuture(new RuntimeException("upload boom"));
+          }
+          return CompletableFuture.completedFuture(mockResult);
+        });
+
+    DirectoryUploadRequest request = DirectoryUploadRequest.builder()
+        .localSourceDirectory(tempDir.toString())
+        .prefix("pfx")
+        .includeSubFolders(true)
+        .build();
+    DirectoryUploadResponse response =
+        store.uploadDirectory(request).get();
+
+    assertNotNull(response);
+    assertEquals(1, response.getFailedTransfers().size());
+    // Listener off + at least one failed transfer → report 0 so callers don't read the
+    // requested total as if everything actually moved. Inspect failedTransfers for detail.
+    assertEquals(0L, response.getTotalBytesTransferred());
   }
 
   @Test
@@ -1456,7 +1491,7 @@ public class AliAsyncBlobStoreTest {
   }
 
   @Test
-  void testDownloadDirectoryLoggingDisabledReturnsNullTotal(
+  void testDownloadDirectoryLoggingDisabledReturnsRequestedBytesOnSuccess(
       @TempDir Path tempDir) throws Exception {
     ObjectSummary obj = mock(ObjectSummary.class);
     when(obj.key()).thenReturn("log/data.bin");
@@ -1479,7 +1514,7 @@ public class AliAsyncBlobStoreTest {
         any(GetObjectRequest.class), any(OperationOptions.class)))
         .thenReturn(CompletableFuture.completedFuture(getResult));
 
-    // transferStatusLoggingEnabled defaults to false — no listener attached, null total.
+    // transferStatusLoggingEnabled defaults to false — no per-file listener attached.
     DirectoryDownloadRequest request = DirectoryDownloadRequest.builder()
         .prefixToDownload("log")
         .localDestinationDirectory(tempDir.toString())
@@ -1489,9 +1524,55 @@ public class AliAsyncBlobStoreTest {
 
     assertNotNull(response);
     assertEquals(0, response.getFailedTransfers().size());
-    assertNull(response.getTotalBytesTransferred());
+    // Listener off + zero failures → fall back to sum of object sizes seen during listing.
+    assertEquals(2048L, response.getTotalBytesTransferred());
     // The file is still downloaded correctly even with no listener.
     assertTrue(Files.exists(tempDir.resolve("data.bin")));
+  }
+
+  @Test
+  void testDownloadDirectoryLoggingDisabledReturnsZeroOnPartialFailure(
+      @TempDir Path tempDir) throws Exception {
+    ObjectSummary okObj = mock(ObjectSummary.class);
+    when(okObj.key()).thenReturn("log/ok.bin");
+    when(okObj.size()).thenReturn(100L);
+    ObjectSummary badObj = mock(ObjectSummary.class);
+    when(badObj.key()).thenReturn("log/bad.bin");
+    when(badObj.size()).thenReturn(200L);
+
+    ListObjectsV2Result listResult = mock(ListObjectsV2Result.class);
+    when(listResult.contents()).thenReturn(List.of(okObj, badObj));
+    when(listResult.commonPrefixes()).thenReturn(null);
+    when(listResult.isTruncated()).thenReturn(false);
+    when(mockAsyncClient.listObjectsV2Async(
+        any(ListObjectsV2Request.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(listResult));
+
+    when(mockAsyncClient.getObjectAsync(
+        any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenAnswer(invocation -> {
+          GetObjectRequest req = invocation.getArgument(0);
+          if (req.key().endsWith("bad.bin")) {
+            return CompletableFuture.failedFuture(new RuntimeException("download boom"));
+          }
+          GetObjectResult result = mock(GetObjectResult.class);
+          when(result.body()).thenReturn(new ByteArrayInputStream(new byte[100]));
+          when(result.contentLength()).thenReturn(100L);
+          when(result.eTag()).thenReturn("\"e\"");
+          return CompletableFuture.completedFuture(result);
+        });
+
+    DirectoryDownloadRequest request = DirectoryDownloadRequest.builder()
+        .prefixToDownload("log")
+        .localDestinationDirectory(tempDir.toString())
+        .build();
+    DirectoryDownloadResponse response =
+        store.downloadDirectory(request).get();
+
+    assertNotNull(response);
+    assertEquals(1, response.getFailedTransfers().size());
+    // Listener off + at least one failed transfer → 0; failedTransfers carries the detail.
+    assertEquals(0L, response.getTotalBytesTransferred());
   }
 
   @Test

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/OssLoggingTransferListenerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/OssLoggingTransferListenerTest.java
@@ -124,9 +124,11 @@ class OssLoggingTransferListenerTest {
     listener.onProgress(100L, 100L, 200L);
     verify(logger).trace(anyString(), any(), any(), any(), any(), any());
 
-    // onFinish -> INFO (direction, key, fileBytes, directoryCumulativeBytes, elapsed)
+    // onFinish -> DEBUG (direction, key, fileBytes, directoryCumulativeBytes, elapsed).
+    // Per-file completion is high-volume on large directories, so it is emitted at DEBUG
+    // to avoid swamping production log appender queues.
     listener.onFinish();
-    verify(logger).info(anyString(), any(), any(), any(), any(), any());
+    verify(logger).debug(anyString(), any(), any(), any(), any(), any());
 
     // transferFailed -> ERROR (direction, key, fileBytes, directoryCumulativeBytes, elapsed, ex)
     RuntimeException ex = new RuntimeException("boom");
@@ -178,10 +180,10 @@ class OssLoggingTransferListenerTest {
     // Directory cumulative = 500 (pre-existing) + 300 (this file) = 800.
     assertEquals(800L, cumulative.get());
 
-    // The INFO completion log records fileBytes=300 and directoryCumulativeBytes=800 as
+    // The DEBUG completion log records fileBytes=300 and directoryCumulativeBytes=800 as
     // distinct positional args, so operators don't misread the running total as per-file.
     ArgumentCaptor<Object> args = ArgumentCaptor.forClass(Object.class);
-    verify(logger).info(anyString(), args.capture(), args.capture(),
+    verify(logger).debug(anyString(), args.capture(), args.capture(),
         args.capture(), args.capture(), args.capture());
     List<Object> captured = args.getAllValues();
     // positional: direction, key, fileBytes, directoryCumulativeBytes, elapsed

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -35,7 +35,9 @@ import com.salesforce.multicloudj.common.exceptions.FailedPreconditionException;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.retries.RetryConfig;
 import com.salesforce.multicloudj.common.util.HexUtil;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -51,6 +53,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.awscore.presigner.PresignedRequest;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.retries.StandardRetryStrategy;
@@ -259,7 +262,9 @@ public class AwsTransformer {
     return builder.build();
   }
 
-  /** Converts SDK RetentionMode to provider SDK ObjectLockMode */
+  /**
+   * Converts SDK RetentionMode to provider SDK ObjectLockMode
+   */
   private ObjectLockMode toAwsObjectLockMode(RetentionMode mode) {
     switch (mode) {
       case GOVERNANCE:
@@ -284,7 +289,9 @@ public class AwsTransformer {
     }
   }
 
-  /** Converts provider SDK ObjectLockMode to SDK RetentionMode */
+  /**
+   * Converts provider SDK ObjectLockMode to SDK RetentionMode
+   */
   private RetentionMode toDriverRetentionMode(ObjectLockMode awsMode) {
     if (awsMode == null) {
       return null;
@@ -299,7 +306,9 @@ public class AwsTransformer {
     }
   }
 
-  /** Converts provider SDK ObjectLockRetentionMode to SDK RetentionMode */
+  /**
+   * Converts provider SDK ObjectLockRetentionMode to SDK RetentionMode
+   */
   private RetentionMode toDriverRetentionMode(ObjectLockRetentionMode awsMode) {
     if (awsMode == null) {
       return null;
@@ -327,7 +336,9 @@ public class AwsTransformer {
     return builder.build();
   }
 
-  /** Builds a {@link DownloadFileRequest} for use with {@code S3TransferManager.downloadFile}. */
+  /**
+   * Builds a {@link DownloadFileRequest} for use with {@code S3TransferManager.downloadFile}.
+   */
   public DownloadFileRequest toRequest(DownloadRequest request, Path destinationPath) {
     return DownloadFileRequest.builder()
         .getObjectRequest(toRequest(request))
@@ -658,7 +669,7 @@ public class AwsTransformer {
   }
 
   public PresignedUrlResponse toPresignedUrlResponse(
-      software.amazon.awssdk.awscore.presigner.PresignedRequest presigned) {
+      PresignedRequest presigned) {
     Map<String, String> flatHeaders = new LinkedHashMap<>();
     presigned.signedHeaders().forEach((k, values) ->
         flatHeaders.put(k, String.join(",", values)));
@@ -669,46 +680,63 @@ public class AwsTransformer {
         .build();
   }
 
-  public DownloadDirectoryRequest toDownloadDirectoryRequest(DirectoryDownloadRequest request) {
-    var downloadDirectoryRequestBuilder =
+  /**
+   * Builds the S3 Transfer Manager download-directory request. When non-null counters are
+   * supplied, {@code totalBytesRequested} is summed inside the filter (post-exclusion) and
+   * {@code totalBytesTransferred} drives a per-file logging listener — but only if
+   * {@code transferStatusLoggingEnabled} is set on the request. The two counters together let
+   * the caller report bytes-transferred without paying the listener's heap cost: on success it
+   * can fall back to the requested total.
+   */
+  public DownloadDirectoryRequest toDownloadDirectoryRequest(
+      DirectoryDownloadRequest request,
+      AtomicLong totalBytesTransferred,
+      AtomicLong totalBytesRequested) {
+    DownloadDirectoryRequest.Builder builder =
         DownloadDirectoryRequest.builder()
             .bucket(getBucket())
             .destination(Paths.get(request.getLocalDestinationDirectory()));
 
     // Download every blob that starts with this prefix
     if (StringUtils.isNotEmpty(request.getPrefixToDownload())) {
-      downloadDirectoryRequestBuilder.listObjectsV2RequestTransformer(
-          builder -> builder.prefix(request.getPrefixToDownload()));
+      builder.listObjectsV2RequestTransformer(
+          b -> b.prefix(request.getPrefixToDownload()));
     }
 
-    // If we have prefixes to exclude from the download, then add in a filter here
-    if (request.getPrefixesToExclude() != null && !request.getPrefixesToExclude().isEmpty()) {
-      downloadDirectoryRequestBuilder.filter(
-          getPrefixExclusionsFilter(request.getPrefixesToExclude()));
-    }
-    return downloadDirectoryRequestBuilder.build();
-  }
+    builder.filter(getPrefixExclusionsFilter(
+        request.getPrefixesToExclude(),
+        totalBytesRequested));
 
-  public DownloadDirectoryRequest toDownloadDirectoryRequest(
-      DirectoryDownloadRequest request, AtomicLong totalBytesTransferred) {
-    DownloadDirectoryRequest.Builder downloadDirectoryRequestBuilder =
-        toDownloadDirectoryRequest(request).toBuilder();
+
     if (request.isTransferStatusLoggingEnabled()) {
       S3LoggingTransferListener transferListener =
           S3LoggingTransferListener.create(totalBytesTransferred);
-      downloadDirectoryRequestBuilder.downloadFileRequestTransformer(
-          builder -> builder.addTransferListener(transferListener));
+      builder.downloadFileRequestTransformer(b -> b.addTransferListener(transferListener));
     }
-    return downloadDirectoryRequestBuilder.build();
+    return builder.build();
   }
 
-  // Return false if we want to exclude this blob from the download
+  // Return false if we want to exclude this blob from the download.
   protected DownloadFilter getPrefixExclusionsFilter(List<String> prefixesToExclude) {
+    return getPrefixExclusionsFilter(prefixesToExclude, null);
+  }
+
+  /**
+   * Same filter contract as the single-arg overload — return {@code false} to exclude. When
+   * {@code totalBytesRequested} is non-null, each retained object's size is added to it, so
+   * the count reflects only objects S3 Transfer Manager will actually download.
+   */
+  protected DownloadFilter getPrefixExclusionsFilter(
+      List<String> prefixesToExclude, AtomicLong totalBytesRequested) {
+    List<String> excludes = prefixesToExclude != null ? prefixesToExclude : List.of();
     return s3Object -> {
-      for (String prefixToExclude : prefixesToExclude) {
+      for (String prefixToExclude : excludes) {
         if (s3Object.key().startsWith(prefixToExclude)) {
           return false;
         }
+      }
+      if (totalBytesRequested != null) {
+        totalBytesRequested.addAndGet(s3Object.size());
       }
       return true;
     };
@@ -731,46 +759,21 @@ public class AwsTransformer {
   }
 
   public UploadDirectoryRequest toUploadDirectoryRequest(DirectoryUploadRequest request) {
-    UploadDirectoryRequest.Builder builder =
-        UploadDirectoryRequest.builder()
-            .bucket(getBucket())
-            .source(Paths.get(request.getLocalSourceDirectory()))
-            .maxDepth(request.isIncludeSubFolders() ? Integer.MAX_VALUE : 1)
-            .followSymbolicLinks(request.isFollowSymbolicLinks())
-            .s3Prefix(request.getPrefix());
-
-    boolean hasTags = request.getTags() != null && !request.getTags().isEmpty();
-    boolean hasObjectLock = request.getObjectLock() != null;
-
-    // Merge tags / object lock into the existing PutObjectRequest per file;
-    // putObjectRequest(Consumer) would replace it and drop bucket/key.
-    if (hasTags || hasObjectLock) {
-      List<Tag> tagSet =
-          hasTags
-              ? request.getTags().entrySet().stream()
-                  .map(e -> Tag.builder().key(e.getKey()).value(e.getValue()).build())
-                  .collect(Collectors.toList())
-              : null;
-      ObjectLockConfiguration lockConfig = request.getObjectLock();
-      builder.uploadFileRequestTransformer(
-          fileRequestBuilder -> {
-            PutObjectRequest existing = fileRequestBuilder.build().putObjectRequest();
-            PutObjectRequest.Builder putBuilder = existing.toBuilder();
-            if (hasTags) {
-              putBuilder.tagging(Tagging.builder().tagSet(tagSet).build());
-            }
-            if (hasObjectLock) {
-              applyObjectLockToPutObjectBuilder(putBuilder, lockConfig);
-            }
-            fileRequestBuilder.putObjectRequest(putBuilder.build());
-          });
-    }
-
-    return builder.build();
+    return toUploadDirectoryRequest(request, null, null);
   }
 
+  /**
+   * Builds the S3 Transfer Manager upload-directory request. When non-null counters are
+   * supplied, the per-file transformer stats each source into {@code totalBytesRequested} and
+   * (if {@code transferStatusLoggingEnabled}) attaches a logging listener that drives
+   * {@code totalBytesTransferred}. Together they let the caller report bytes-transferred
+   * without paying the listener's heap cost: on success it can fall back to the requested
+   * total.
+   */
   public UploadDirectoryRequest toUploadDirectoryRequest(
-      DirectoryUploadRequest request, AtomicLong totalBytesTransferred) {
+      DirectoryUploadRequest request,
+      AtomicLong totalBytesTransferred,
+      AtomicLong totalBytesRequested) {
     UploadDirectoryRequest.Builder builder =
         UploadDirectoryRequest.builder()
             .bucket(getBucket())
@@ -778,23 +781,36 @@ public class AwsTransformer {
             .maxDepth(request.isIncludeSubFolders() ? Integer.MAX_VALUE : 1)
             .followSymbolicLinks(request.isFollowSymbolicLinks())
             .s3Prefix(request.getPrefix());
+
     boolean hasTags = request.getTags() != null && !request.getTags().isEmpty();
     boolean hasObjectLock = request.getObjectLock() != null;
-    boolean transferStatusLoggingEnabled = request.isTransferStatusLoggingEnabled();
-    if (hasTags || hasObjectLock || transferStatusLoggingEnabled) {
-      S3LoggingTransferListener transferListener =
-          transferStatusLoggingEnabled
-              ? S3LoggingTransferListener.create(totalBytesTransferred)
-              : null;
-      List<Tag> tagSet =
-          hasTags
-              ? request.getTags().entrySet().stream()
-                  .map(e -> Tag.builder().key(e.getKey()).value(e.getValue()).build())
-                  .collect(Collectors.toList())
-              : null;
-      ObjectLockConfiguration lockConfig = request.getObjectLock();
-      builder.uploadFileRequestTransformer(
-          fileRequestBuilder -> {
+    boolean transferStatusLoggingEnabled =
+        request.isTransferStatusLoggingEnabled() && totalBytesTransferred != null;
+    boolean countRequested = totalBytesRequested != null;
+
+    if (!hasTags && !hasObjectLock && !transferStatusLoggingEnabled && !countRequested) {
+      return builder.build();
+    }
+
+    List<Tag> tagSet =
+        hasTags
+            ? request.getTags().entrySet().stream()
+              .map(e -> Tag.builder().key(e.getKey()).value(e.getValue()).build())
+              .collect(Collectors.toList())
+            : null;
+    ObjectLockConfiguration lockConfig = request.getObjectLock();
+    S3LoggingTransferListener transferListener =
+        transferStatusLoggingEnabled
+            ? S3LoggingTransferListener.create(totalBytesTransferred)
+            : null;
+    // Merge tags / object lock into the existing PutObjectRequest per file;
+    // putObjectRequest(Consumer) would replace it and drop bucket/key.
+    // S3 Transfer Manager doesn't expose a directory-listing filter for uploads, so this
+    // per-file hook is also where we stat each source's planned size into
+    // totalBytesRequested.
+    builder.uploadFileRequestTransformer(
+        fileRequestBuilder -> {
+          if (hasTags || hasObjectLock) {
             PutObjectRequest existing = fileRequestBuilder.build().putObjectRequest();
             PutObjectRequest.Builder putBuilder = existing.toBuilder();
             if (hasTags) {
@@ -804,11 +820,25 @@ public class AwsTransformer {
               applyObjectLockToPutObjectBuilder(putBuilder, lockConfig);
             }
             fileRequestBuilder.putObjectRequest(putBuilder.build());
-            if (transferListener != null) {
-              fileRequestBuilder.addTransferListener(transferListener);
+          }
+          if (transferListener != null) {
+            fileRequestBuilder.addTransferListener(transferListener);
+          }
+          if (countRequested) {
+            // Best-effort stat. If the file vanished between filesystem walk and upload start,
+            // skip the count — the upload itself will fail and surface via failedTransfers.
+            Path source = fileRequestBuilder.build().source();
+            if (source != null) {
+              try {
+                totalBytesRequested.addAndGet(Files.size(source));
+              } catch (IOException ignored) {
+                // intentional: undercount by one file is acceptable; the failed upload tells
+                // the caller something went wrong, and partial-failure already maps to 0
+                // transferred.
+              }
             }
-          });
-    }
+          }
+        });
     return builder.build();
   }
 
@@ -967,7 +997,9 @@ public class AwsTransformer {
     return strategyBuilder.build();
   }
 
-  /** Creates a GetObjectRetentionRequest for retrieving object retention */
+  /**
+   * Creates a GetObjectRetentionRequest for retrieving object retention
+   */
   public GetObjectRetentionRequest toGetObjectRetentionRequest(String key, String versionId) {
     return GetObjectRetentionRequest.builder()
         .bucket(getBucket())
@@ -976,7 +1008,9 @@ public class AwsTransformer {
         .build();
   }
 
-  /** Creates a GetObjectLegalHoldRequest for retrieving legal hold status */
+  /**
+   * Creates a GetObjectLegalHoldRequest for retrieving legal hold status
+   */
   public GetObjectLegalHoldRequest toGetObjectLegalHoldRequest(String key, String versionId) {
     return GetObjectLegalHoldRequest.builder()
         .bucket(getBucket())
@@ -985,7 +1019,9 @@ public class AwsTransformer {
         .build();
   }
 
-  /** Creates a PutObjectRetentionRequest for updating object retention */
+  /**
+   * Creates a PutObjectRetentionRequest for updating object retention
+   */
   public PutObjectRetentionRequest toPutObjectRetentionRequest(
       String key,
       String versionId,
@@ -1022,7 +1058,9 @@ public class AwsTransformer {
     return builder.build();
   }
 
-  /** Creates a PutObjectLegalHoldRequest for updating legal hold status */
+  /**
+   * Creates a PutObjectLegalHoldRequest for updating legal hold status
+   */
   public PutObjectLegalHoldRequest toPutObjectLegalHoldRequest(
       String key, String versionId, boolean legalHold) {
     return PutObjectLegalHoldRequest.builder()
@@ -1036,7 +1074,9 @@ public class AwsTransformer {
         .build();
   }
 
-  /** Converts GetObjectRetentionResponse and GetObjectLegalHoldResponse to ObjectLockInfo */
+  /**
+   * Converts GetObjectRetentionResponse and GetObjectLegalHoldResponse to ObjectLockInfo
+   */
   public ObjectLockInfo toObjectLockInfo(
       GetObjectRetentionResponse retentionResponse, GetObjectLegalHoldResponse legalHoldResponse) {
     if (retentionResponse == null || retentionResponse.retention() == null) {

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -758,10 +758,6 @@ public class AwsTransformer {
         .build();
   }
 
-  public UploadDirectoryRequest toUploadDirectoryRequest(DirectoryUploadRequest request) {
-    return toUploadDirectoryRequest(request, null, null);
-  }
-
   /**
    * Builds the S3 Transfer Manager upload-directory request. When non-null counters are
    * supplied, the per-file transformer stats each source into {@code totalBytesRequested} and

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -821,16 +821,17 @@ public class AwsTransformer {
             fileRequestBuilder.addTransferListener(transferListener);
           }
           if (countRequested) {
-            // Best-effort stat. If the file vanished between filesystem walk and upload start,
-            // skip the count — the upload itself will fail and surface via failedTransfers.
+            // Best-effort stat, evaluated independently per file. A file that throws here is
+            // also a file the SDK can't upload, so it'll appear in failedTransfers and the
+            // response will already report 0 via resolveDirectoryTotalBytes — the under-counted
+            // requested total is never the value handed back to the caller in that case.
             Path source = fileRequestBuilder.build().source();
             if (source != null) {
               try {
                 totalBytesRequested.addAndGet(Files.size(source));
               } catch (IOException ignored) {
-                // intentional: undercount by one file is acceptable; the failed upload tells
-                // the caller something went wrong, and partial-failure already maps to 0
-                // transferred.
+                // Skip this file's contribution; other files in the same directory op are
+                // unaffected and still get counted.
               }
             }
           }

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -703,12 +703,21 @@ public class AwsTransformer {
           b -> b.prefix(request.getPrefixToDownload()));
     }
 
-    builder.filter(getPrefixExclusionsFilter(
-        request.getPrefixesToExclude(),
-        totalBytesRequested));
+    // Only install a filter when we actually have work for it (exclusion or byte counting).
+    // S3 Transfer Manager may take a fast path internally when no filter is set, and there's
+    // no point allocating a pass-through lambda that returns true for every object.
+    boolean hasExclusions =
+        request.getPrefixesToExclude() != null && !request.getPrefixesToExclude().isEmpty();
+    if (hasExclusions || totalBytesRequested != null) {
+      builder.filter(getPrefixExclusionsFilter(
+          request.getPrefixesToExclude(),
+          totalBytesRequested));
+    }
 
-
-    if (request.isTransferStatusLoggingEnabled()) {
+    // Symmetric to toUploadDirectoryRequest: only attach the listener when the caller
+    // supplied a counter to drive — a null counter signals "don't bother counting", and
+    // attaching the listener anyway would NPE inside its constructor.
+    if (request.isTransferStatusLoggingEnabled() && totalBytesTransferred != null) {
       S3LoggingTransferListener transferListener =
           S3LoggingTransferListener.create(totalBytesTransferred);
       builder.downloadFileRequestTransformer(b -> b.addTransferListener(transferListener));
@@ -725,6 +734,11 @@ public class AwsTransformer {
    * Same filter contract as the single-arg overload — return {@code false} to exclude. When
    * {@code totalBytesRequested} is non-null, each retained object's size is added to it, so
    * the count reflects only objects S3 Transfer Manager will actually download.
+   *
+   * <p>Counting relies on the SDK calling this filter exactly once per listed object during
+   * the listing phase — the {@link DownloadFilter} contract today. A future SDK change that
+   * re-invoked the filter (e.g. on internal page retry) would over-count, but the alternative
+   * of deduplicating by key would re-introduce the heap pressure this PR exists to avoid.
    */
   protected DownloadFilter getPrefixExclusionsFilter(
       List<String> prefixesToExclude, AtomicLong totalBytesRequested) {
@@ -803,7 +817,9 @@ public class AwsTransformer {
     // putObjectRequest(Consumer) would replace it and drop bucket/key.
     // S3 Transfer Manager doesn't expose a directory-listing filter for uploads, so this
     // per-file hook is also where we stat each source's planned size into
-    // totalBytesRequested.
+    // totalBytesRequested. This relies on the SDK invoking the transformer exactly once per
+    // file (its current contract). A future SDK change that re-invoked on retry could
+    // over-count; the same trade-off applies as the download filter above.
     builder.uploadFileRequestTransformer(
         fileRequestBuilder -> {
           if (hasTags || hasObjectLock) {

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStore.java
@@ -438,8 +438,10 @@ public class AwsAsyncBlobStore extends AbstractAsyncBlobStore implements AwsSdkS
   protected CompletableFuture<DirectoryDownloadResponse> doDownloadDirectory(
       DirectoryDownloadRequest directoryDownloadRequest) {
     AtomicLong totalBytesTransferred = new AtomicLong(0L);
+    AtomicLong totalBytesRequested = new AtomicLong(0L);
     DownloadDirectoryRequest request =
-        transformer.toDownloadDirectoryRequest(directoryDownloadRequest, totalBytesTransferred);
+        transformer.toDownloadDirectoryRequest(
+            directoryDownloadRequest, totalBytesTransferred, totalBytesRequested);
     return transferManager
         .downloadDirectory(request)
         .completionFuture()
@@ -447,17 +449,21 @@ public class AwsAsyncBlobStore extends AbstractAsyncBlobStore implements AwsSdkS
             completed ->
                 transformer.toDirectoryDownloadResponse(
                     completed,
-                    directoryDownloadRequest.isTransferStatusLoggingEnabled()
-                        ? totalBytesTransferred.get()
-                        : null));
+                    resolveDirectoryTotalBytes(
+                        directoryDownloadRequest.isTransferStatusLoggingEnabled(),
+                        completed.failedTransfers().isEmpty(),
+                        totalBytesTransferred,
+                        totalBytesRequested)));
   }
 
   @Override
   protected CompletableFuture<DirectoryUploadResponse> doUploadDirectory(
       DirectoryUploadRequest directoryUploadRequest) {
     AtomicLong totalBytesTransferred = new AtomicLong(0L);
+    AtomicLong totalBytesRequested = new AtomicLong(0L);
     UploadDirectoryRequest uploadDirectoryRequest =
-        transformer.toUploadDirectoryRequest(directoryUploadRequest, totalBytesTransferred);
+        transformer.toUploadDirectoryRequest(
+            directoryUploadRequest, totalBytesTransferred, totalBytesRequested);
     return transferManager
         .uploadDirectory(uploadDirectoryRequest)
         .completionFuture()
@@ -465,9 +471,31 @@ public class AwsAsyncBlobStore extends AbstractAsyncBlobStore implements AwsSdkS
             completed ->
                 transformer.toDirectoryUploadResponse(
                     completed,
-                    directoryUploadRequest.isTransferStatusLoggingEnabled()
-                        ? totalBytesTransferred.get()
-                        : null));
+                    resolveDirectoryTotalBytes(
+                        directoryUploadRequest.isTransferStatusLoggingEnabled(),
+                        completed.failedTransfers().isEmpty(),
+                        totalBytesTransferred,
+                        totalBytesRequested)));
+  }
+
+  /**
+   * Picks the value to populate {@code totalBytesTransferred} in the directory response.
+   *
+   * <p>When transfer-status logging is enabled, the per-file listener has accumulated actual
+   * bytes — use that. When disabled, fall back to the requested total (sum of object sizes
+   * counted in the filter / per-file size stat) on full success, or 0 if any per-file transfer
+   * failed. Attaching a listener has significant heap cost on large directory operations, so
+   * callers leaving it off still get a usable byte total without paying that cost.
+   */
+  private static Long resolveDirectoryTotalBytes(
+      boolean loggingEnabled,
+      boolean allTransfersSucceeded,
+      AtomicLong totalBytesTransferred,
+      AtomicLong totalBytesRequested) {
+    if (loggingEnabled) {
+      return totalBytesTransferred.get();
+    }
+    return allTransfersSucceeded ? totalBytesRequested.get() : 0L;
   }
 
   @Override

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStore.java
@@ -483,9 +483,10 @@ public class AwsAsyncBlobStore extends AbstractAsyncBlobStore implements AwsSdkS
    *
    * <p>When transfer-status logging is enabled, the per-file listener has accumulated actual
    * bytes — use that. When disabled, fall back to the requested total (sum of object sizes
-   * counted in the filter / per-file size stat) on full success, or 0 if any per-file transfer
-   * failed. Attaching a listener has significant heap cost on large directory operations, so
-   * callers leaving it off still get a usable byte total without paying that cost.
+   * counted in the filter / per-file size stat) on full success, or {@code null} on partial
+   * failure so callers can't confuse it with an empty directory that succeeded. Attaching a
+   * listener has significant heap cost on large directory operations, so callers leaving it
+   * off still get a usable byte total without paying that cost.
    */
   private static Long resolveDirectoryTotalBytes(
       boolean loggingEnabled,
@@ -495,7 +496,7 @@ public class AwsAsyncBlobStore extends AbstractAsyncBlobStore implements AwsSdkS
     if (loggingEnabled) {
       return totalBytesTransferred.get();
     }
-    return allTransfersSucceeded ? totalBytesRequested.get() : 0L;
+    return allTransfersSucceeded ? totalBytesRequested.get() : null;
   }
 
   @Override

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/async/S3LoggingTransferListener.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/async/S3LoggingTransferListener.java
@@ -50,7 +50,7 @@ public final class S3LoggingTransferListener implements TransferListener {
     long oldValue = totalBytesTransferred.getAndAdd(transferred);
     Duration transferTime =
         startTime == null ? Duration.ZERO : Duration.between(startTime, Instant.now());
-    logger.info(
+    logger.debug(
         "substrate SDK transferListener: oldValue={}, newValue={},"
             + " transferTime={}, progressSnapshot={}. transfer complete.",
         oldValue,

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
@@ -793,7 +793,7 @@ public class AwsTransformerTest {
             .build();
 
     DownloadDirectoryRequest downloadDirectoryRequest =
-        transformer.toDownloadDirectoryRequest(request);
+        transformer.toDownloadDirectoryRequest(request, null, null);
 
     assertEquals(BUCKET, downloadDirectoryRequest.bucket());
     assertEquals(destination, downloadDirectoryRequest.destination().toString());

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
@@ -838,7 +838,8 @@ public class AwsTransformerTest {
             .prefix("/files")
             .includeSubFolders(true)
             .build();
-    UploadDirectoryRequest request = transformer.toUploadDirectoryRequest(directoryUploadRequest);
+    UploadDirectoryRequest request =
+        transformer.toUploadDirectoryRequest(directoryUploadRequest, null, null);
     assertEquals(BUCKET, request.bucket());
     assertTrue(request.maxDepth().isPresent());
     assertEquals(Integer.MAX_VALUE, request.maxDepth().getAsInt());
@@ -852,7 +853,7 @@ public class AwsTransformerTest {
             .prefix("/files")
             .includeSubFolders(false)
             .build();
-    request = transformer.toUploadDirectoryRequest(directoryUploadRequest);
+    request = transformer.toUploadDirectoryRequest(directoryUploadRequest, null, null);
     assertTrue(request.maxDepth().isPresent());
   }
 
@@ -865,7 +866,8 @@ public class AwsTransformerTest {
             .includeSubFolders(true)
             .followSymbolicLinks(true)
             .build();
-    UploadDirectoryRequest request = transformer.toUploadDirectoryRequest(directoryUploadRequest);
+    UploadDirectoryRequest request =
+        transformer.toUploadDirectoryRequest(directoryUploadRequest, null, null);
     assertEquals(Optional.of(true), request.followSymbolicLinks());
 
     directoryUploadRequest =
@@ -875,7 +877,7 @@ public class AwsTransformerTest {
             .includeSubFolders(true)
             .followSymbolicLinks(false)
             .build();
-    request = transformer.toUploadDirectoryRequest(directoryUploadRequest);
+    request = transformer.toUploadDirectoryRequest(directoryUploadRequest, null, null);
     assertEquals(Optional.of(false), request.followSymbolicLinks());
   }
 
@@ -892,7 +894,8 @@ public class AwsTransformerTest {
             .build();
 
     // When
-    UploadDirectoryRequest request = transformer.toUploadDirectoryRequest(directoryUploadRequest);
+    UploadDirectoryRequest request =
+        transformer.toUploadDirectoryRequest(directoryUploadRequest, null, null);
 
     // Then
     assertEquals(BUCKET, request.bucket());
@@ -925,7 +928,7 @@ public class AwsTransformerTest {
             .build();
 
     UploadDirectoryRequest request =
-        transformer.toUploadDirectoryRequest(directoryUploadRequest);
+        transformer.toUploadDirectoryRequest(directoryUploadRequest, null, null);
 
     assertNotNull(request);
     // Verify the per-file transformer applies object lock to each PutObjectRequest
@@ -960,7 +963,7 @@ public class AwsTransformerTest {
             .build();
 
     UploadDirectoryRequest request =
-        transformer.toUploadDirectoryRequest(directoryUploadRequest);
+        transformer.toUploadDirectoryRequest(directoryUploadRequest, null, null);
 
     assertNotNull(request);
     UploadFileRequest.Builder fileBuilder =

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -57,6 +58,7 @@ import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectLegalHoldResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRetentionResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest;
@@ -799,6 +801,80 @@ public class AwsTransformerTest {
     assertEquals(destination, downloadDirectoryRequest.destination().toString());
     assertNotNull(downloadDirectoryRequest.filter());
     assertNotNull(downloadDirectoryRequest.listObjectsRequestTransformer());
+  }
+
+  @Test
+  void testToDownloadDirectoryRequest_LoggingEnabledButNullCounter_NoListener() {
+    // Pinning symmetric behavior with the upload path: when transferStatusLoggingEnabled is
+    // true but the caller passes a null totalBytesTransferred counter, no listener should be
+    // attached. A null counter signals "don't count", and constructing the listener with null
+    // would NPE — silently dropping it would be a worse footgun.
+    DirectoryDownloadRequest request =
+        DirectoryDownloadRequest.builder()
+            .localDestinationDirectory("/home/documents")
+            .prefixToDownload("/files")
+            .transferStatusLoggingEnabled(true)
+            .build();
+
+    DownloadDirectoryRequest downloadDirectoryRequest =
+        transformer.toDownloadDirectoryRequest(request, null, null);
+
+    // Drive the SDK's downloadFileRequestTransformer against a stub per-file builder; with
+    // the null-counter guard in place no listener should be attached, even though the
+    // request flag asks for transfer-status logging.
+    DownloadFileRequest.Builder fileBuilder =
+        DownloadFileRequest.builder()
+            .destination(Paths.get("/tmp/dest.txt"))
+            .getObjectRequest(GetObjectRequest.builder().bucket(BUCKET).key("a").build());
+    downloadDirectoryRequest.downloadFileRequestTransformer().accept(fileBuilder);
+    DownloadFileRequest fileRequest = fileBuilder.build();
+    assertTrue(fileRequest.transferListeners() == null
+        || fileRequest.transferListeners().isEmpty());
+
+    // And the default filter (no exclusions, no counter) admits every object without
+    // mutating any shared counter.
+    AtomicLong wouldBeRequested = new AtomicLong(0L);
+    downloadDirectoryRequest.filter().test(S3Object.builder().key("a").size(123L).build());
+    assertEquals(0L, wouldBeRequested.get());
+  }
+
+  @Test
+  void testToUploadDirectoryRequest_LoggingEnabledButNullCounter_NoListener()
+      throws java.io.IOException {
+    // Symmetric guard to the download path: logging request + null totalBytesTransferred
+    // should not attach the listener. Counters opt in to byte tracking; null means opt out.
+    java.nio.file.Path tempDir =
+        java.nio.file.Files.createTempDirectory("aws-transformer-null-counter");
+    try {
+      DirectoryUploadRequest directoryUploadRequest =
+          DirectoryUploadRequest.builder()
+              .localSourceDirectory(tempDir.toString())
+              .prefix("/files")
+              .includeSubFolders(true)
+              .transferStatusLoggingEnabled(true)
+              .build();
+
+      // Pass null transferred-counter, non-null requested-counter — listener should be skipped,
+      // and (because requested counter is non-null) the per-file transformer is installed for
+      // the byte-stat side-effect but not for the listener.
+      AtomicLong totalBytesRequested = new AtomicLong(0L);
+      UploadDirectoryRequest request =
+          transformer.toUploadDirectoryRequest(directoryUploadRequest, null, totalBytesRequested);
+
+      UploadFileRequest.Builder fileBuilder =
+          UploadFileRequest.builder()
+              .source(Paths.get(tempDir.toString(), "missing.txt"))
+              .putObjectRequest(
+                  PutObjectRequest.builder().bucket(BUCKET).key("/files/missing.txt").build());
+      request.uploadFileRequestTransformer().accept(fileBuilder);
+      UploadFileRequest fileRequest = fileBuilder.build();
+      // SDK returns null when no listeners were attached. Either null or empty proves the
+      // guard worked: the listener was not attached despite isTransferStatusLoggingEnabled().
+      assertTrue(fileRequest.transferListeners() == null
+          || fileRequest.transferListeners().isEmpty());
+    } finally {
+      java.nio.file.Files.deleteIfExists(tempDir);
+    }
   }
 
   @Test

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStoreTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStoreTest.java
@@ -1592,8 +1592,9 @@ public class AwsAsyncBlobStoreTest {
     DirectoryDownloadResponse response = aws.doDownloadDirectory(downloadRequest).get();
     assertNotNull(response);
     assertEquals(1, response.getFailedTransfers().size());
-    // Listener off + any failure → 0; callers must consult failedTransfers for detail.
-    assertEquals(0L, response.getTotalBytesTransferred());
+    // Listener off + any failure → null so callers can't confuse it with an empty directory
+    // that succeeded. failedTransfers carries the actual error detail.
+    assertNull(response.getTotalBytesTransferred());
   }
 
   @Test
@@ -1702,8 +1703,9 @@ public class AwsAsyncBlobStoreTest {
       DirectoryUploadResponse response = aws.doUploadDirectory(uploadRequest).get();
       assertNotNull(response);
       assertEquals(1, response.getFailedTransfers().size());
-      // Listener off + any failure → 0.
-      assertEquals(0L, response.getTotalBytesTransferred());
+      // Listener off + any failure → null so callers can't confuse it with an empty directory
+      // that succeeded. failedTransfers carries the actual error detail.
+      assertNull(response.getTotalBytesTransferred());
     } finally {
       Files.deleteIfExists(tempFile);
       Files.deleteIfExists(tempDir);

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStoreTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStoreTest.java
@@ -1521,6 +1521,195 @@ public class AwsAsyncBlobStoreTest {
     }
   }
 
+  @Test
+  void doDownloadDirectory_LoggingDisabled_SuccessReportsRequestedBytes()
+      throws ExecutionException, InterruptedException {
+    DirectoryDownload awsResponseFuture = mock(DirectoryDownload.class);
+    CompletedDirectoryDownload awsResponse = mock(CompletedDirectoryDownload.class);
+    doAnswer(
+            invocation -> {
+              DownloadDirectoryRequest request = invocation.getArgument(0);
+              // Filter chains exclusion -> size accumulation. With no exclusions, every passing
+              // object's size is summed into totalBytesRequested by the transformer.
+              request.filter().test(S3Object.builder().key("files/a.txt").size(123L).build());
+              request.filter().test(S3Object.builder().key("files/b.txt").size(77L).build());
+              return awsResponseFuture;
+            })
+        .when(mockS3TransferManager)
+        .downloadDirectory(any(DownloadDirectoryRequest.class));
+    doReturn(future(awsResponse)).when(awsResponseFuture).completionFuture();
+    doReturn(List.of()).when(awsResponse).failedTransfers();
+
+    // transferStatusLoggingEnabled defaults to false — listener-off path.
+    DirectoryDownloadRequest downloadRequest =
+        DirectoryDownloadRequest.builder()
+            .prefixToDownload("files/")
+            .localDestinationDirectory("/home/documents")
+            .build();
+
+    DirectoryDownloadResponse response = aws.doDownloadDirectory(downloadRequest).get();
+    assertNotNull(response);
+    // Listener off + zero failures → response carries the filter-accumulated requested total.
+    assertEquals(200L, response.getTotalBytesTransferred());
+  }
+
+  @Test
+  void doDownloadDirectory_LoggingDisabled_PartialFailureReportsZero()
+      throws ExecutionException, InterruptedException {
+    DirectoryDownload awsResponseFuture = mock(DirectoryDownload.class);
+    CompletedDirectoryDownload awsResponse = mock(CompletedDirectoryDownload.class);
+    doAnswer(
+            invocation -> {
+              DownloadDirectoryRequest request = invocation.getArgument(0);
+              request.filter().test(S3Object.builder().key("files/a.txt").size(123L).build());
+              request.filter().test(S3Object.builder().key("files/b.txt").size(77L).build());
+              return awsResponseFuture;
+            })
+        .when(mockS3TransferManager)
+        .downloadDirectory(any(DownloadDirectoryRequest.class));
+    doReturn(future(awsResponse)).when(awsResponseFuture).completionFuture();
+    // At least one failed transfer pushes the response into the partial-failure branch.
+    DownloadFileRequest failedReq =
+        DownloadFileRequest.builder()
+            .destination(Paths.get("/tmp/b.txt"))
+            .getObjectRequest(GetObjectRequest.builder().bucket(BUCKET).key("files/b.txt").build())
+            .build();
+    doReturn(
+            List.of(
+                FailedFileDownload.builder()
+                    .request(failedReq)
+                    .exception(new RuntimeException("download boom"))
+                    .build()))
+        .when(awsResponse)
+        .failedTransfers();
+
+    DirectoryDownloadRequest downloadRequest =
+        DirectoryDownloadRequest.builder()
+            .prefixToDownload("files/")
+            .localDestinationDirectory("/home/documents")
+            .build();
+
+    DirectoryDownloadResponse response = aws.doDownloadDirectory(downloadRequest).get();
+    assertNotNull(response);
+    assertEquals(1, response.getFailedTransfers().size());
+    // Listener off + any failure → 0; callers must consult failedTransfers for detail.
+    assertEquals(0L, response.getTotalBytesTransferred());
+  }
+
+  @Test
+  void doUploadDirectory_LoggingDisabled_SuccessReportsRequestedBytes()
+      throws ExecutionException, InterruptedException, IOException {
+    DirectoryUpload mockDirectoryUpload = mock(DirectoryUpload.class);
+    CompletedDirectoryUpload mockCompletedUpload = mock(CompletedDirectoryUpload.class);
+    Path tempDir = Files.createTempDirectory("aws-async-upload-dir-listener-off");
+    Path tempFile = tempDir.resolve("a.txt");
+    Files.write(tempFile, "hello world".getBytes(StandardCharsets.UTF_8)); // 11 bytes
+
+    try {
+      doAnswer(
+              invocation -> {
+                UploadDirectoryRequest request = invocation.getArgument(0);
+                // Drive the per-file transformer so Files.size(source) runs and the requested
+                // total is accumulated by the production code under test.
+                software.amazon.awssdk.transfer.s3.model.UploadFileRequest.Builder
+                    uploadFileRequestBuilder =
+                        software.amazon.awssdk.transfer.s3.model.UploadFileRequest.builder()
+                            .source(tempFile)
+                            .putObjectRequest(
+                                PutObjectRequest.builder()
+                                    .bucket(BUCKET)
+                                    .key("files/a.txt")
+                                    .build());
+                request.uploadFileRequestTransformer().accept(uploadFileRequestBuilder);
+                return mockDirectoryUpload;
+              })
+          .when(mockS3TransferManager)
+          .uploadDirectory(any(UploadDirectoryRequest.class));
+      doReturn(CompletableFuture.completedFuture(mockCompletedUpload))
+          .when(mockDirectoryUpload)
+          .completionFuture();
+      doReturn(List.of()).when(mockCompletedUpload).failedTransfers();
+
+      DirectoryUploadRequest uploadRequest =
+          DirectoryUploadRequest.builder()
+              .localSourceDirectory(tempDir.toString())
+              .prefix("files/")
+              .includeSubFolders(true)
+              .build();
+
+      DirectoryUploadResponse response = aws.doUploadDirectory(uploadRequest).get();
+      assertNotNull(response);
+      // Listener off + zero failures → response carries the per-file Files.size() total.
+      assertEquals(11L, response.getTotalBytesTransferred());
+    } finally {
+      Files.deleteIfExists(tempFile);
+      Files.deleteIfExists(tempDir);
+    }
+  }
+
+  @Test
+  void doUploadDirectory_LoggingDisabled_PartialFailureReportsZero()
+      throws ExecutionException, InterruptedException, IOException {
+    DirectoryUpload mockDirectoryUpload = mock(DirectoryUpload.class);
+    CompletedDirectoryUpload mockCompletedUpload = mock(CompletedDirectoryUpload.class);
+    Path tempDir = Files.createTempDirectory("aws-async-upload-dir-partial-fail");
+    Path tempFile = tempDir.resolve("a.txt");
+    Files.write(tempFile, "hello world".getBytes(StandardCharsets.UTF_8)); // 11 bytes
+
+    try {
+      doAnswer(
+              invocation -> {
+                UploadDirectoryRequest request = invocation.getArgument(0);
+                software.amazon.awssdk.transfer.s3.model.UploadFileRequest.Builder
+                    uploadFileRequestBuilder =
+                        software.amazon.awssdk.transfer.s3.model.UploadFileRequest.builder()
+                            .source(tempFile)
+                            .putObjectRequest(
+                                PutObjectRequest.builder()
+                                    .bucket(BUCKET)
+                                    .key("files/a.txt")
+                                    .build());
+                request.uploadFileRequestTransformer().accept(uploadFileRequestBuilder);
+                return mockDirectoryUpload;
+              })
+          .when(mockS3TransferManager)
+          .uploadDirectory(any(UploadDirectoryRequest.class));
+      doReturn(CompletableFuture.completedFuture(mockCompletedUpload))
+          .when(mockDirectoryUpload)
+          .completionFuture();
+      software.amazon.awssdk.transfer.s3.model.UploadFileRequest failedUploadReq =
+          software.amazon.awssdk.transfer.s3.model.UploadFileRequest.builder()
+              .source(tempFile)
+              .putObjectRequest(
+                  PutObjectRequest.builder().bucket(BUCKET).key("files/a.txt").build())
+              .build();
+      doReturn(
+              List.of(
+                  software.amazon.awssdk.transfer.s3.model.FailedFileUpload.builder()
+                      .request(failedUploadReq)
+                      .exception(new RuntimeException("upload boom"))
+                      .build()))
+          .when(mockCompletedUpload)
+          .failedTransfers();
+
+      DirectoryUploadRequest uploadRequest =
+          DirectoryUploadRequest.builder()
+              .localSourceDirectory(tempDir.toString())
+              .prefix("files/")
+              .includeSubFolders(true)
+              .build();
+
+      DirectoryUploadResponse response = aws.doUploadDirectory(uploadRequest).get();
+      assertNotNull(response);
+      assertEquals(1, response.getFailedTransfers().size());
+      // Listener off + any failure → 0.
+      assertEquals(0L, response.getTotalBytesTransferred());
+    } finally {
+      Files.deleteIfExists(tempFile);
+      Files.deleteIfExists(tempDir);
+    }
+  }
+
   private TransferListener.Context.TransferComplete createTransferCompleteContext(long bytes) {
     TransferProgressSnapshot transferProgressSnapshot = mock(TransferProgressSnapshot.class);
     doReturn(bytes).when(transferProgressSnapshot).transferredBytes();


### PR DESCRIPTION
## Summary

Populate the directory-transfer response's `totalBytesTransferred` even when `transferStatusLoggingEnabled=false`, by accumulating per-object sizes during listing (downloads) or per-file size stat (uploads). Callers can now leave the per-file `TransferListener` off — which avoids major heap pressure on large directory operations — and still get a useful byte total on success.

Also lowers the per-file `transferComplete` / `onFinish` log line from INFO to DEBUG in both AWS (`S3LoggingTransferListener`) and Ali (`OssLoggingTransferListener`), so even when the listener is enabled it doesn't flood log appender queues on directories with thousands of files.

## Behavior

For both `DirectoryDownloadResponse.totalBytesTransferred` and `DirectoryUploadResponse.totalBytesTransferred`:

| `transferStatusLoggingEnabled` | Outcome | `totalBytesTransferred` |
|---|---|---|
| `true` | any | listener-accumulated total (unchanged) |
| `false` | full success (zero failed transfers) | sum of requested object/file sizes |
| `false` | partial failure (≥1 failed transfer) | `0` — callers consult `failedTransfers` |

## Changes

**AWS**
- `S3LoggingTransferListener` — per-file `transferComplete` log: INFO → DEBUG.
- `AwsTransformer.toDownloadDirectoryRequest` — collapsed into a single canonical 3-arg method; the existing `getPrefixExclusionsFilter` now optionally accumulates retained-object size into `totalBytesRequested` on the same true-return path, so excluded objects are never counted.
- `AwsTransformer.toUploadDirectoryRequest` — collapsed into a single canonical 3-arg method; the per-file `uploadFileRequestTransformer` now stats `Files.size(source)` into `totalBytesRequested` (best-effort; IOException is swallowed since the doomed file will surface via `failedTransfers`).
- `AwsAsyncBlobStore.doDownloadDirectory` / `doUploadDirectory` — allocate both counters and pick the response value via a shared `resolveDirectoryTotalBytes` helper.

**Ali**
- `OssLoggingTransferListener` — per-file `onFinish` log: INFO → DEBUG.
- `AliAsyncBlobStore.doDownloadDirectory` — accumulates `blob.getObjectSize()` in the listing consumer (after folder-marker + exclusion checks).
- `AliAsyncBlobStore.doUploadDirectory` — sums the existing stage-1 `fileSizes` stat pass.
- Shared `resolveDirectoryTotalBytes` helper mirrors the AWS one.

## Testing

- AWS: 4 new tests — listener-off success + partial-failure, for both download and upload (`mvn test -pl blob/blob-aws`: 258 passed, 2 pre-existing skips).
- Ali: 2 existing `...ReturnsNullTotal` tests renamed to `...ReturnsRequestedBytesOnSuccess` and re-asserted to expect the sum; 2 new partial-failure tests; OssLoggingTransferListener test updated for the DEBUG level on `onFinish` (`mvn test -pl blob/blob-ali`: 244 passed).

## Cross-cloud notes

- AWS S3 Transfer Manager: downloads exercise `DownloadDirectoryRequest.filter`; uploads exercise `uploadFileRequestTransformer` (no listing filter is exposed for uploads).
- Ali OSS: download already lists objects explicitly in `AliAsyncBlobStore` (so `getObjectSize()` is in hand during listing); upload already does a stage-1 stat pass — both reuse what's there.

## Compatibility

The `totalBytesTransferred` field shape is unchanged. Callers who previously saw `null` when the listener was off now see the requested total on success (or `0` on partial failure). The listener-on path is unchanged.