### PR TITLE
sts: implement AssumeRoleWithWebIdentity (OIDC) for Alibaba

### DIFF
--- a/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliSts.java
+++ b/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliSts.java
@@ -9,6 +9,8 @@ import com.aliyuncs.http.HttpClientConfig;
 import com.aliyuncs.profile.DefaultProfile;
 import com.aliyuncs.sts.model.v20150401.AssumeRoleRequest;
 import com.aliyuncs.sts.model.v20150401.AssumeRoleResponse;
+import com.aliyuncs.sts.model.v20150401.AssumeRoleWithOIDCRequest;
+import com.aliyuncs.sts.model.v20150401.AssumeRoleWithOIDCResponse;
 import com.aliyuncs.sts.model.v20150401.GetCallerIdentityRequest;
 import com.aliyuncs.sts.model.v20150401.GetCallerIdentityResponse;
 import com.aliyuncs.utils.EnvironmentUtils;
@@ -17,7 +19,6 @@ import com.salesforce.multicloudj.common.exceptions.ExceptionHandler;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
-import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.driver.AbstractSts;
 import com.salesforce.multicloudj.sts.model.AssumeRoleWebIdentityRequest;
@@ -210,10 +211,45 @@ public class AliSts extends AbstractSts {
     }
   }
 
+  // Env var the Aliyun SDK's own OIDCCredentialsProvider reads for the OIDC provider ARN when one
+  // is not supplied explicitly; mirrored here so callers can configure it out-of-band.
+  static final String OIDC_PROVIDER_ARN_ENV = "ALIBABA_CLOUD_OIDC_PROVIDER_ARN";
+
   @Override
   protected StsCredentials getSTSCredentialsWithAssumeRoleWebIdentity(
       AssumeRoleWebIdentityRequest request) {
-    throw new UnSupportedOperationException("Not supported yet.");
+    // AssumeRoleWithOIDC requires the OIDC provider ARN to be named explicitly on the request; it
+    // cannot be derived from the token. Take it from the request, else fall back to the env var the
+    // Aliyun SDK itself uses, else reject.
+    String providerArn = request.getWebIdentityProviderArn();
+    if (providerArn == null || providerArn.isEmpty()) {
+      providerArn = System.getenv(OIDC_PROVIDER_ARN_ENV);
+    }
+    if (providerArn == null || providerArn.isEmpty()) {
+      throw new InvalidArgumentException(
+          "webIdentityProviderArn is required for AssumeRoleWithOIDC; set it on the request or via "
+              + "the " + OIDC_PROVIDER_ARN_ENV + " environment variable");
+    }
+
+    AssumeRoleWithOIDCRequest oidcRequest = new AssumeRoleWithOIDCRequest();
+    oidcRequest.setRoleArn(request.getRole());
+    oidcRequest.setOIDCProviderArn(providerArn);
+    oidcRequest.setOIDCToken(request.getWebIdentityToken());
+    oidcRequest.setRoleSessionName(request.getSessionName());
+    if (request.getExpiration() > 0) {
+      oidcRequest.setDurationSeconds((long) request.getExpiration());
+    }
+
+    try {
+      AssumeRoleWithOIDCResponse response = stsClient.getAcsResponse(oidcRequest);
+      AssumeRoleWithOIDCResponse.Credentials credentials = response.getCredentials();
+      return new StsCredentials(
+          credentials.getAccessKeyId(),
+          credentials.getAccessKeySecret(),
+          credentials.getSecurityToken());
+    } catch (ClientException e) {
+      throw mapException(e);
+    }
   }
 
   @Override

--- a/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsTest.java
+++ b/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsTest.java
@@ -10,10 +10,13 @@ import com.aliyuncs.http.HttpClientConfig;
 import com.aliyuncs.profile.IClientProfile;
 import com.aliyuncs.sts.model.v20150401.AssumeRoleRequest;
 import com.aliyuncs.sts.model.v20150401.AssumeRoleResponse;
+import com.aliyuncs.sts.model.v20150401.AssumeRoleWithOIDCRequest;
+import com.aliyuncs.sts.model.v20150401.AssumeRoleWithOIDCResponse;
 import com.aliyuncs.sts.model.v20150401.GetCallerIdentityRequest;
 import com.aliyuncs.sts.model.v20150401.GetCallerIdentityResponse;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
+import com.salesforce.multicloudj.sts.model.AssumeRoleWebIdentityRequest;
 import com.salesforce.multicloudj.sts.model.AssumedRoleRequest;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
@@ -21,6 +24,7 @@ import java.net.URI;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 public class AliStsTest {
@@ -45,6 +49,16 @@ public class AliStsTest {
         .thenReturn(mockResponse);
     Mockito.when(mockStsClient.getAcsResponse(any(GetCallerIdentityRequest.class)))
         .thenReturn(callerIdentityResponse);
+
+    AssumeRoleWithOIDCResponse.Credentials oidcCredentials =
+        new AssumeRoleWithOIDCResponse.Credentials();
+    oidcCredentials.setAccessKeyId("oidcKeyId");
+    oidcCredentials.setAccessKeySecret("oidcSecret");
+    oidcCredentials.setSecurityToken("oidcToken");
+    AssumeRoleWithOIDCResponse oidcResponse = new AssumeRoleWithOIDCResponse();
+    oidcResponse.setCredentials(oidcCredentials);
+    Mockito.when(mockStsClient.getAcsResponse(any(AssumeRoleWithOIDCRequest.class)))
+        .thenReturn(oidcResponse);
   }
 
   @Test
@@ -95,6 +109,61 @@ public class AliStsTest {
     Assertions.assertEquals("testKeyId", credentials.getAccessKeyId());
     Assertions.assertEquals("testSecret", credentials.getAccessKeySecret());
     Assertions.assertEquals("testToken", credentials.getSecurityToken());
+  }
+
+  @Test
+  public void testAssumeRoleWithWebIdentity_explicitProviderArn() throws ClientException {
+    // Use a dedicated mock so the captured request is unambiguous (the class-level mock is shared).
+    DefaultAcsClient client = Mockito.mock(DefaultAcsClient.class);
+    AssumeRoleWithOIDCResponse.Credentials creds = new AssumeRoleWithOIDCResponse.Credentials();
+    creds.setAccessKeyId("oidcKeyId");
+    creds.setAccessKeySecret("oidcSecret");
+    creds.setSecurityToken("oidcToken");
+    AssumeRoleWithOIDCResponse response = new AssumeRoleWithOIDCResponse();
+    response.setCredentials(creds);
+    Mockito.when(client.getAcsResponse(any(AssumeRoleWithOIDCRequest.class))).thenReturn(response);
+
+    AliSts sts = new AliSts().builder().build(client);
+    AssumeRoleWebIdentityRequest request =
+        AssumeRoleWebIdentityRequest.builder()
+            .role("testRole")
+            .webIdentityToken("testOidcToken")
+            .sessionName("testSession")
+            .webIdentityProviderArn("acs:ram::123:oidc-provider/test")
+            .build();
+
+    StsCredentials credentials = sts.assumeRoleWithWebIdentity(request);
+
+    Assertions.assertEquals("oidcKeyId", credentials.getAccessKeyId());
+    Assertions.assertEquals("oidcSecret", credentials.getAccessKeySecret());
+    Assertions.assertEquals("oidcToken", credentials.getSecurityToken());
+
+    // Verify the cloud-agnostic request was wired to the Aliyun OIDC request correctly.
+    ArgumentCaptor<AssumeRoleWithOIDCRequest> captor =
+        ArgumentCaptor.forClass(AssumeRoleWithOIDCRequest.class);
+    Mockito.verify(client).getAcsResponse(captor.capture());
+    AssumeRoleWithOIDCRequest sent = captor.getValue();
+    Assertions.assertEquals("testRole", sent.getRoleArn());
+    Assertions.assertEquals("testOidcToken", sent.getOIDCToken());
+    Assertions.assertEquals("testSession", sent.getRoleSessionName());
+    Assertions.assertEquals("acs:ram::123:oidc-provider/test", sent.getOIDCProviderArn());
+  }
+
+  @Test
+  public void testAssumeRoleWithWebIdentity_missingProviderArn_throws() {
+    AliSts sts = new AliSts().builder().build(mockStsClient);
+    AssumeRoleWebIdentityRequest request =
+        AssumeRoleWebIdentityRequest.builder()
+            .role("testRole")
+            .webIdentityToken("testOidcToken")
+            .sessionName("testSession")
+            .build();
+
+    // No provider ARN on the request. Guarded so the assertion is only made when the env-var
+    // fallback is also absent (keeps the test correct in any environment).
+    if (System.getenv(AliSts.OIDC_PROVIDER_ARN_ENV) == null) {
+      assertThrows(InvalidArgumentException.class, () -> sts.assumeRoleWithWebIdentity(request));
+    }
   }
 
   @Test

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/AssumeRoleWebIdentityRequest.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/AssumeRoleWebIdentityRequest.java
@@ -12,8 +12,7 @@ public class AssumeRoleWebIdentityRequest {
   private final String sessionName;
   private final int expiration;
 
-  // Optional: identifier of the web-identity (OIDC) provider to assume the role through. Some
-  // substrates require the provider to be named explicitly on the request; others resolve it
-  // implicitly from the token issuer and ignore this field.
+  // Identifier (ARN) of the web-identity (OIDC) provider to assume the role through. Each provider
+  // decides whether to consume this or resolve the provider some other way.
   private final String webIdentityProviderArn;
 }

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/AssumeRoleWebIdentityRequest.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/AssumeRoleWebIdentityRequest.java
@@ -11,4 +11,9 @@ public class AssumeRoleWebIdentityRequest {
   private final String webIdentityToken;
   private final String sessionName;
   private final int expiration;
+
+  // Optional: identifier of the web-identity (OIDC) provider to assume the role through. Some
+  // substrates require the provider to be named explicitly on the request; others resolve it
+  // implicitly from the token issuer and ignore this field.
+  private final String webIdentityProviderArn;
 }


### PR DESCRIPTION
## Summary
Implements `AssumeRoleWithWebIdentity` (OIDC) for the Alibaba STS provider. It was the only provider still unimplemented — `AliSts.getSTSCredentialsWithAssumeRoleWebIdentity` previously threw `UnSupportedOperationException`, while AWS and GCP already support it. The cloud-agnostic plumbing (`AbstractSts.assumeRoleWithWebIdentity`, `StsClient.getAssumeRoleWithWebIdentityCredentials`, `AssumeRoleWebIdentityRequest`) already exists.

## Changes
- **`AliSts`**: implement web identity via the Aliyun STS `AssumeRoleWithOIDC` API — map the request, call the service, return the issued `StsCredentials`, and route errors through the existing `mapException` path.
- **`AssumeRoleWebIdentityRequest`**: add an optional `webIdentityProviderArn` field. Alibaba's `AssumeRoleWithOIDC` requires the OIDC provider to be named explicitly on the request (it cannot be derived from the token), whereas providers that infer it from the token issuer simply ignore the field. This mirrors the existing pattern of optional, provider-specific fields on shared STS request models (e.g. `GetCallerIdentityRequest.aud` is consumed by GCP only; `AssumedRoleRequest.credentialScope` by AWS/GCP only).
- The provider ARN is resolved from the request, else the `ALIBABA_CLOUD_OIDC_PROVIDER_ARN` environment variable (the fallback the Aliyun SDK itself uses), else an `InvalidArgumentException` is thrown.

## Testing
- `AliStsTest`: added coverage for the explicit-provider-ARN happy path (verifies the request is wired through correctly and credentials are mapped back) and the missing-provider-ARN error path.
- Full STS unit suite passes: `sts-client` (34), `sts-aws` (17), `sts-gcp` (22), `sts-ali` (15) — the AWS/GCP suites confirm the new optional model field is backward-compatible (they ignore it).
- No conformance test added: this matches AWS and GCP, which also cover `AssumeRoleWithWebIdentity` only at the unit-test level — the flow requires a live external OIDC token that cannot be reliably captured in WireMock record mode. Validated end-to-end against live Alibaba STS separately.

## Compatibility
Additive, optional model field; no change to existing STS operations or to AWS/GCP behavior.