### PR TITLE
blobstore: gcp: only override HTTP transport when caller configured it

### DIFF
--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -1727,11 +1727,6 @@ public class GcpBlobStore extends AbstractBlobStore {
     }
 
     private static CloseableHttpClient buildHttpClient(Builder builder) {
-      // Start from ApacheHttpTransport.newDefaultHttpClientBuilder() so we inherit GCP's
-      // curated defaults (maxConnTotal=200, maxConnPerRoute=20, useSystemProperties,
-      // SSL socket factory, system-default route planner, redirect/retry disabled) instead
-      // of the raw Apache defaults (maxTotal=20, maxPerRoute=2) that HttpClientBuilder.create()
-      // would give us.
       HttpClientBuilder httpClientBuilder = ApacheHttpTransport.newDefaultHttpClientBuilder();
       httpClientBuilder.setDefaultRequestConfig(buildRequestConfig(builder));
       if (builder.getMaxConnections() != null) {

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -126,10 +126,8 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 import org.apache.http.HttpHost;
 import org.apache.http.client.config.RequestConfig;
-import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1513,7 +1511,6 @@ public class GcpBlobStore extends AbstractBlobStore {
 
   @Getter
   public static class Builder extends AbstractBlobStore.Builder<GcpBlobStore, Builder> {
-    private static final int DEFAULT_MAX_CONNECTIONS = 50;
 
     private Storage storage;
     private MultipartUploadClient mpuClient;
@@ -1603,6 +1600,18 @@ public class GcpBlobStore extends AbstractBlobStore {
       return endpointStr;
     }
 
+    /**
+     * Determines whether the caller has configured any HTTP-transport option that requires us to
+     * override the GCS SDK's default transport. When this returns {@code false}, the SDK's own
+     * default transport (and its default connection pool) is used.
+     */
+    private static boolean shouldConfigureHttpClient(Builder builder) {
+      return builder.getProxyEndpoint() != null
+          || builder.getMaxConnections() != null
+          || builder.getSocketTimeout() != null
+          || builder.getIdleConnectionTimeout() != null;
+    }
+
     /** Creates HttpTransportOptions with ApacheHttpTransport */
     private static HttpTransportOptions buildTransportOptions(Builder builder) {
       CloseableHttpClient httpClient = buildHttpClient(builder);
@@ -1612,10 +1621,10 @@ public class GcpBlobStore extends AbstractBlobStore {
 
     /** Helper function for generating the Storage client */
     private static Storage buildStorage(Builder builder) {
-      HttpTransportOptions transportOptions = buildTransportOptions(builder);
-
       StorageOptions.Builder storageOptionsBuilder = StorageOptions.newBuilder();
-      storageOptionsBuilder.setTransportOptions(transportOptions);
+      if (shouldConfigureHttpClient(builder)) {
+        storageOptionsBuilder.setTransportOptions(buildTransportOptions(builder));
+      }
 
       String endpoint = normalizeEndpoint(builder.getEndpoint());
       if (endpoint != null) {
@@ -1639,10 +1648,10 @@ public class GcpBlobStore extends AbstractBlobStore {
 
     /** Helper function for generating the MultipartUpload client */
     private static MultipartUploadClient buildMultipartUploadClient(Builder builder) {
-      HttpTransportOptions transportOptions = buildTransportOptions(builder);
-
-      HttpStorageOptions.Builder storageOptionsBuilder =
-          HttpStorageOptions.http().setTransportOptions(transportOptions);
+      HttpStorageOptions.Builder storageOptionsBuilder = HttpStorageOptions.http();
+      if (shouldConfigureHttpClient(builder)) {
+        storageOptionsBuilder.setTransportOptions(buildTransportOptions(builder));
+      }
 
       String endpoint = normalizeEndpoint(builder.getEndpoint());
       if (endpoint != null) {
@@ -1718,24 +1727,23 @@ public class GcpBlobStore extends AbstractBlobStore {
     }
 
     private static CloseableHttpClient buildHttpClient(Builder builder) {
-      HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+      // Start from ApacheHttpTransport.newDefaultHttpClientBuilder() so we inherit GCP's
+      // curated defaults (maxConnTotal=200, maxConnPerRoute=20, useSystemProperties,
+      // SSL socket factory, system-default route planner, redirect/retry disabled) instead
+      // of the raw Apache defaults (maxTotal=20, maxPerRoute=2) that HttpClientBuilder.create()
+      // would give us.
+      HttpClientBuilder httpClientBuilder = ApacheHttpTransport.newDefaultHttpClientBuilder();
       httpClientBuilder.setDefaultRequestConfig(buildRequestConfig(builder));
-      httpClientBuilder.setConnectionManager(buildConnectionManager(builder));
+      if (builder.getMaxConnections() != null) {
+        int maxConns = builder.getMaxConnections();
+        httpClientBuilder.setMaxConnTotal(maxConns);
+        httpClientBuilder.setMaxConnPerRoute(maxConns);
+      }
       if (builder.getIdleConnectionTimeout() != null) {
         httpClientBuilder.evictIdleConnections(
             builder.getIdleConnectionTimeout().toMillis(), TimeUnit.MILLISECONDS);
       }
       return httpClientBuilder.build();
-    }
-
-    private static HttpClientConnectionManager buildConnectionManager(Builder builder) {
-      PoolingHttpClientConnectionManager connectionManager =
-          new PoolingHttpClientConnectionManager();
-      int maxConns = builder.getMaxConnections() != null
-          ? builder.getMaxConnections() : DEFAULT_MAX_CONNECTIONS;
-      connectionManager.setMaxTotal(maxConns);
-      connectionManager.setDefaultMaxPerRoute(maxConns);
-      return connectionManager;
     }
 
     private static RequestConfig buildRequestConfig(Builder builder) {

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -127,6 +127,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -2285,33 +2286,91 @@ class GcpBlobStoreTest {
   }
 
   @Test
-  void testBuildConnectionManager_defaultsPoolWhenMaxConnectionsUnset() throws Exception {
+  void testBuildHttpClient_inheritsGcpDefaultsWhenMaxConnectionsUnset() throws Exception {
     GcpBlobStore.Builder builder = new GcpBlobStore.Builder();
 
-    PoolingHttpClientConnectionManager connectionManager = invokeBuildConnectionManager(builder);
+    PoolingHttpClientConnectionManager connectionManager =
+        extractConnectionManager(invokeBuildHttpClient(builder));
 
-    assertEquals(50, connectionManager.getMaxTotal());
-    assertEquals(50, connectionManager.getDefaultMaxPerRoute());
+    // GCP's ApacheHttpTransport.newDefaultHttpClientBuilder() sets 200/20; we must not
+    // override those when the caller did not set maxConnections.
+    assertEquals(200, connectionManager.getMaxTotal());
+    assertEquals(20, connectionManager.getDefaultMaxPerRoute());
   }
 
   @Test
-  void testBuildConnectionManager_usesExplicitMaxConnections() throws Exception {
+  void testBuildHttpClient_usesExplicitMaxConnections() throws Exception {
     GcpBlobStore.Builder builder =
         (GcpBlobStore.Builder) new GcpBlobStore.Builder().withMaxConnections(123);
 
-    PoolingHttpClientConnectionManager connectionManager = invokeBuildConnectionManager(builder);
+    PoolingHttpClientConnectionManager connectionManager =
+        extractConnectionManager(invokeBuildHttpClient(builder));
 
     assertEquals(123, connectionManager.getMaxTotal());
     assertEquals(123, connectionManager.getDefaultMaxPerRoute());
   }
 
-  private static PoolingHttpClientConnectionManager invokeBuildConnectionManager(
-      GcpBlobStore.Builder builder) throws Exception {
+  private static CloseableHttpClient invokeBuildHttpClient(GcpBlobStore.Builder builder)
+      throws Exception {
     Method method =
         GcpBlobStore.Builder.class.getDeclaredMethod(
-            "buildConnectionManager", GcpBlobStore.Builder.class);
+            "buildHttpClient", GcpBlobStore.Builder.class);
     method.setAccessible(true);
-    return (PoolingHttpClientConnectionManager) method.invoke(null, builder);
+    return (CloseableHttpClient) method.invoke(null, builder);
+  }
+
+  private static PoolingHttpClientConnectionManager extractConnectionManager(
+      CloseableHttpClient httpClient) throws Exception {
+    // Apache's InternalHttpClient holds the connection manager on a private "connManager" field.
+    java.lang.reflect.Field field = httpClient.getClass().getDeclaredField("connManager");
+    field.setAccessible(true);
+    return (PoolingHttpClientConnectionManager) field.get(httpClient);
+  }
+
+  @Test
+  void testShouldConfigureHttpClient_falseWhenNothingSet() throws Exception {
+    GcpBlobStore.Builder builder = new GcpBlobStore.Builder();
+    assertFalse(invokeShouldConfigureHttpClient(builder));
+  }
+
+  @Test
+  void testShouldConfigureHttpClient_trueWhenMaxConnectionsSet() throws Exception {
+    GcpBlobStore.Builder builder =
+        (GcpBlobStore.Builder) new GcpBlobStore.Builder().withMaxConnections(10);
+    assertTrue(invokeShouldConfigureHttpClient(builder));
+  }
+
+  @Test
+  void testShouldConfigureHttpClient_trueWhenSocketTimeoutSet() throws Exception {
+    GcpBlobStore.Builder builder =
+        (GcpBlobStore.Builder)
+            new GcpBlobStore.Builder().withSocketTimeout(Duration.ofSeconds(5));
+    assertTrue(invokeShouldConfigureHttpClient(builder));
+  }
+
+  @Test
+  void testShouldConfigureHttpClient_trueWhenIdleConnectionTimeoutSet() throws Exception {
+    GcpBlobStore.Builder builder =
+        (GcpBlobStore.Builder)
+            new GcpBlobStore.Builder().withIdleConnectionTimeout(Duration.ofSeconds(5));
+    assertTrue(invokeShouldConfigureHttpClient(builder));
+  }
+
+  @Test
+  void testShouldConfigureHttpClient_trueWhenProxyEndpointSet() throws Exception {
+    GcpBlobStore.Builder builder =
+        (GcpBlobStore.Builder)
+            new GcpBlobStore.Builder().withProxyEndpoint(URI.create("http://proxy.example:3128"));
+    assertTrue(invokeShouldConfigureHttpClient(builder));
+  }
+
+  private static boolean invokeShouldConfigureHttpClient(GcpBlobStore.Builder builder)
+      throws Exception {
+    Method method =
+        GcpBlobStore.Builder.class.getDeclaredMethod(
+            "shouldConfigureHttpClient", GcpBlobStore.Builder.class);
+    method.setAccessible(true);
+    return (Boolean) method.invoke(null, builder);
   }
 
   private static UploadResult makeUploadResult(String key, TransferStatus status, Exception ex) {

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -105,6 +105,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
@@ -2322,7 +2323,7 @@ class GcpBlobStoreTest {
   private static PoolingHttpClientConnectionManager extractConnectionManager(
       CloseableHttpClient httpClient) throws Exception {
     // Apache's InternalHttpClient holds the connection manager on a private "connManager" field.
-    java.lang.reflect.Field field = httpClient.getClass().getDeclaredField("connManager");
+    Field field = httpClient.getClass().getDeclaredField("connManager");
     field.setAccessible(true);
     return (PoolingHttpClientConnectionManager) field.get(httpClient);
   }


### PR DESCRIPTION
## Summary

- `GcpBlobStore.Builder` unconditionally installed a custom Apache `ApacheHttpTransport` and hardcoded a 50-connection pool. Behind the scenes it built the Apache client from `HttpClientBuilder.create()` + a private `PoolingHttpClientConnectionManager`, so it skipped GCP's own curated defaults (`maxConnTotal=200`, `maxConnPerRoute=20`, `useSystemProperties`, SSL socket factory, `SystemDefaultRoutePlanner`, redirect/retry disabled) and inherited Apache's raw `20/2`. The hardcoded `50` was compensating for that lost setup.
- Align with `AwsBlobStore`'s pattern: only override the SDK's default transport when the caller actually configured an HTTP option (`proxyEndpoint`, `maxConnections`, `socketTimeout`, or `idleConnectionTimeout`). When we do take the custom path, seed the builder from `ApacheHttpTransport.newDefaultHttpClientBuilder()` so GCP's defaults apply, and only tweak `setMaxConnTotal` / `setMaxConnPerRoute` when the caller set `maxConnections`.
- Drop the hardcoded `DEFAULT_MAX_CONNECTIONS = 50` and the manual `PoolingHttpClientConnectionManager` construction.

## Behavior change

| Caller configured                          | Before                                             | After                                                        |
| ------------------------------------------ | -------------------------------------------------- | ------------------------------------------------------------ |
| Nothing HTTP-related                       | Apache transport, pool `50/50`                     | GCS SDK's default transport (`NetHttpTransport`, its own pool) |
| Only proxy / socket / idle timeout         | Apache transport, pool `50/50`                     | Apache transport, pool `200/20` (GCP default)                |
| `maxConnections=N`                         | Apache transport, pool `N/N`                       | Apache transport, pool `N/N` (unchanged)                     |

Existing callers relying on the implicit `50` now get either the GCS SDK's default transport or GCP's `200/20` — both strictly more capable than the previous behavior. Callers who need a specific pool size should continue setting `withMaxConnections(...)` explicitly.

## Test plan

- [x] `mvn test -pl blob/blob-gcp -Dtest=GcpBlobStoreTest` — 169 tests pass
- [x] New unit tests cover the `shouldConfigureHttpClient` gate (5 cases) and assert:
  - `buildHttpClient` inherits GCP's `200/20` pool when `maxConnections` is unset
  - `buildHttpClient` applies the caller's value to both total and per-route when `maxConnections` is set
- [ ] Run conformance tests in replay mode: `mvn test -pl blob/blob-gcp -Dtest=GcpBlobStoreIT`
- [ ] Sanity-check with a live GCS bucket if reviewer wants confirmation that the default-transport path is functional end-to-end