### PR TITLE
blobstore: dedupe Ali OSS download paths and avoid byte[] double buffering

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -312,14 +312,22 @@ public class AliBlobStore extends AbstractBlobStore implements AliSdkService {
    * of draining into a {@link ByteArrayOutputStream} and then copying out through
    * {@code toByteArray()}.
    * When the content length is known and addressable as one array, the body is read into an exactly
-   * sized buffer (trimmed if the stream ends early). Otherwise — unknown, zero, or oversized length
-   * — it falls back to draining the full stream.
+   * sized buffer; if the stream turns out to hold more bytes than the reported length, the read is
+   * rejected rather than silently truncating the payload ({@code readNBytes} already truncates if
+   * the stream ends early, which is harmless). Otherwise — unknown, zero, or oversized length — it
+   * falls back to draining the full stream.
    */
   private byte[] readBody(GetObjectResult result) throws IOException {
     Long reported = result.contentLength();
     long contentLength = reported != null ? reported : 0L;
     if (contentLength > 0 && contentLength <= MAX_ARRAY_SIZE) {
-      return result.body().readNBytes((int) contentLength);
+      InputStream body = result.body();
+      byte[] bytes = body.readNBytes((int) contentLength);
+      if (body.read() != -1) {
+        throw new IOException(
+            "Object stream exceeded the reported content length of " + contentLength + " bytes");
+      }
+      return bytes;
     }
     // Fallback: drain the entire stream when the length is unknown, zero, or too large to allocate.
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -96,6 +96,11 @@ import lombok.Getter;
 @AutoService(AbstractBlobStore.class)
 public class AliBlobStore extends AbstractBlobStore implements AliSdkService {
 
+  private static final int COPY_BUFFER_SIZE = 16 * 1024;
+
+  // Largest array the JVM can reliably allocate; some VMs reserve a few header words.
+  private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
   private final OSSClient ossClient;
   private final AliTransformer transformer;
 
@@ -224,23 +229,7 @@ public class AliBlobStore extends AbstractBlobStore implements AliSdkService {
   @Override
   protected DownloadResponse doDownload(
       DownloadRequest downloadRequest, OutputStream outputStream) {
-    GetObjectRequest request =
-        transformer.toGetObjectRequest(downloadRequest);
-    try (GetObjectResult result =
-        ossClient.getObject(request,
-            OperationOptions.defaults())) {
-      validateRangeResponse(downloadRequest, result);
-      copyStream(result.body(), outputStream);
-      return transformer.toDownloadResponse(downloadRequest.getKey(), result);
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to download Blob: " + downloadRequest.getKey(), e);
-    } catch (Exception e) {
-      handleArchivedObjects(downloadRequest, e);
-      if (e instanceof RuntimeException) {
-        throw (RuntimeException) e;
-      }
-      throw new RuntimeException("Failed to download Blob: " + downloadRequest.getKey(), e);
-    }
+    return download(downloadRequest, result -> copyStream(result.body(), outputStream));
   }
 
   /**
@@ -252,10 +241,7 @@ public class AliBlobStore extends AbstractBlobStore implements AliSdkService {
    */
   @Override
   protected DownloadResponse doDownload(DownloadRequest downloadRequest, ByteArray byteArray) {
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    DownloadResponse downloadResponse = doDownload(downloadRequest, outputStream);
-    byteArray.setBytes(outputStream.toByteArray());
-    return downloadResponse;
+    return download(downloadRequest, result -> byteArray.setBytes(readBody(result)));
   }
 
   /**
@@ -279,15 +265,36 @@ public class AliBlobStore extends AbstractBlobStore implements AliSdkService {
    */
   @Override
   protected DownloadResponse doDownload(DownloadRequest downloadRequest, Path path) {
-    Path destinationPath =
-        createDownloadDestinationPath(downloadRequest, path);
-    GetObjectRequest request =
-        transformer.toGetObjectRequest(downloadRequest);
+    Path destinationPath = createDownloadDestinationPath(downloadRequest, path);
+    return download(downloadRequest, result -> Files.copy(result.body(), destinationPath));
+  }
+
+  /**
+   * Consumes the body of a {@link GetObjectResult} into a download destination.
+   */
+  @FunctionalInterface
+  private interface BodyConsumer {
+    void accept(GetObjectResult result) throws IOException;
+  }
+
+  /**
+   * Shared GET-object download flow for the destination-based overloads (OutputStream, byte array,
+   * and file/path). It issues the GET, validates any requested range, hands the open result to the
+   * supplied {@link BodyConsumer} to drain the body, and closes the result via try-with-resources.
+   * The error contract is uniform across every destination: archived/delete-marker detection runs
+   * through {@link #handleArchivedObjects}, and other failures are wrapped in
+   * {@code RuntimeException} so the framework's exception-translation layer maps them consistently.
+   *
+   * <p>The InputStream overload is intentionally not routed through here: it returns the body
+   * stream to the caller without consuming or closing it, so it cannot share this
+   * try-with-resources flow.
+   */
+  private DownloadResponse download(DownloadRequest downloadRequest, BodyConsumer consumer) {
+    GetObjectRequest request = transformer.toGetObjectRequest(downloadRequest);
     try (GetObjectResult result =
-        ossClient.getObject(request,
-            OperationOptions.defaults())) {
+        ossClient.getObject(request, OperationOptions.defaults())) {
       validateRangeResponse(downloadRequest, result);
-      Files.copy(result.body(), destinationPath);
+      consumer.accept(result);
       return transformer.toDownloadResponse(downloadRequest.getKey(), result);
     } catch (IOException e) {
       throw new RuntimeException("Failed to download Blob: " + downloadRequest.getKey(), e);
@@ -298,6 +305,26 @@ public class AliBlobStore extends AbstractBlobStore implements AliSdkService {
       }
       throw new RuntimeException("Failed to download Blob: " + downloadRequest.getKey(), e);
     }
+  }
+
+  /**
+   * Reads the object body into a single right-sized {@code byte[]}, avoiding the double buffering
+   * of draining into a {@link ByteArrayOutputStream} and then copying out through
+   * {@code toByteArray()}.
+   * When the content length is known and addressable as one array, the body is read into an exactly
+   * sized buffer (trimmed if the stream ends early). Otherwise — unknown, zero, or oversized length
+   * — it falls back to draining the full stream.
+   */
+  private byte[] readBody(GetObjectResult result) throws IOException {
+    Long reported = result.contentLength();
+    long contentLength = reported != null ? reported : 0L;
+    if (contentLength > 0 && contentLength <= MAX_ARRAY_SIZE) {
+      return result.body().readNBytes((int) contentLength);
+    }
+    // Fallback: drain the entire stream when the length is unknown, zero, or too large to allocate.
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    copyStream(result.body(), outputStream);
+    return outputStream.toByteArray();
   }
 
   /**
@@ -464,15 +491,11 @@ public class AliBlobStore extends AbstractBlobStore implements AliSdkService {
     }
   }
 
-  private void copyStream(InputStream in, OutputStream out) {
-    try {
-      byte[] buffer = new byte[1024];
-      int bytesRead;
-      while ((bytesRead = in.read(buffer)) != -1) {
-        out.write(buffer, 0, bytesRead);
-      }
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+  private void copyStream(InputStream in, OutputStream out) throws IOException {
+    byte[] buffer = new byte[COPY_BUFFER_SIZE];
+    int bytesRead;
+    while ((bytesRead = in.read(buffer)) != -1) {
+      out.write(buffer, 0, bytesRead);
     }
   }
 

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -398,6 +398,20 @@ public class AliBlobStoreTest {
     assertEquals(0, byteArray.getBytes().length);
   }
 
+  @Test
+  void testDoDownloadByteArray_contentLengthSmallerThanStream_throws() {
+    String content = "muchLongerThanReported";
+    // Reported length (5) under-reports the actual 22-byte stream: the read must NOT silently
+    // truncate the payload, it must fail loudly instead.
+    doReturn(buildByteArrayGetObjectResult(content, 5L))
+        .when(mockOssClient).getObject(any(GetObjectRequest.class), any());
+
+    ByteArray byteArray = new ByteArray();
+    assertThrows(
+        RuntimeException.class,
+        () -> ali.doDownload(getTestDownloadRequestNoRange(), byteArray));
+  }
+
   void verifyDownloadTestResults(DownloadResponse response, Instant now) {
 
     // Verify the parameters passed into the OSS SDK
@@ -1876,6 +1890,47 @@ public class AliBlobStoreTest {
     ResourceNotFoundException ex = assertThrows(
         ResourceNotFoundException.class,
         () -> ali.doDownload(request, new java.io.ByteArrayOutputStream()));
+
+    ArchiveInfo info = ex.getArchiveInfo();
+    assertNotNull(info, "ArchiveInfo should be populated when a delete marker is detected");
+    assertTrue(info.isArchived());
+    assertEquals(priorVersionId, info.getVersionId());
+  }
+
+  @Test
+  void testDoDownloadByteArray_checkArchived_deletedOnVersionedBucket_throwsWithArchiveInfo() {
+    // The ByteArray download path must preserve the same archived-object contract as the
+    // OutputStream path: a 404 + x-oss-delete-marker GET resolves the prior version and throws
+    // ResourceNotFoundException with ArchiveInfo populated. This guards the shared download()
+    // helper so the byte[] overload cannot silently diverge from the streaming overload.
+    String key = "deleted-key";
+    String priorVersionId = "v-prior-1";
+
+    ServiceException service = mock(ServiceException.class);
+    when(service.statusCode()).thenReturn(404);
+    when(service.errorCode()).thenReturn("NoSuchKey");
+    when(service.headers()).thenReturn(Map.of("x-oss-delete-marker", "true"));
+    OperationException op = mock(OperationException.class);
+    when(op.getCause()).thenReturn(service);
+    when(mockOssClient.getObject(any(GetObjectRequest.class), any(OperationOptions.class)))
+        .thenThrow(op);
+
+    ObjectVersion priorVersion = mock(ObjectVersion.class);
+    when(priorVersion.versionId()).thenReturn(priorVersionId);
+    when(priorVersion.key()).thenReturn(key);
+    ListObjectVersionsResult listResult = mock(ListObjectVersionsResult.class);
+    when(listResult.versions()).thenReturn(List.of(priorVersion));
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(listResult).iterator());
+    when(mockOssClient.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    DownloadRequest request = DownloadRequest.builder()
+        .withKey(key).withCheckArchived(true).build();
+
+    ResourceNotFoundException ex = assertThrows(
+        ResourceNotFoundException.class,
+        () -> ali.doDownload(request, new ByteArray()));
 
     ArchiveInfo info = ex.getArchiveInfo();
     assertNotNull(info, "ArchiveInfo should be populated when a delete marker is detected");

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -332,6 +332,72 @@ public class AliBlobStoreTest {
     }
   }
 
+  @Test
+  void testDoDownloadByteArray_exactContentLength() {
+    String content = "downloadedData";
+    doReturn(buildByteArrayGetObjectResult(content, content.length()))
+        .when(mockOssClient).getObject(any(GetObjectRequest.class), any());
+
+    ByteArray byteArray = new ByteArray();
+    ali.doDownload(getTestDownloadRequestNoRange(), byteArray);
+
+    assertEquals(content.length(), byteArray.getBytes().length);
+    assertEquals(content, new String(byteArray.getBytes(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void testDoDownloadByteArray_contentLengthLargerThanStream_trimsToActualBytes() {
+    String content = "downloadedData";
+    // Reported length intentionally larger than the actual stream; result must be trimmed.
+    doReturn(buildByteArrayGetObjectResult(content, 100L))
+        .when(mockOssClient).getObject(any(GetObjectRequest.class), any());
+
+    ByteArray byteArray = new ByteArray();
+    ali.doDownload(getTestDownloadRequestNoRange(), byteArray);
+
+    assertEquals(content.length(), byteArray.getBytes().length);
+    assertEquals(content, new String(byteArray.getBytes(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void testDoDownloadByteArray_zeroContentLength_drainsEntireStream() {
+    String content = "downloadedData";
+    // A zero content length (e.g. a missing Content-Length header) must fall back to draining the
+    // full stream rather than returning an empty array.
+    doReturn(buildByteArrayGetObjectResult(content, 0L))
+        .when(mockOssClient).getObject(any(GetObjectRequest.class), any());
+
+    ByteArray byteArray = new ByteArray();
+    ali.doDownload(getTestDownloadRequestNoRange(), byteArray);
+
+    assertEquals(content, new String(byteArray.getBytes(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void testDoDownloadByteArray_nullContentLength_drainsEntireStream() {
+    String content = "downloadedData";
+    // A null content length (e.g. the SDK omits it) must fall back to draining the full stream.
+    GetObjectResult result = buildByteArrayGetObjectResult(content, 0L);
+    doReturn(null).when(result).contentLength();
+    doReturn(result).when(mockOssClient).getObject(any(GetObjectRequest.class), any());
+
+    ByteArray byteArray = new ByteArray();
+    ali.doDownload(getTestDownloadRequestNoRange(), byteArray);
+
+    assertEquals(content, new String(byteArray.getBytes(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void testDoDownloadByteArray_emptyObject() {
+    doReturn(buildByteArrayGetObjectResult("", 0L))
+        .when(mockOssClient).getObject(any(GetObjectRequest.class), any());
+
+    ByteArray byteArray = new ByteArray();
+    ali.doDownload(getTestDownloadRequestNoRange(), byteArray);
+
+    assertEquals(0, byteArray.getBytes().length);
+  }
+
   void verifyDownloadTestResults(DownloadResponse response, Instant now) {
 
     // Verify the parameters passed into the OSS SDK
@@ -1206,6 +1272,26 @@ public class AliBlobStoreTest {
         .withVersionId("version-1")
         .withRange(10L, 110L)
         .build();
+  }
+
+  private DownloadRequest getTestDownloadRequestNoRange() {
+    return new DownloadRequest.Builder()
+        .withKey("object-1")
+        .withVersionId("version-1")
+        .build();
+  }
+
+  // Builds a minimal GetObjectResult for the byte-array read path with a caller-controlled
+  // reported content length, so tests can exercise exact/over-reported/zero-length behavior.
+  private GetObjectResult buildByteArrayGetObjectResult(String content, long reportedLength) {
+    InputStream inputStream =
+        new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    GetObjectResult result = mock(GetObjectResult.class);
+    doReturn("version-1").when(result).versionId();
+    doReturn("etag1").when(result).eTag();
+    doReturn(reportedLength).when(result).contentLength();
+    doReturn(inputStream).when(result).body();
+    return result;
   }
 
   private GetObjectResult buildTestGetObjectResult(


### PR DESCRIPTION
## Summary
The Ali OSS `ByteArray` download path drained the object stream into a `ByteArrayOutputStream` and then copied it again via `toByteArray()`, buffering the payload twice. This reads directly into a single right-sized `byte[]` instead, and consolidates the four download overloads' duplicated try/catch into one shared helper so they share a uniform error contract.

## Changes
- **Avoid double buffering on the byte[] path:** `doDownload(DownloadRequest, ByteArray)` now reads the body into a single right-sized array via `InputStream.readNBytes(len)` when the content length is known, falling back to a full drain when the length is unknown, zero, or larger than a single array can hold.
- **Shared download helper:** the `OutputStream`, `ByteArray`, and `File`/`Path` overloads now route through one private `download(...)` method that performs the GET, range validation, body consumption, and the `catch`/`handleArchivedObjects`/exception-wrapping in one place. This removes the duplicated try/catch and guarantees that archived/delete-marker detection and `RuntimeException` wrapping behave identically across every download destination.
- The `InputStream` overload is intentionally left as-is — it hands the live body stream to the caller without consuming or closing it, so it can't share the try-with-resources flow.
- `copyStream` buffer bumped from 1 KiB to 16 KiB.

## Testing
- Unit tests: `mvn test -pl blob/blob-ali -Dtest=AliBlobStoreTest` — 81 pass. Adds cases for exact, over-reported, zero, null, and empty content lengths on the byte[] path.
- Conformance (replay): `mvn test -pl blob/blob-ali -Dtest=AliBlobStoreIT` — 123 pass / 0 fail (21 pre-existing skips). No WireMock re-recording needed; existing mappings unchanged.

## Cross-Cloud Compatibility
Behavioral change is internal to the Ali provider's read path; the download API contract (including archived-object detection) is unchanged and verified by the shared conformance suite.