### PR TITLE
chore: add .git-blame-ignore-revs to exclude checkstyle reformat from blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Revisions intentionally excluded from `git blame`.
+#
+# Enable locally with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# (GitHub honors this file automatically in the blame UI.)
+
+# chore: enforce the checkstyle (whole-repo reformat, no logic changes) — PR #330
+14771469737e75686c6e3b23528d9fbb682d5cb1


### PR DESCRIPTION
## What
Adds `.git-blame-ignore-revs` at the repo root, listing the merge SHA of #330 (`chore: enforce the checkstyle`).

## Why
#330 reformatted ~100 files to enforce Google Java Style with no logic changes. As a result, `git blame` currently attributes the majority of lines in those files to that commit instead of the real author, making history hard to trace.

Listing the reformat commit here tells `git blame` to skip it and surface the actual authoring commit. GitHub's blame UI honors this file automatically; locally it's a one-time opt-in:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```
