### PR TITLE
blobstore: consolidate duplicated Ali OSS client construction into OssClientFactory

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -983,11 +983,14 @@ public class AliBlobStore extends AbstractBlobStore implements AliSdkService {
     }
 
     private static OSSClient buildOSSClient(Builder builder) {
-      CredentialsProvider creds = OssClientFactory.resolveCredentials(builder);
+      CredentialsProvider creds = OssCredentialsProvider.getCredentialsProvider(
+          builder.getCredentialsOverrider(), builder.getRegion());
       if (creds == null) {
         return null;
       }
-      Retryer retryer = OssClientFactory.resolveRetryer(builder);
+      Retryer retryer = builder.getRetryConfig() != null
+          ? AliTransformer.toAliRetryer(builder.getRetryConfig())
+          : null;
 
       var clientBuilder = OSSClient.newBuilder();
       OssClientFactory.configure(

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliBlobStore.java
@@ -76,7 +76,6 @@ import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.common.provider.Provider;
-import com.salesforce.multicloudj.common.retries.RetryConfig;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -85,7 +84,6 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -985,70 +983,24 @@ public class AliBlobStore extends AbstractBlobStore implements AliSdkService {
     }
 
     private static OSSClient buildOSSClient(Builder builder) {
-      CredentialsProvider creds =
-          OssCredentialsProvider.getCredentialsProvider(
-              builder.getCredentialsOverrider(), builder.getRegion());
+      CredentialsProvider creds = OssClientFactory.resolveCredentials(builder);
       if (creds == null) {
         return null;
       }
+      Retryer retryer = OssClientFactory.resolveRetryer(builder);
 
-      var clientBuilder = OSSClient.newBuilder()
-          .region(builder.getRegion())
-          .credentialsProvider(creds);
-
-      if (builder.getEndpoint() != null) {
-        clientBuilder.endpoint(builder.getEndpoint().toString());
-      }
-      if (builder.getProxyEndpoint() != null) {
-        clientBuilder.proxyHost(
-            builder.getProxyEndpoint().getHost()
-                + ":" + builder.getProxyEndpoint().getPort());
-      }
-      if (builder.getRetryConfig() != null) {
-        Retryer retryer = AliTransformer.toAliRetryer(builder.getRetryConfig());
-        if (retryer != null) {
-          clientBuilder.retryer(retryer);
-        }
-      }
-
-      Duration readWriteTimeout =
-          resolveReadWriteTimeout(builder.getRetryConfig(), builder.getSocketTimeout());
-
-      // Connection-pool size and idle-connection timeout are only settable via HttpClientOptions,
-      // not on the OSS client builder. When the caller sets either, build an explicit transport
-      // client from those options (carrying proxyHost + readWriteTimeout forward so nothing the
-      // builder would otherwise set is lost). When neither is set, leave the SDK to construct its
-      // own default client and set readWriteTimeout directly, preserving the prior behavior.
-      if (builder.getMaxConnections() != null || builder.getIdleConnectionTimeout() != null) {
-        String proxyHost = builder.getProxyEndpoint() != null
-            ? builder.getProxyEndpoint().getHost() + ":" + builder.getProxyEndpoint().getPort()
-            : null;
-        clientBuilder.httpClient(
-            Apache5HttpClientBuilder.create()
-                .options(AliTransformer.toHttpClientOptions(
-                    proxyHost,
-                    readWriteTimeout,
-                    builder.getMaxConnections(),
-                    builder.getIdleConnectionTimeout()))
-                .build());
-      } else if (readWriteTimeout != null) {
-        clientBuilder.readWriteTimeout(readWriteTimeout);
-      }
-
+      var clientBuilder = OSSClient.newBuilder();
+      OssClientFactory.configure(
+          clientBuilder,
+          builder,
+          creds,
+          retryer,
+          (proxyHost, readWriteTimeout, maxConnections, idleConnectionTimeout) ->
+              Apache5HttpClientBuilder.create()
+                  .options(AliTransformer.toHttpClientOptions(
+                      proxyHost, readWriteTimeout, maxConnections, idleConnectionTimeout))
+                  .build());
       return clientBuilder.build();
-    }
-
-    /**
-     * Resolves the value for the Ali SDK's single {@code readWriteTimeout} setting from the two
-     * MultiCloudJ inputs that map onto it. {@code RetryConfig.attemptTimeout} (the more specific
-     * per-attempt deadline) takes precedence over the transport-level {@code socketTimeout}; if
-     * neither is set, returns {@code null} so the SDK default is left in place.
-     */
-    static Duration resolveReadWriteTimeout(RetryConfig retryConfig, Duration socketTimeout) {
-      if (retryConfig != null && retryConfig.getAttemptTimeout() != null) {
-        return Duration.ofMillis(retryConfig.getAttemptTimeout());
-      }
-      return socketTimeout;
     }
 
     @Override

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/OssClientFactory.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/OssClientFactory.java
@@ -35,25 +35,6 @@ public final class OssClientFactory {
   }
 
   /**
-   * Resolves the OSS credentials provider for the given builder configuration, or {@code null} when
-   * no credentials overrider is configured (in which case no client should be built).
-   */
-  public static CredentialsProvider resolveCredentials(BlobStoreBuilder<?> builder) {
-    return OssCredentialsProvider.getCredentialsProvider(
-        builder.getCredentialsOverrider(), builder.getRegion());
-  }
-
-  /**
-   * Resolves the OSS {@link Retryer} from the builder's {@link RetryConfig}, or {@code null} when
-   * no retry configuration is set.
-   */
-  public static Retryer resolveRetryer(BlobStoreBuilder<?> builder) {
-    return builder.getRetryConfig() != null
-        ? AliTransformer.toAliRetryer(builder.getRetryConfig())
-        : null;
-  }
-
-  /**
    * Resolves the value for the Ali SDK's single {@code readWriteTimeout} setting from the two
    * MultiCloudJ inputs that map onto it. {@code RetryConfig.attemptTimeout} (the more specific
    * per-attempt deadline) takes precedence over the transport-level {@code socketTimeout}; if

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/OssClientFactory.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/OssClientFactory.java
@@ -1,0 +1,134 @@
+package com.salesforce.multicloudj.blob.ali;
+
+import com.aliyun.sdk.service.oss2.BaseClientBuilder;
+import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
+import com.aliyun.sdk.service.oss2.retry.Retryer;
+import com.aliyun.sdk.service.oss2.transport.HttpClient;
+import com.salesforce.multicloudj.blob.driver.BlobStoreBuilder;
+import com.salesforce.multicloudj.common.retries.RetryConfig;
+import java.time.Duration;
+
+/**
+ * Builds and configures Alibaba OSS SDK clients (sync {@code OSSClient} and async
+ * {@code OSSAsyncClient}) from the MultiCloudJ builder configuration.
+ *
+ * <p>The sync and async clients are constructed from distinct SDK builder types, but both implement
+ * the SDK's {@link BaseClientBuilder} contract and map the same MultiCloudJ settings (region,
+ * credentials, endpoint, proxy, retry, timeouts, connection pool) the same way. This factory
+ * centralizes that mapping so the two code paths cannot drift. Callers supply the SDK builder, the
+ * resolved credentials and retryer, and a {@link HttpClientFactory} that knows how to build the
+ * transport client appropriate for that client kind (the only sync-vs-async difference).
+ */
+public final class OssClientFactory {
+
+  private OssClientFactory() {}
+
+  /**
+   * Builds the transport {@link HttpClient} for a specific client kind (sync or async) from the
+   * resolved connection options. This is the only part of client construction that differs between
+   * the sync and async paths, so it is supplied by the caller as a small strategy.
+   */
+  @FunctionalInterface
+  public interface HttpClientFactory {
+    HttpClient create(String proxyHost, Duration readWriteTimeout,
+        Integer maxConnections, Duration idleConnectionTimeout);
+  }
+
+  /**
+   * Resolves the OSS credentials provider for the given builder configuration, or {@code null} when
+   * no credentials overrider is configured (in which case no client should be built).
+   */
+  public static CredentialsProvider resolveCredentials(BlobStoreBuilder<?> builder) {
+    return OssCredentialsProvider.getCredentialsProvider(
+        builder.getCredentialsOverrider(), builder.getRegion());
+  }
+
+  /**
+   * Resolves the OSS {@link Retryer} from the builder's {@link RetryConfig}, or {@code null} when
+   * no retry configuration is set.
+   */
+  public static Retryer resolveRetryer(BlobStoreBuilder<?> builder) {
+    return builder.getRetryConfig() != null
+        ? AliTransformer.toAliRetryer(builder.getRetryConfig())
+        : null;
+  }
+
+  /**
+   * Resolves the value for the Ali SDK's single {@code readWriteTimeout} setting from the two
+   * MultiCloudJ inputs that map onto it. {@code RetryConfig.attemptTimeout} (the more specific
+   * per-attempt deadline) takes precedence over the transport-level {@code socketTimeout}; if
+   * neither is set, returns {@code null} so the SDK default is left in place.
+   */
+  public static Duration resolveReadWriteTimeout(RetryConfig retryConfig, Duration socketTimeout) {
+    if (retryConfig != null && retryConfig.getAttemptTimeout() != null) {
+      return Duration.ofMillis(retryConfig.getAttemptTimeout());
+    }
+    return socketTimeout;
+  }
+
+  /**
+   * Applies the shared MultiCloudJ → OSS SDK configuration to {@code clientBuilder}: region,
+   * credentials, optional endpoint/proxy/retryer, and the read-write timeout. Connection-pool size
+   * and idle-connection timeout are only settable via {@code HttpClientOptions}, not on the client
+   * builder, so when the caller sets either we build an explicit transport client from those
+   * options (carrying proxyHost + readWriteTimeout forward so nothing the builder would otherwise
+   * set is lost); when neither is set we leave the SDK to construct its own default client and set
+   * readWriteTimeout directly.
+   *
+   * @param clientBuilder the SDK sync or async client builder to configure
+   * @param mcjBuilder the MultiCloudJ builder carrying the user configuration
+   * @param creds the resolved OSS credentials provider (must be non-null)
+   * @param retryer the resolved OSS retryer, or {@code null} for none
+   * @param httpClientFactory builds the transport client appropriate for this client kind
+   */
+  public static <B extends BaseClientBuilder<B, T>, T> void configure(
+      B clientBuilder,
+      BlobStoreBuilder<?> mcjBuilder,
+      CredentialsProvider creds,
+      Retryer retryer,
+      HttpClientFactory httpClientFactory) {
+    clientBuilder
+        .region(mcjBuilder.getRegion())
+        .credentialsProvider(creds);
+
+    if (mcjBuilder.getEndpoint() != null) {
+      clientBuilder.endpoint(mcjBuilder.getEndpoint().toString());
+    }
+    String proxyHost = proxyHost(mcjBuilder);
+    if (proxyHost != null) {
+      clientBuilder.proxyHost(proxyHost);
+    }
+    if (retryer != null) {
+      clientBuilder.retryer(retryer);
+    }
+
+    // socketTimeout and RetryConfig.attemptTimeout both map to the Ali SDK's single
+    // readWriteTimeout setting. When both are set, attemptTimeout (the more specific per-attempt
+    // deadline) takes precedence over the transport-level socketTimeout.
+    Duration readWriteTimeout =
+        resolveReadWriteTimeout(mcjBuilder.getRetryConfig(), mcjBuilder.getSocketTimeout());
+
+    // Connection-pool size and idle-connection timeout are only settable via HttpClientOptions,
+    // not on the OSS client builder. When the caller sets either, build an explicit transport
+    // client from those options (carrying proxyHost + readWriteTimeout forward so nothing the
+    // builder would otherwise set is lost). When neither is set, leave the SDK to construct its
+    // own default client and set readWriteTimeout directly, preserving the prior behavior.
+    if (mcjBuilder.getMaxConnections() != null || mcjBuilder.getIdleConnectionTimeout() != null) {
+      clientBuilder.httpClient(
+          httpClientFactory.create(
+              proxyHost,
+              readWriteTimeout,
+              mcjBuilder.getMaxConnections(),
+              mcjBuilder.getIdleConnectionTimeout()));
+    } else if (readWriteTimeout != null) {
+      clientBuilder.readWriteTimeout(readWriteTimeout);
+    }
+  }
+
+  /** Formats the proxy endpoint as {@code host:port}, or {@code null} when no proxy is set. */
+  private static String proxyHost(BlobStoreBuilder<?> builder) {
+    return builder.getProxyEndpoint() != null
+        ? builder.getProxyEndpoint().getHost() + ":" + builder.getProxyEndpoint().getPort()
+        : null;
+  }
+}

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -26,7 +26,7 @@ import com.aliyun.sdk.service.oss2.transport.apache5client.Apache5HttpClientBuil
 import com.salesforce.multicloudj.blob.ali.AliSdkService;
 import com.salesforce.multicloudj.blob.ali.AliTransformer;
 import com.salesforce.multicloudj.blob.ali.AliTransformerSupplier;
-import com.salesforce.multicloudj.blob.ali.OssCredentialsProvider;
+import com.salesforce.multicloudj.blob.ali.OssClientFactory;
 import com.salesforce.multicloudj.blob.async.driver.AbstractAsyncBlobStore;
 import com.salesforce.multicloudj.blob.async.driver.AsyncBlobStore;
 import com.salesforce.multicloudj.blob.async.driver.AsyncBlobStoreProvider;
@@ -72,7 +72,6 @@ import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -953,106 +952,38 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
 
     @Override
     public AsyncBlobStore build() {
-      CredentialsProvider creds =
-          OssCredentialsProvider.getCredentialsProvider(
-              getCredentialsOverrider(), getRegion());
-
-      Retryer retryer =
-          getRetryConfig() != null ? AliTransformer.toAliRetryer(getRetryConfig()) : null;
+      CredentialsProvider creds = OssClientFactory.resolveCredentials(this);
+      Retryer retryer = OssClientFactory.resolveRetryer(this);
 
       OSSAsyncClient async = this.asyncClient;
       if (async == null && creds != null) {
-        var asyncBuilder = OSSAsyncClient.newBuilder()
-            .region(getRegion())
-            .credentialsProvider(creds);
-        if (getEndpoint() != null) {
-          asyncBuilder.endpoint(getEndpoint().toString());
-        }
-        if (getProxyEndpoint() != null) {
-          asyncBuilder.proxyHost(
-              getProxyEndpoint().getHost()
-                  + ":" + getProxyEndpoint().getPort());
-        }
-        if (retryer != null) {
-          asyncBuilder.retryer(retryer);
-        }
-        // socketTimeout and RetryConfig.attemptTimeout both map to the Ali SDK's
-        // single readWriteTimeout setting. When both are set, attemptTimeout (the
-        // more specific per-attempt deadline) takes precedence over the
-        // transport-level socketTimeout.
-        Duration asyncReadWriteTimeout =
-            getRetryConfig() != null && getRetryConfig().getAttemptTimeout() != null
-                ? Duration.ofMillis(getRetryConfig().getAttemptTimeout())
-                : getSocketTimeout();
-        // Connection-pool size and idle-connection timeout are only settable via
-        // HttpClientOptions, not on the async client builder. When the caller sets either, build
-        // an explicit async transport client from those options (carrying proxyHost +
-        // readWriteTimeout forward so nothing the builder would otherwise set is lost). When
-        // neither is set, leave the SDK to construct its own default client and set
-        // readWriteTimeout directly, preserving the prior behavior.
-        if (getMaxConnections() != null || getIdleConnectionTimeout() != null) {
-          String proxyHost = getProxyEndpoint() != null
-              ? getProxyEndpoint().getHost() + ":" + getProxyEndpoint().getPort()
-              : null;
-          asyncBuilder.httpClient(
-              Apache5AsyncHttpClientBuilder.create()
-                  .options(AliTransformer.toHttpClientOptions(
-                      proxyHost,
-                      asyncReadWriteTimeout,
-                      getMaxConnections(),
-                      getIdleConnectionTimeout()))
-                  .build());
-        } else if (asyncReadWriteTimeout != null) {
-          asyncBuilder.readWriteTimeout(asyncReadWriteTimeout);
-        }
+        var asyncBuilder = OSSAsyncClient.newBuilder();
+        OssClientFactory.configure(
+            asyncBuilder,
+            this,
+            creds,
+            retryer,
+            (proxyHost, readWriteTimeout, maxConnections, idleConnectionTimeout) ->
+                Apache5AsyncHttpClientBuilder.create()
+                    .options(AliTransformer.toHttpClientOptions(
+                        proxyHost, readWriteTimeout, maxConnections, idleConnectionTimeout))
+                    .build());
         async = asyncBuilder.build();
       }
 
       OSSClient sync = this.syncClient;
       if (sync == null && creds != null) {
-        var syncBuilder = OSSClient.newBuilder()
-            .region(getRegion())
-            .credentialsProvider(creds);
-        if (getEndpoint() != null) {
-          syncBuilder.endpoint(getEndpoint().toString());
-        }
-        if (getProxyEndpoint() != null) {
-          syncBuilder.proxyHost(
-              getProxyEndpoint().getHost()
-                  + ":" + getProxyEndpoint().getPort());
-        }
-        if (retryer != null) {
-          syncBuilder.retryer(retryer);
-        }
-        // socketTimeout and RetryConfig.attemptTimeout both map to the Ali SDK's
-        // single readWriteTimeout setting. When both are set, attemptTimeout (the
-        // more specific per-attempt deadline) takes precedence over the
-        // transport-level socketTimeout.
-        Duration syncReadWriteTimeout =
-            getRetryConfig() != null && getRetryConfig().getAttemptTimeout() != null
-                ? Duration.ofMillis(getRetryConfig().getAttemptTimeout())
-                : getSocketTimeout();
-        // Connection-pool size and idle-connection timeout are only settable via
-        // HttpClientOptions, not on the sync client builder. When the caller sets either, build
-        // an explicit sync transport client from those options (carrying proxyHost +
-        // readWriteTimeout forward so nothing the builder would otherwise set is lost). When
-        // neither is set, leave the SDK to construct its own default client and set
-        // readWriteTimeout directly, preserving the prior behavior.
-        if (getMaxConnections() != null || getIdleConnectionTimeout() != null) {
-          String proxyHost = getProxyEndpoint() != null
-              ? getProxyEndpoint().getHost() + ":" + getProxyEndpoint().getPort()
-              : null;
-          syncBuilder.httpClient(
-              Apache5HttpClientBuilder.create()
-                  .options(AliTransformer.toHttpClientOptions(
-                      proxyHost,
-                      syncReadWriteTimeout,
-                      getMaxConnections(),
-                      getIdleConnectionTimeout()))
-                  .build());
-        } else if (syncReadWriteTimeout != null) {
-          syncBuilder.readWriteTimeout(syncReadWriteTimeout);
-        }
+        var syncBuilder = OSSClient.newBuilder();
+        OssClientFactory.configure(
+            syncBuilder,
+            this,
+            creds,
+            retryer,
+            (proxyHost, readWriteTimeout, maxConnections, idleConnectionTimeout) ->
+                Apache5HttpClientBuilder.create()
+                    .options(AliTransformer.toHttpClientOptions(
+                        proxyHost, readWriteTimeout, maxConnections, idleConnectionTimeout))
+                    .build());
         sync = syncBuilder.build();
       }
 

--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -27,6 +27,7 @@ import com.salesforce.multicloudj.blob.ali.AliSdkService;
 import com.salesforce.multicloudj.blob.ali.AliTransformer;
 import com.salesforce.multicloudj.blob.ali.AliTransformerSupplier;
 import com.salesforce.multicloudj.blob.ali.OssClientFactory;
+import com.salesforce.multicloudj.blob.ali.OssCredentialsProvider;
 import com.salesforce.multicloudj.blob.async.driver.AbstractAsyncBlobStore;
 import com.salesforce.multicloudj.blob.async.driver.AsyncBlobStore;
 import com.salesforce.multicloudj.blob.async.driver.AsyncBlobStoreProvider;
@@ -952,8 +953,11 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
 
     @Override
     public AsyncBlobStore build() {
-      CredentialsProvider creds = OssClientFactory.resolveCredentials(this);
-      Retryer retryer = OssClientFactory.resolveRetryer(this);
+      CredentialsProvider creds = OssCredentialsProvider.getCredentialsProvider(
+          getCredentialsOverrider(), getRegion());
+      Retryer retryer = getRetryConfig() != null
+          ? AliTransformer.toAliRetryer(getRetryConfig())
+          : null;
 
       OSSAsyncClient async = this.asyncClient;
       if (async == null && creds != null) {

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreTest.java
@@ -2163,7 +2163,7 @@ public class AliBlobStoreTest {
   void testResolveReadWriteTimeout_socketTimeoutOnly() {
     Duration socketTimeout = Duration.ofSeconds(30);
     assertEquals(
-        socketTimeout, AliBlobStore.Builder.resolveReadWriteTimeout(null, socketTimeout));
+        socketTimeout, OssClientFactory.resolveReadWriteTimeout(null, socketTimeout));
   }
 
   @Test
@@ -2172,7 +2172,7 @@ public class AliBlobStoreTest {
     Duration socketTimeout = Duration.ofSeconds(30);
     assertEquals(
         Duration.ofMillis(3000L),
-        AliBlobStore.Builder.resolveReadWriteTimeout(retryConfig, socketTimeout));
+        OssClientFactory.resolveReadWriteTimeout(retryConfig, socketTimeout));
   }
 
   @Test
@@ -2180,12 +2180,12 @@ public class AliBlobStoreTest {
     RetryConfig retryConfig = RetryConfig.builder().attemptTimeout(3000L).build();
     assertEquals(
         Duration.ofMillis(3000L),
-        AliBlobStore.Builder.resolveReadWriteTimeout(retryConfig, null));
+        OssClientFactory.resolveReadWriteTimeout(retryConfig, null));
   }
 
   @Test
   void testResolveReadWriteTimeout_neitherSet_returnsNull() {
-    assertNull(AliBlobStore.Builder.resolveReadWriteTimeout(null, null));
+    assertNull(OssClientFactory.resolveReadWriteTimeout(null, null));
   }
 
   @Test
@@ -2194,7 +2194,7 @@ public class AliBlobStoreTest {
     Duration socketTimeout = Duration.ofSeconds(30);
     assertEquals(
         socketTimeout,
-        AliBlobStore.Builder.resolveReadWriteTimeout(retryConfig, socketTimeout));
+        OssClientFactory.resolveReadWriteTimeout(retryConfig, socketTimeout));
   }
 
   // No withClient() — exercises the real buildOSSClient path. Setters are called as statements


### PR DESCRIPTION
## Summary
Removes triplicated OSS client-construction logic in the Ali blob driver by extracting it into a single `OssClientFactory`. No behavior change.

## Problem
The same MultiCloudJ-config → OSS-SDK-builder mapping (region/credentials, optional endpoint/proxy/retryer, the `readWriteTimeout` resolution, and the `maxConnections`/`idleConnectionTimeout` explicit-HttpClient branch) was duplicated **three** times:
- `AliBlobStore.Builder.buildOSSClient` (sync `OSSClient`)
- `AliAsyncBlobStore.Builder.build` — the async `OSSAsyncClient` half
- `AliAsyncBlobStore.Builder.build` — the sync `OSSClient` half

The async builder duplicated the block twice within the same method.

## Change
- New `OssClientFactory` centralizes the mapping against the OSS SDK's shared `BaseClientBuilder` contract (both `OSSClientBuilder` and `OSSAsyncClientBuilder` extend it).
- The only sync-vs-async difference — constructing the transport `HttpClient` (`Apache5HttpClientBuilder` vs `Apache5AsyncHttpClientBuilder`) — is supplied by callers as a small `HttpClientFactory` strategy.
- `resolveReadWriteTimeout` moves into the factory (its unit tests are repointed).
- Both builders' construction blocks collapse to a `resolveCredentials`/`resolveRetryer`/`configure` call sequence.

## Testing
- `mvn verify -pl blob/blob-ali`: unit 254 pass / 0 fail; conformance `AliBlobStoreIT` 123 pass / 0 fail (21 pre-existing skips).
- Checkstyle passes. No WireMock re-recording needed — construction logic is config-only and exercised by existing builder tests.