### PR TITLE
blobstore: fix the content length handling in aws blob store

### DIFF
--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
@@ -134,8 +134,7 @@ public class AwsBlobStore extends AbstractBlobStore implements AwsSdkService {
    */
   @Override
   protected UploadResponse doUpload(UploadRequest uploadRequest, InputStream inputStream) {
-    return doUpload(
-        uploadRequest, RequestBody.fromInputStream(inputStream, uploadRequest.getContentLength()));
+    return doUpload(uploadRequest, transformer.toRequestBody(uploadRequest, inputStream));
   }
 
   /**

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -56,6 +56,8 @@ import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.awscore.presigner.PresignedRequest;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.retries.StandardRetryStrategy;
 import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.retries.api.RetryStrategy;
@@ -118,6 +120,9 @@ public class AwsTransformer {
    * the correlation id that appears in the same upload's logs and trace span.
    */
   public static final String CORRELATION_ID_METADATA_KEY = "correlation-id";
+
+  /** Default MIME type used for the request body when the caller does not provide one. */
+  private static final String OCTET_STREAM_MIME = "application/octet-stream";
 
   private final String bucket;
 
@@ -186,8 +191,24 @@ public class AwsTransformer {
   }
 
   public AsyncRequestBody toAsyncRequestBody(UploadRequest uploadRequest, InputStream inputStream) {
+    Long contentLength =
+        uploadRequest.getContentLength() > 0 ? uploadRequest.getContentLength() : null;
     return AsyncRequestBody.fromInputStream(
-        inputStream, uploadRequest.getContentLength(), Executors.newSingleThreadExecutor());
+        inputStream, contentLength, Executors.newSingleThreadExecutor());
+  }
+
+  /**
+   * Builds a sync {@link RequestBody} for an {@link InputStream} upload, honouring the optional
+   * {@code contentLength} on {@link UploadRequest}. When {@code contentLength} is unspecified
+   * (i.e. not positive), an unknown-length {@link ContentStreamProvider}-based body is returned;
+   * the AWS SDK will buffer chunks internally to support retries.
+   */
+  public RequestBody toRequestBody(UploadRequest uploadRequest, InputStream inputStream) {
+    if (uploadRequest.getContentLength() > 0) {
+      return RequestBody.fromInputStream(inputStream, uploadRequest.getContentLength());
+    }
+    return RequestBody.fromContentProvider(
+        ContentStreamProvider.fromInputStream(inputStream), OCTET_STREAM_MIME);
   }
 
   public PutObjectRequest toRequest(UploadRequest request) {

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreTest.java
@@ -352,6 +352,33 @@ public class AwsBlobStoreTest {
   }
 
   @Test
+  void testDoUploadInputStreamWithoutContentLength() throws java.io.IOException {
+    // contentLength is optional on UploadRequest; when omitted, the request body handed to the
+    // S3 client must be an unknown-length stream, not a zero-length body.
+    doReturn(buildMockPutObjectResponse())
+        .when(mockS3Client)
+        .putObject((PutObjectRequest) any(), (RequestBody) any());
+
+    byte[] content = "payload-without-content-length".getBytes();
+    UploadRequest uploadRequest = new UploadRequest.Builder().withKey("object-1").build();
+
+    UploadResponse response =
+        aws.doUpload(uploadRequest, new java.io.ByteArrayInputStream(content));
+    assertEquals("object-1", response.getKey());
+
+    org.mockito.ArgumentCaptor<RequestBody> captor =
+        org.mockito.ArgumentCaptor.forClass(RequestBody.class);
+    verify(mockS3Client).putObject((PutObjectRequest) any(), captor.capture());
+    RequestBody captured = captor.getValue();
+    assertFalse(
+        captured.optionalContentLength().isPresent(),
+        "RequestBody must report unknown length when contentLength is not supplied");
+    try (InputStream streamed = captured.contentStreamProvider().newStream()) {
+      assertArrayEquals(content, streamed.readAllBytes());
+    }
+  }
+
+  @Test
   void testDoUploadByteArray() {
     doReturn(buildMockPutObjectResponse())
         .when(mockS3Client)

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
@@ -1,5 +1,6 @@
 package com.salesforce.multicloudj.blob.aws;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -48,6 +49,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
@@ -330,6 +332,53 @@ public class AwsTransformerTest {
 
     assertTrue(asyncRequestBody.contentLength().isPresent());
     assertEquals(content.length, asyncRequestBody.contentLength().get());
+  }
+
+  @Test
+  void testToAsyncRequestBodyInputStreamWithoutContentLength() {
+    // When the caller omits contentLength (Optional per UploadRequest javadoc), the SDK must
+    // read the stream to EOF instead of interpreting the primitive default 0 as an empty body.
+    byte[] content = "This is test data".getBytes();
+    InputStream inputStream = new ByteArrayInputStream(content);
+    UploadRequest uploadRequest = UploadRequest.builder().withKey("key").build();
+
+    AsyncRequestBody asyncRequestBody = transformer.toAsyncRequestBody(uploadRequest, inputStream);
+
+    assertFalse(asyncRequestBody.contentLength().isPresent());
+  }
+
+  @Test
+  void testToRequestBodyInputStreamWithContentLength() throws Exception {
+    byte[] content = "This is test data".getBytes();
+    InputStream inputStream = new ByteArrayInputStream(content);
+    UploadRequest uploadRequest =
+        UploadRequest.builder().withKey("key").withContentLength(content.length).build();
+
+    RequestBody requestBody = transformer.toRequestBody(uploadRequest, inputStream);
+
+    assertTrue(requestBody.optionalContentLength().isPresent());
+    assertEquals(content.length, requestBody.optionalContentLength().get());
+    // Bytes streamed through the provider must match the input verbatim.
+    try (InputStream streamed = requestBody.contentStreamProvider().newStream()) {
+      assertArrayEquals(content, streamed.readAllBytes());
+    }
+  }
+
+  @Test
+  void testToRequestBodyInputStreamWithoutContentLength() throws Exception {
+    // Bug reproduction: without withContentLength(...) the previous code called
+    // RequestBody.fromInputStream(stream, 0) which uploads a zero-length body. The fixed
+    // path must produce an unknown-length RequestBody whose bytes still match the input.
+    byte[] content = "This is test data".getBytes();
+    InputStream inputStream = new ByteArrayInputStream(content);
+    UploadRequest uploadRequest = UploadRequest.builder().withKey("key").build();
+
+    RequestBody requestBody = transformer.toRequestBody(uploadRequest, inputStream);
+
+    assertFalse(requestBody.optionalContentLength().isPresent());
+    try (InputStream streamed = requestBody.contentStreamProvider().newStream()) {
+      assertArrayEquals(content, streamed.readAllBytes());
+    }
   }
 
   @Test

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStoreTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStoreTest.java
@@ -493,6 +493,29 @@ public class AwsAsyncBlobStoreTest {
   }
 
   @Test
+  void testDoUploadInputStreamWithoutContentLength()
+      throws ExecutionException, InterruptedException {
+    // contentLength is optional. When omitted the AsyncRequestBody must report unknown length,
+    // otherwise the SDK will interpret the primitive default (0) as a zero-length upload.
+    doReturn(CompletableFuture.completedFuture(buildMockPutObjectResponse()))
+        .when(mockS3Client)
+        .putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class));
+
+    UploadRequest uploadRequest =
+        new UploadRequest.Builder()
+            .withKey("object-1")
+            .withMetadata(java.util.Map.of("key-1", "value-1"))
+            .withTags(java.util.Map.of("tag-1", "value-1"))
+            .build();
+
+    aws.doUpload(uploadRequest, mock(InputStream.class)).get();
+
+    ArgumentCaptor<AsyncRequestBody> bodyCaptor = ArgumentCaptor.forClass(AsyncRequestBody.class);
+    verify(mockS3Client).putObject(any(PutObjectRequest.class), bodyCaptor.capture());
+    assertFalse(bodyCaptor.getValue().contentLength().isPresent());
+  }
+
+  @Test
   void testDoUploadByteArray() throws ExecutionException, InterruptedException {
     doReturn(CompletableFuture.completedFuture(buildMockPutObjectResponse()))
         .when(mockS3Client)

--- a/dbbackuprestore/dbbackuprestore-ali/pom.xml
+++ b/dbbackuprestore/dbbackuprestore-ali/pom.xml
@@ -20,12 +20,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>

--- a/dbbackuprestore/dbbackuprestore-aws/pom.xml
+++ b/dbbackuprestore/dbbackuprestore-aws/pom.xml
@@ -20,12 +20,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>

--- a/dbbackuprestore/dbbackuprestore-gcp-firestore/pom.xml
+++ b/dbbackuprestore/dbbackuprestore-gcp-firestore/pom.xml
@@ -20,12 +20,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>

--- a/docstore/docstore-ali/pom.xml
+++ b/docstore/docstore-ali/pom.xml
@@ -20,12 +20,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>

--- a/docstore/docstore-aws/pom.xml
+++ b/docstore/docstore-aws/pom.xml
@@ -20,12 +20,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>

--- a/docstore/docstore-client/pom.xml
+++ b/docstore/docstore-client/pom.xml
@@ -15,12 +15,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>

--- a/docstore/docstore-client/src/test/java/com/salesforce/multicloudj/docstore/driver/QueryTest.java
+++ b/docstore/docstore-client/src/test/java/com/salesforce/multicloudj/docstore/driver/QueryTest.java
@@ -3,7 +3,7 @@ package com.salesforce.multicloudj.docstore.driver;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import com.salesforce.multicloudj.docstore.client.Query;
 import java.util.ArrayList;

--- a/docstore/docstore-gcp-firestore/pom.xml
+++ b/docstore/docstore-gcp-firestore/pom.xml
@@ -20,12 +20,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>

--- a/docstore/docstore-gcp-spanner/pom.xml
+++ b/docstore/docstore-gcp-spanner/pom.xml
@@ -25,12 +25,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>

--- a/iam/iam-aws/pom.xml
+++ b/iam/iam-aws/pom.xml
@@ -29,12 +29,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Summary

< Provide a brief description of the changes in this PR >

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
