### PR TITLE
blobstore: use version-agnostic TLS strategy construction in Ali ITs

### DIFF
--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobClientIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobClientIT.java
@@ -16,7 +16,7 @@ import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
-import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
@@ -71,11 +71,14 @@ public class AliBlobClientIT extends AbstractBlobClientIT {
               .build();
 
       SSLContext sslContext = TestsUtil.createTrustAllSSLContext();
-      TlsSocketStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
-          .setSslContext(sslContext)
-          .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-          .setHostVerificationPolicy(HostnameVerificationPolicy.CLIENT)
-          .buildClassic();
+      // Construct DefaultClientTlsStrategy directly rather than via ClientTlsStrategyBuilder:
+      // the builder's setHostVerificationPolicy/buildClassic methods only exist in httpclient5
+      // 5.5.x, whereas this constructor (SSLContext, HostnameVerificationPolicy, HostnameVerifier)
+      // is present in both 5.4.x and 5.5.x. DefaultClientTlsStrategy implements TlsSocketStrategy.
+      TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(
+          sslContext,
+          HostnameVerificationPolicy.CLIENT,
+          NoopHostnameVerifier.INSTANCE);
       PoolingHttpClientConnectionManager connManager =
           PoolingHttpClientConnectionManagerBuilder.create()
               .setTlsSocketStrategy(tlsStrategy)

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliBlobStoreIT.java
@@ -19,7 +19,7 @@ import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
-import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
@@ -84,11 +84,14 @@ public class AliBlobStoreIT extends AbstractBlobStoreIT {
         final String bucketName, final CredentialsOverrider credentialsOverrider) {
 
       SSLContext sslContext = TestsUtil.createTrustAllSSLContext();
-      TlsSocketStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
-          .setSslContext(sslContext)
-          .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-          .setHostVerificationPolicy(HostnameVerificationPolicy.CLIENT)
-          .buildClassic();
+      // Construct DefaultClientTlsStrategy directly rather than via ClientTlsStrategyBuilder:
+      // the builder's setHostVerificationPolicy/buildClassic methods only exist in httpclient5
+      // 5.5.x, whereas this constructor (SSLContext, HostnameVerificationPolicy, HostnameVerifier)
+      // is present in both 5.4.x and 5.5.x. DefaultClientTlsStrategy implements TlsSocketStrategy.
+      TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(
+          sslContext,
+          HostnameVerificationPolicy.CLIENT,
+          NoopHostnameVerifier.INSTANCE);
       PoolingHttpClientConnectionManager connManager =
           PoolingHttpClientConnectionManagerBuilder.create()
               .setTlsSocketStrategy(tlsStrategy)


### PR DESCRIPTION
## Summary
Makes the Ali integration-test harness build against both httpclient5 5.4.x and 5.5.x by replacing a 5.5.x-only builder API with an equivalent constructor. No production code, no dependency, and no runtime behavior changes.

## Problem
`AliBlobStoreIT` and `AliBlobClientIT` construct the WireMock-proxy `TlsSocketStrategy` via:
```java
ClientTlsStrategyBuilder.create()
    .setSslContext(sslContext)
    .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
    .setHostVerificationPolicy(HostnameVerificationPolicy.CLIENT)
    .buildClassic();
```
Both `setHostVerificationPolicy(...)` and `buildClassic()` were introduced in httpclient5 **5.5.x** and do not exist in **5.4.x**, so the ITs fail to compile against the older line.

## Change
Construct the strategy directly:
```java
new DefaultClientTlsStrategy(
    sslContext,
    HostnameVerificationPolicy.CLIENT,
    NoopHostnameVerifier.INSTANCE);
```
- This constructor exists in **both 5.4.x and 5.5.x**, and `DefaultClientTlsStrategy implements TlsSocketStrategy`.
- It is exactly what `ClientTlsStrategyBuilder.buildClassic()` returns internally (`buildImpl()` → `DefaultClientTlsStrategy`), so behavior is identical — same trust-all SSLContext, `CLIENT` hostname-verification policy, and noop verifier.

## Why
This keeps the test harness portable across httpclient5 versions without changing the pinned dependency (still 5.5.1 here) or any runtime/driver code. It only affects how the test harness builds its proxy TLS strategy.

## Testing
- `mvn verify -pl blob/blob-ali` — `AliBlobStoreIT` (123) and `AliBlobClientIT` (2) pass in replay mode; checkstyle clean.
- Verified the same source compiles and the ITs pass against both httpclient5 5.4.x and 5.5.x.