### PR TITLE
docs: build site from latest release tag instead of main

### DIFF
--- a/scripts/generate-site.sh
+++ b/scripts/generate-site.sh
@@ -9,17 +9,39 @@
 
 set -e
 
-VERSION=${1:-$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)}
-TEMP_DIR=$(mktemp -d)
 SITE_BRANCH="site"
-MAIN_BRANCH="main"
+UPSTREAM_REMOTE="upstream"
+
+# 1. Fetch tags from upstream so the latest release is available locally
+echo "Fetching tags from ${UPSTREAM_REMOTE}..."
+git fetch "$UPSTREAM_REMOTE" --tags --prune --prune-tags
+
+# 2. Determine the release tag to build from (arg overrides auto-detect)
+if [ -n "$1" ]; then
+    RELEASE_TAG="$1"
+else
+    RELEASE_TAG=$(git tag -l 'multicloudj-v*' --sort=-v:refname | head -n 1)
+fi
+
+if [ -z "$RELEASE_TAG" ]; then
+    echo "ERROR: could not determine latest release tag (looked for multicloudj-v*)" >&2
+    exit 1
+fi
+
+# Derive the numeric version (e.g. multicloudj-v0.4.0 -> 0.4.0) for output paths
+VERSION="${RELEASE_TAG#multicloudj-v}"
+VERSION="${VERSION#v}"
+
+TEMP_DIR=$(mktemp -d)
 TARGET_DIR="docs/api/java/${VERSION}"
 LATEST_DIR="docs/api/java/latest"
 
-# 1. Checkout main branch
-git checkout "$MAIN_BRANCH"
+echo "Building site for release tag ${RELEASE_TAG} (version ${VERSION})"
 
-# 2. Generate delomboked sources and JavaDoc in temp dir
+# 3. Checkout the release tag (detached HEAD) to build sources from that revision
+git checkout "$RELEASE_TAG"
+
+# 4. Generate delomboked sources and JavaDoc in temp dir
 echo "Generating delomboked sources..."
 mvn clean generate-sources -DskipTests
 
@@ -27,25 +49,25 @@ echo "Generating JavaDoc from delomboked sources..."
 mvn site -DskipTests
 cp -r target/site/apidocs/* "$TEMP_DIR/"
 
-# 3. Checkout site branch
+# 5. Checkout site branch
 git checkout "$SITE_BRANCH"
 
-# 4. Copy JavaDoc to versioned directory (overwrite if exists)
+# 6. Copy JavaDoc to versioned directory (overwrite if exists)
 rm -rf "$TARGET_DIR"
 mkdir -p "$TARGET_DIR"
 cp -r "$TEMP_DIR"/* "$TARGET_DIR/"
 
-# 5. Update latest symlink
+# 7. Update latest symlink
 rm -f "$LATEST_DIR"
 ln -sf "$VERSION" "$LATEST_DIR"
 
-# 6. Generate Jekyll HTML from Markdown sources
+# 8. Generate Jekyll HTML from Markdown sources
 echo "Running Jekyll build..."
 export PATH="/opt/homebrew/opt/ruby@3.3/bin:$PATH"
 bundle install --quiet
 bundle exec jekyll build --destination docs
 
-# 7. Show result
+# 9. Show result
 echo "JavaDoc for version $VERSION copied to $TARGET_DIR (site branch)"
 echo "Latest symlink updated to point to $VERSION"
 echo "Jekyll HTML generated in docs/"


### PR DESCRIPTION
## Summary

- `scripts/generate-site.sh` was checking out `main` before generating JavaDoc / Jekyll HTML, so the published site tracked in-progress work rather than a released version.
- Now the script `git fetch upstream --tags --prune --prune-tags` first, then checks out the latest `multicloudj-v*` tag (or an explicit tag passed as `$1`).
- `VERSION` (used for the `docs/api/java/<version>/` path and the `latest` symlink) is derived from the tag, stripping the `multicloudj-v` / `v` prefix.

## Behavior change

The optional CLI argument used to be a raw version (e.g. `0.4.0`); it is now the tag name (e.g. `multicloudj-v0.4.0`). With no argument the script auto-picks the newest tag.

## Test plan

- [ ] Run `./scripts/generate-site.sh` with no args on a clean checkout — confirms upstream fetch + tag auto-detect + build.
- [ ] Run `./scripts/generate-site.sh multicloudj-v0.3.6` — confirms explicit-tag override checks out the correct revision and writes to `docs/api/java/0.3.6/`.
- [ ] Verify `docs/api/java/latest` symlink points at the version that was just built.