### PR TITLE
blobstore: gcp: switch InputStream upload path to storage.createFrom

### DIFF
--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -7,7 +7,6 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.auth.Credentials;
 import com.google.auto.service.AutoService;
 import com.google.cloud.ReadChannel;
-import com.google.cloud.WriteChannel;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -183,15 +182,17 @@ public class GcpBlobStore extends AbstractBlobStore {
   @Override
   protected UploadResponse doUpload(UploadRequest uploadRequest, InputStream inputStream) {
     rejectUnsupportedChecksum(uploadRequest.getChecksumAlgorithm());
-    try (WriteChannel writer =
-            storage.writer(
-                transformer.toBlobInfo(uploadRequest),
-                transformer.getBlobWriteOptions(uploadRequest));
-         var channel = Channels.newOutputStream(writer)) {
-      ByteStreams.copy(inputStream, channel);
+    try {
+      storage.createFrom(
+          transformer.toBlobInfo(uploadRequest),
+          inputStream,
+          transformer.getBlobWriteOptions(uploadRequest));
     } catch (IOException e) {
       throw new SubstrateSdkException("Request failed while uploading from input stream", e);
     }
+    // Fetch the committed object so the response carries the fully-populated server-side
+    // metadata (generation, retention, hold flags, etag) rather than relying on the
+    // upload-response fields, which some GCS API paths do not fully populate.
     Blob blob = getRequiredBlob(BlobId.of(getBucket(), uploadRequest.getKey()));
     return transformer.toUploadResponse(blob);
   }
@@ -241,17 +242,7 @@ public class GcpBlobStore extends AbstractBlobStore {
     // ReadChannel streaming (parallelDownload is ignored for this overload).
     try (ReadChannel reader = storage.reader(blobId);
         var channel = Channels.newInputStream(reader)) {
-
-      var range =
-          transformer.computeRange(
-              downloadRequest.getStart(), downloadRequest.getEnd(), blob.getSize());
-      if (range.getLeft() != null) {
-        reader.seek(range.getLeft());
-      }
-      if (range.getRight() != null) {
-        reader.limit(range.getRight());
-      }
-
+      applyRange(reader, downloadRequest, blob);
       ByteStreams.copy(channel, outputStream);
       return transformer.toDownloadResponse(blob);
     } catch (IOException e) {
@@ -279,19 +270,41 @@ public class GcpBlobStore extends AbstractBlobStore {
     Blob blob = getRequiredBlobForDownload(downloadRequest);
     try {
       ReadChannel reader = blob.reader();
-      var range =
-          transformer.computeRange(
-              downloadRequest.getStart(), downloadRequest.getEnd(), blob.getSize());
-      if (range.getLeft() != null) {
-        reader.seek(range.getLeft());
-      }
-      if (range.getRight() != null) {
-        reader.limit(range.getRight());
-      }
+      applyRange(reader, downloadRequest, blob);
       InputStream inputStream = Channels.newInputStream(reader);
       return transformer.toDownloadResponse(blob, inputStream);
     } catch (IOException e) {
       throw new SubstrateSdkException("Failed to create input stream for download", e);
+    }
+  }
+
+  /**
+   * Applies the requested byte range to a {@link ReadChannel} before streaming.
+   *
+   * <p>Full-object downloads skip range setup entirely: with no start or end, {@code computeRange}
+   * would return {@code (null, null)} and neither {@code seek} nor {@code limit} would be applied,
+   * so the emitted GCS GET is identical either way. Short-circuiting here avoids a needless
+   * transformer call and keeps the request byte-for-byte the same as a plain full-object read.
+   *
+   * @param reader the channel to position/limit
+   * @param downloadRequest the request carrying the optional start/end offsets
+   * @param blob the resolved blob, used for its size when resolving a suffix range
+   * @throws IOException if positioning the channel fails
+   */
+  private void applyRange(ReadChannel reader, DownloadRequest downloadRequest, Blob blob)
+      throws IOException {
+    boolean hasRange = downloadRequest.getStart() != null || downloadRequest.getEnd() != null;
+    if (!hasRange) {
+      return;
+    }
+    var range =
+        transformer.computeRange(
+            downloadRequest.getStart(), downloadRequest.getEnd(), blob.getSize());
+    if (range.getLeft() != null) {
+      reader.seek(range.getLeft());
+    }
+    if (range.getRight() != null) {
+      reader.limit(range.getRight());
     }
   }
 
@@ -1500,6 +1513,7 @@ public class GcpBlobStore extends AbstractBlobStore {
 
   @Getter
   public static class Builder extends AbstractBlobStore.Builder<GcpBlobStore, Builder> {
+    private static final int DEFAULT_MAX_CONNECTIONS = 50;
 
     private Storage storage;
     private MultipartUploadClient mpuClient;
@@ -1717,10 +1731,10 @@ public class GcpBlobStore extends AbstractBlobStore {
     private static HttpClientConnectionManager buildConnectionManager(Builder builder) {
       PoolingHttpClientConnectionManager connectionManager =
           new PoolingHttpClientConnectionManager();
-      if (builder.getMaxConnections() != null) {
-        connectionManager.setMaxTotal(builder.getMaxConnections());
-        connectionManager.setDefaultMaxPerRoute(builder.getMaxConnections());
-      }
+      int maxConns = builder.getMaxConnections() != null
+          ? builder.getMaxConnections() : DEFAULT_MAX_CONNECTIONS;
+      connectionManager.setMaxTotal(maxConns);
+      connectionManager.setDefaultMaxPerRoute(maxConns);
       return connectionManager;
     }
 

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -29,7 +29,6 @@ import com.google.api.gax.paging.Page;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.cloud.ReadChannel;
-import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -106,6 +105,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
@@ -127,6 +127,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -175,9 +176,6 @@ class GcpBlobStoreTest {
 
   @Mock
   private BlobInfo mockBlobInfo;
-
-  @Mock
-  private WriteChannel mockWriteChannel;
 
   @Mock
   private ReadChannel mockReadChannel;
@@ -274,85 +272,53 @@ class GcpBlobStoreTest {
   }
 
   @Test
-  void testDoUpload_WithInputStream() {
-    try (MockedStatic<ByteStreams> mockedStatic = Mockito.mockStatic(ByteStreams.class)) {
-      // Given
-      UploadRequest uploadRequest = UploadRequest.builder().withKey(TEST_KEY).build();
+  void testDoUpload_WithInputStream() throws IOException {
+    // Given
+    UploadRequest uploadRequest = UploadRequest.builder().withKey(TEST_KEY).build();
 
-      UploadResponse expectedResponse =
-          UploadResponse.builder().key(TEST_KEY).versionId(TEST_VERSION_ID).eTag(TEST_ETAG).build();
+    UploadResponse expectedResponse =
+        UploadResponse.builder().key(TEST_KEY).versionId(TEST_VERSION_ID).eTag(TEST_ETAG).build();
 
-      when(mockTransformer.toBlobInfo(uploadRequest)).thenReturn(mockBlobInfo);
-      when(mockTransformer.getBlobWriteOptions(uploadRequest))
-          .thenReturn(new Storage.BlobWriteOption[0]);
-      when(mockStorage.writer(eq(mockBlobInfo), any(Storage.BlobWriteOption[].class)))
-          .thenReturn(mockWriteChannel);
-      when(mockStorage.get(BlobId.of(TEST_BUCKET, TEST_KEY))).thenReturn(mockBlob);
-      when(mockTransformer.toUploadResponse(mockBlob)).thenReturn(expectedResponse);
+    when(mockTransformer.toBlobInfo(uploadRequest)).thenReturn(mockBlobInfo);
+    when(mockTransformer.getBlobWriteOptions(uploadRequest))
+        .thenReturn(new Storage.BlobWriteOption[0]);
+    when(mockStorage.createFrom(
+        eq(mockBlobInfo), any(InputStream.class), any(Storage.BlobWriteOption[].class)))
+        .thenReturn(mockBlob);
+    // After createFrom, doUpload fetches the committed object to get fully-populated metadata.
+    when(mockStorage.get(any(BlobId.class))).thenReturn(mockBlob);
+    when(mockTransformer.toUploadResponse(mockBlob)).thenReturn(expectedResponse);
 
-      // When
-      UploadResponse response =
-          gcpBlobStore.doUpload(uploadRequest, new ByteArrayInputStream(TEST_CONTENT));
+    // When
+    UploadResponse response =
+        gcpBlobStore.doUpload(uploadRequest, new ByteArrayInputStream(TEST_CONTENT));
 
-      // Then
-      assertEquals(expectedResponse, response);
-      verify(mockStorage).writer(eq(mockBlobInfo), any(Storage.BlobWriteOption[].class));
-      verify(mockStorage).get(BlobId.of(TEST_BUCKET, TEST_KEY));
-      verify(mockTransformer).toUploadResponse(mockBlob);
-    }
+    // Then
+    assertEquals(expectedResponse, response);
+    verify(mockStorage).createFrom(
+        eq(mockBlobInfo), any(InputStream.class), any(Storage.BlobWriteOption[].class));
+    verify(mockStorage).get(any(BlobId.class));
+    verify(mockTransformer).toUploadResponse(mockBlob);
   }
 
   @Test
-  void testDoUpload_WithInputStream_ThrowsException() {
-    try (MockedStatic<ByteStreams> mockedStatic = Mockito.mockStatic(ByteStreams.class)) {
-      // Given
-      UploadRequest uploadRequest = UploadRequest.builder().withKey(TEST_KEY).build();
+  void testDoUpload_WithInputStream_ThrowsException() throws IOException {
+    // Given
+    UploadRequest uploadRequest = UploadRequest.builder().withKey(TEST_KEY).build();
 
-      when(mockTransformer.toBlobInfo(uploadRequest)).thenReturn(mockBlobInfo);
-      when(mockTransformer.getBlobWriteOptions(uploadRequest))
-          .thenReturn(new Storage.BlobWriteOption[0]);
-      when(mockStorage.writer(eq(mockBlobInfo), any(Storage.BlobWriteOption[].class)))
-          .thenReturn(mockWriteChannel);
-      mockedStatic
-          .when(() -> ByteStreams.copy(any(InputStream.class), any(OutputStream.class)))
-          .thenThrow(new IOException("Test exception"));
+    when(mockTransformer.toBlobInfo(uploadRequest)).thenReturn(mockBlobInfo);
+    when(mockTransformer.getBlobWriteOptions(uploadRequest))
+        .thenReturn(new Storage.BlobWriteOption[0]);
+    when(mockStorage.createFrom(
+        eq(mockBlobInfo), any(InputStream.class), any(Storage.BlobWriteOption[].class)))
+        .thenThrow(new IOException("Test exception"));
 
-      // When & Then
-      SubstrateSdkException exception =
-          assertThrows(
-              SubstrateSdkException.class,
-              () -> {
-                gcpBlobStore.doUpload(uploadRequest, new ByteArrayInputStream(TEST_CONTENT));
-              });
-      assertEquals("Request failed while uploading from input stream", exception.getMessage());
-    }
-  }
-
-  @Test
-  void testDoUpload_FileNotFound() {
-    try (MockedStatic<ByteStreams> mockedStatic = Mockito.mockStatic(ByteStreams.class)) {
-      // Given
-      UploadRequest uploadRequest = UploadRequest.builder().withKey(TEST_KEY).build();
-
-      when(mockTransformer.toBlobInfo(uploadRequest)).thenReturn(mockBlobInfo);
-      when(mockTransformer.getBlobWriteOptions(uploadRequest))
-          .thenReturn(new Storage.BlobWriteOption[0]);
-      when(mockStorage.writer(eq(mockBlobInfo), any(Storage.BlobWriteOption[].class)))
-          .thenReturn(mockWriteChannel);
-      when(mockStorage.get(BlobId.of(TEST_BUCKET, TEST_KEY))).thenReturn(null);
-
-      // When
-      ResourceNotFoundException exception =
-          assertThrows(
-              ResourceNotFoundException.class,
-              () -> {
-                gcpBlobStore.doUpload(uploadRequest, new ByteArrayInputStream(TEST_CONTENT));
-              });
-
-      // Then
-      verify(mockStorage).writer(mockBlobInfo);
-      verify(mockStorage).get(BlobId.of(TEST_BUCKET, TEST_KEY));
-    }
+    // When & Then
+    SubstrateSdkException exception =
+        assertThrows(
+            SubstrateSdkException.class,
+            () -> gcpBlobStore.doUpload(uploadRequest, new ByteArrayInputStream(TEST_CONTENT)));
+    assertEquals("Request failed while uploading from input stream", exception.getMessage());
   }
 
   @Test
@@ -480,9 +446,6 @@ class GcpBlobStoreTest {
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockTransformer.toDownloadResponse(mockBlob)).thenReturn(expectedResponse);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
 
       ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
@@ -493,6 +456,7 @@ class GcpBlobStoreTest {
       assertEquals(expectedResponse, response);
       verify(mockStorage).reader(mockBlobId);
       verify(mockStorage).get(mockBlobId);
+      verify(mockTransformer, never()).computeRange(any(), any(), anyLong());
       verify(mockTransformer).toDownloadResponse(mockBlob);
     }
   }
@@ -508,9 +472,6 @@ class GcpBlobStoreTest {
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockTransformer.toDownloadResponse(mockBlob)).thenReturn(expectedResponse);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
 
       ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
       DownloadResponse response = gcpBlobStore.doDownload(downloadRequest, outputStream);
@@ -579,9 +540,6 @@ class GcpBlobStoreTest {
 
       when(mockTransformer.toBlobId(downloadRequest)).thenReturn(mockBlobId);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       mockedStatic
           .when(() -> ByteStreams.copy(any(InputStream.class), any(OutputStream.class)))
@@ -612,9 +570,6 @@ class GcpBlobStoreTest {
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockTransformer.toDownloadResponse(mockBlob)).thenReturn(expectedResponse);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
 
       ByteArray byteArray = new ByteArray();
 
@@ -640,9 +595,6 @@ class GcpBlobStoreTest {
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockTransformer.toDownloadResponse(mockBlob)).thenReturn(expectedResponse);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
 
       // When
       DownloadResponse response = gcpBlobStore.doDownload(downloadRequest, testFile.toFile());
@@ -665,9 +617,6 @@ class GcpBlobStoreTest {
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockTransformer.toDownloadResponse(mockBlob)).thenReturn(expectedResponse);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
 
       // When
       DownloadResponse response = gcpBlobStore.doDownload(downloadRequest, testFile);
@@ -695,9 +644,6 @@ class GcpBlobStoreTest {
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockTransformer.toDownloadResponse(mockBlob)).thenReturn(expectedResponse);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
 
       // When
       DownloadResponse response = gcpBlobStore.doDownload(downloadRequest, destinationRoot);
@@ -770,9 +716,6 @@ class GcpBlobStoreTest {
       when(mockTransformer.toBlobId(downloadRequest)).thenReturn(mockBlobId);
       when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
-      doReturn(new ImmutablePair<>(null, null))
-          .when(mockTransformer)
-          .computeRange(any(), any(), anyLong());
       mockedStatic
           .when(() -> ByteStreams.copy(any(InputStream.class), any(OutputStream.class)))
           .thenThrow(new IOException("Test exception"));
@@ -1850,9 +1793,6 @@ class GcpBlobStoreTest {
       when(mockTransformer.toBlobId(downloadRequest)).thenReturn(mockBlobId);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
       when(mockBlob.reader()).thenReturn(mockReadChannel);
-      when(mockBlob.getSize()).thenReturn(100L);
-      when(mockTransformer.computeRange(any(), any(), anyLong()))
-          .thenReturn(new ImmutablePair<>(null, null));
       when(mockTransformer.toDownloadResponse(eq(mockBlob), any(InputStream.class)))
           .thenReturn(expectedResponse);
 
@@ -1862,7 +1802,7 @@ class GcpBlobStoreTest {
       verify(mockTransformer).toBlobId(downloadRequest);
       verify(mockStorage).get(mockBlobId);
       verify(mockBlob).reader();
-      verify(mockTransformer).computeRange(null, null, 100L);
+      verify(mockTransformer, never()).computeRange(any(), any(), anyLong());
       verify(mockTransformer).toDownloadResponse(eq(mockBlob), any(InputStream.class));
     }
   }
@@ -2342,6 +2282,36 @@ class GcpBlobStoreTest {
 
     assertNotNull(store);
     assertEquals(GcpConstants.PROVIDER_ID, store.getProviderId());
+  }
+
+  @Test
+  void testBuildConnectionManager_defaultsPoolWhenMaxConnectionsUnset() throws Exception {
+    GcpBlobStore.Builder builder = new GcpBlobStore.Builder();
+
+    PoolingHttpClientConnectionManager connectionManager = invokeBuildConnectionManager(builder);
+
+    assertEquals(50, connectionManager.getMaxTotal());
+    assertEquals(50, connectionManager.getDefaultMaxPerRoute());
+  }
+
+  @Test
+  void testBuildConnectionManager_usesExplicitMaxConnections() throws Exception {
+    GcpBlobStore.Builder builder =
+        (GcpBlobStore.Builder) new GcpBlobStore.Builder().withMaxConnections(123);
+
+    PoolingHttpClientConnectionManager connectionManager = invokeBuildConnectionManager(builder);
+
+    assertEquals(123, connectionManager.getMaxTotal());
+    assertEquals(123, connectionManager.getDefaultMaxPerRoute());
+  }
+
+  private static PoolingHttpClientConnectionManager invokeBuildConnectionManager(
+      GcpBlobStore.Builder builder) throws Exception {
+    Method method =
+        GcpBlobStore.Builder.class.getDeclaredMethod(
+            "buildConnectionManager", GcpBlobStore.Builder.class);
+    method.setAccessible(true);
+    return (PoolingHttpClientConnectionManager) method.invoke(null, builder);
   }
 
   private static UploadResult makeUploadResult(String key, TransferStatus status, Exception ex) {


### PR DESCRIPTION
## Summary

The GCS InputStream upload path was the odd one out among our four upload overloads. While byte[], File, and Path all go through storage.createFrom(...) and get the resulting Blob back directly, the InputStream path was still using the older WriteChannel + ByteStreams.copy flow and because WriteChannel doesn't return the Blob on close, we had to follow every upload with an extra storage.get(...) call just to fetch the metadata we needed for the response.

This PR brings the InputStream overload in line with the rest: switch to storage.createFrom(BlobInfo, InputStream, options[]), which completes the upload and returns the Blob in one shot. The extra GET disappears, the four overloads are now consistent, and the WriteChannel import and its associated mock can be cleaned up.
