### PR TITLE
blob: add ADAPTIVE retry mode with cross-cloud fallback safety

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -42,9 +42,8 @@ import com.aliyun.sdk.service.oss2.models.TagSet;
 import com.aliyun.sdk.service.oss2.models.Tagging;
 import com.aliyun.sdk.service.oss2.models.UploadPartRequest;
 import com.aliyun.sdk.service.oss2.models.UploadPartResult;
-import com.aliyun.sdk.service.oss2.retry.BackoffDelayer;
-import com.aliyun.sdk.service.oss2.retry.EqualJitterBackoff;
 import com.aliyun.sdk.service.oss2.retry.FixedDelayBackoff;
+import com.aliyun.sdk.service.oss2.retry.FullJitterBackoff;
 import com.aliyun.sdk.service.oss2.retry.Retryer;
 import com.aliyun.sdk.service.oss2.retry.StandardRetryer;
 import com.aliyun.sdk.service.oss2.transport.BinaryData;
@@ -88,9 +87,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Getter
 public class AliTransformer {
+
+  private static final Logger logger = LoggerFactory.getLogger(AliTransformer.class);
 
   private static final String SERVER_SIDE_ENCRYPTION_KMS = "KMS";
 
@@ -757,15 +760,17 @@ public class AliTransformer {
    *
    * <p>Mapping:
    * <ul>
-   *   <li>EXPONENTIAL mode → {@link EqualJitterBackoff} with baseDelay and maxBackoff</li>
+   *   <li>EXPONENTIAL mode → {@link FullJitterBackoff} with baseDelay and maxBackoff</li>
    *   <li>FIXED mode → {@link FixedDelayBackoff} with constant delay</li>
+   *   <li>ADAPTIVE mode → no native equivalent in the OSS v2 SDK; the StandardRetryer default
+   *       backoff is left in place (safe no-op, never throws)</li>
    *   <li>maxAttempts → {@link StandardRetryer.Builder#maxAttempts(Integer)}</li>
    * </ul>
    *
    * <p>Note: The Ali OSS v2 SDK does not support a totalTimeout equivalent (a hard deadline
    * across all retry attempts combined). This field from RetryConfig is not applied. The
    * attemptTimeout is handled separately via readWriteTimeout on the client builder.
-   * The multiplier field is not directly configurable — EqualJitterBackoff uses 2x internally.
+   * The multiplier field is not directly configurable — FullJitterBackoff uses 2x internally.
    */
   public static Retryer toAliRetryer(RetryConfig config) {
     if (config == null) {
@@ -783,33 +788,45 @@ public class AliTransformer {
       builder.maxAttempts(config.getMaxAttempts());
     }
 
-    if (config.getMode() != null) {
-      BackoffDelayer backoff;
-      if (config.getMode() == RetryConfig.Mode.EXPONENTIAL) {
-        if (config.getInitialDelayMillis() <= 0) {
-          throw new InvalidArgumentException(
-              "RetryConfig.initialDelayMillis must be greater than 0 for EXPONENTIAL mode, got: "
-                  + config.getInitialDelayMillis());
-        }
-        if (config.getMaxDelayMillis() <= 0) {
-          throw new InvalidArgumentException(
-              "RetryConfig.maxDelayMillis must be greater than 0 for EXPONENTIAL mode, got: "
-                  + config.getMaxDelayMillis());
-        }
-        backoff = new EqualJitterBackoff(
-            Duration.ofMillis(config.getInitialDelayMillis()),
-            Duration.ofMillis(config.getMaxDelayMillis()));
-      } else {
-        if (config.getFixedDelayMillis() <= 0) {
-          throw new InvalidArgumentException(
-              "RetryConfig.fixedDelayMillis must be greater than 0 for FIXED mode, got: "
-                  + config.getFixedDelayMillis());
-        }
-        backoff = new FixedDelayBackoff(
-            Duration.ofMillis(config.getFixedDelayMillis()));
+    if (config.getMode() == RetryConfig.Mode.EXPONENTIAL) {
+      if (config.getInitialDelayMillis() <= 0) {
+        throw new InvalidArgumentException(
+            "RetryConfig.initialDelayMillis must be greater than 0 for EXPONENTIAL mode, got: "
+                + config.getInitialDelayMillis());
       }
-      builder.backoffDelayer(backoff);
+      if (config.getMaxDelayMillis() <= 0) {
+        throw new InvalidArgumentException(
+            "RetryConfig.maxDelayMillis must be greater than 0 for EXPONENTIAL mode, got: "
+                + config.getMaxDelayMillis());
+      }
+      builder.backoffDelayer(new FullJitterBackoff(
+          Duration.ofMillis(config.getInitialDelayMillis()),
+          Duration.ofMillis(config.getMaxDelayMillis())));
+    } else if (config.getMode() == RetryConfig.Mode.FIXED) {
+      if (config.getFixedDelayMillis() <= 0) {
+        throw new InvalidArgumentException(
+            "RetryConfig.fixedDelayMillis must be greater than 0 for FIXED mode, got: "
+                + config.getFixedDelayMillis());
+      }
+      builder.backoffDelayer(new FixedDelayBackoff(
+          Duration.ofMillis(config.getFixedDelayMillis())));
+    } else if (config.getMode() == RetryConfig.Mode.ADAPTIVE) {
+      // ADAPTIVE mode has no native equivalent in the Ali OSS v2 SDK, which offers only static
+      // backoff delayers and no client-side rate-limiting controller. Leave the StandardRetryer's
+      // default backoff in place rather than approximate it. maxAttempts above still applies.
+      if (config.isRequireAdaptive()) {
+        throw new UnSupportedOperationException(
+            "RetryConfig.mode=ADAPTIVE with requireAdaptive=true is not supported by the Ali OSS "
+                + "v2 SDK, which has no native adaptive/token-bucket retry controller. Either "
+                + "clear requireAdaptive to allow the default-backoff fallback, or use EXPONENTIAL "
+                + "or FIXED mode for this provider.");
+      }
+      logger.warn(
+          "RetryConfig.mode=ADAPTIVE has no native equivalent in the Ali OSS v2 SDK; falling back "
+              + "to the default backoff. Client-side adaptive rate-limiting is NOT in effect. Set "
+              + "requireAdaptive=true to fail fast instead of degrading silently.");
     }
+    // A null mode keeps the StandardRetryer default backoff.
 
     return builder.build();
   }

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -868,10 +868,10 @@ public class AliTransformerTest {
 
     assertNotNull(retryer);
     assertEquals(5, retryer.maxAttempts());
-    // Verify delay is within expected range (EqualJitterBackoff adds jitter)
+    // Verify delay is within expected range (FullJitterBackoff draws uniformly from [0, cap))
     Duration delay = retryer.retryDelay(1, new RuntimeException("test"));
     assertNotNull(delay);
-    assertTrue(delay.toMillis() >= 100);
+    assertTrue(delay.toMillis() >= 0);
     assertTrue(delay.toMillis() <= 10000);
   }
 
@@ -913,6 +913,36 @@ public class AliTransformerTest {
     assertNotNull(delay);
     assertTrue(delay.toMillis() > 0,
         "Default backoff should produce a positive delay, got: " + delay.toMillis());
+  }
+
+  @Test
+  void testToAliRetryerAdaptiveModeUsesDefaults() {
+    RetryConfig config = RetryConfig.builder()
+        .mode(RetryConfig.Mode.ADAPTIVE)
+        .maxAttempts(4)
+        .build();
+
+    var retryer = AliTransformer.toAliRetryer(config);
+
+    assertNotNull(retryer);
+    assertEquals(4, retryer.maxAttempts());
+    Duration delay = retryer.retryDelay(1, new RuntimeException("test"));
+    assertNotNull(delay);
+    assertTrue(delay.toMillis() > 0,
+        "Default backoff should produce a positive delay, got: " + delay.toMillis());
+  }
+
+  @Test
+  void testToAliRetryerAdaptiveRequiredFailsFast() {
+    // requireAdaptive=true must reject the silent fallback on a provider with no native adaptive
+    // controller, so a config that assumes adaptive protection can never run without it.
+    RetryConfig config = RetryConfig.builder()
+        .mode(RetryConfig.Mode.ADAPTIVE)
+        .requireAdaptive(true)
+        .maxAttempts(4)
+        .build();
+
+    assertThrows(UnSupportedOperationException.class, () -> AliTransformer.toAliRetryer(config));
   }
 
   @Test

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -58,6 +58,7 @@ import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.retries.AdaptiveRetryStrategy;
 import software.amazon.awssdk.retries.StandardRetryStrategy;
 import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.retries.api.RetryStrategy;
@@ -980,7 +981,10 @@ public class AwsTransformer {
   }
 
   /**
-   * Converts MultiCloudJ RetryConfig to AWS SDK RetryStrategy
+   * Converts MultiCloudJ RetryConfig to AWS SDK RetryStrategy. EXPONENTIAL and FIXED modes produce
+   * a {@link StandardRetryStrategy} with the corresponding backoff; ADAPTIVE mode produces an
+   * {@link AdaptiveRetryStrategy} that throttles the client request rate under server-side
+   * throttling. A null mode uses the SDK default backoff.
    *
    * @param retryConfig The retry configuration to convert
    * @return AWS SDK RetryStrategy
@@ -1005,6 +1009,14 @@ public class AwsTransformer {
     // If mode is not set, use AWS SDK's default backoff strategy
     if (retryConfig.getMode() == null) {
       return strategyBuilder.build();
+    }
+
+    if (retryConfig.getMode() == RetryConfig.Mode.ADAPTIVE) {
+      AdaptiveRetryStrategy.Builder adaptiveBuilder = AdaptiveRetryStrategy.builder();
+      if (retryConfig.getMaxAttempts() != null) {
+        adaptiveBuilder.maxAttempts(retryConfig.getMaxAttempts());
+      }
+      return adaptiveBuilder.build();
     }
 
     // Configure backoff strategy based on mode

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
@@ -3,6 +3,7 @@ package com.salesforce.multicloudj.blob.aws;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -50,6 +51,8 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.retries.AdaptiveRetryStrategy;
+import software.amazon.awssdk.retries.StandardRetryStrategy;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
@@ -1426,6 +1429,63 @@ public class AwsTransformerTest {
     RetryStrategy strategy = transformer.toAwsRetryStrategy(config);
 
     assertNotNull(strategy);
+  }
+
+  @Test
+  void testToAwsRetryStrategyWithAdaptiveMode() {
+    RetryConfig config =
+        RetryConfig.builder().mode(RetryConfig.Mode.ADAPTIVE).maxAttempts(4).build();
+
+    RetryStrategy strategy = transformer.toAwsRetryStrategy(config);
+
+    assertNotNull(strategy);
+    assertInstanceOf(
+        AdaptiveRetryStrategy.class,
+        strategy,
+        "REGRESSION GUARD: downstream consumers rely on AWS adaptive rate-limiting. ADAPTIVE mode "
+            + "must map to AdaptiveRetryStrategy — do not downgrade it to StandardRetryStrategy.");
+  }
+
+  @Test
+  void testToAwsRetryStrategyAdaptiveRequiredStillAdaptive() {
+    RetryConfig config =
+        RetryConfig.builder()
+            .mode(RetryConfig.Mode.ADAPTIVE)
+            .requireAdaptive(true)
+            .maxAttempts(4)
+            .build();
+
+    RetryStrategy strategy = transformer.toAwsRetryStrategy(config);
+
+    assertInstanceOf(
+        AdaptiveRetryStrategy.class,
+        strategy,
+        "REGRESSION GUARD: requireAdaptive=true must be honored natively on AWS, not rejected.");
+  }
+
+  @Test
+  void testToAwsRetryStrategyAdaptiveWithoutMaxAttempts() {
+    RetryConfig config = RetryConfig.builder().mode(RetryConfig.Mode.ADAPTIVE).build();
+
+    RetryStrategy strategy = transformer.toAwsRetryStrategy(config);
+
+    assertInstanceOf(AdaptiveRetryStrategy.class, strategy);
+  }
+
+  @Test
+  void testToAwsRetryStrategyExponentialIsStandardNotAdaptive() {
+    RetryConfig config =
+        RetryConfig.builder()
+            .mode(RetryConfig.Mode.EXPONENTIAL)
+            .maxAttempts(3)
+            .initialDelayMillis(100L)
+            .multiplier(2.0)
+            .maxDelayMillis(5000L)
+            .build();
+
+    RetryStrategy strategy = transformer.toAwsRetryStrategy(config);
+
+    assertInstanceOf(StandardRetryStrategy.class, strategy);
   }
 
   @Test

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpTransformer.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpTransformer.java
@@ -27,6 +27,7 @@ import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.retries.RetryConfig;
 import com.salesforce.multicloudj.common.util.HexUtil;
 import java.io.IOException;
@@ -50,9 +51,13 @@ import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Getter
 public class GcpTransformer {
+
+  private static final Logger logger = LoggerFactory.getLogger(GcpTransformer.class);
 
   private final String bucket;
   private static final String TAG_PREFIX = "gcp-tag-";
@@ -582,6 +587,22 @@ public class GcpTransformer {
           .setInitialRetryDelayDuration(Duration.ofMillis(retryConfig.getFixedDelayMillis()))
           .setRetryDelayMultiplier(1.0)
           .setMaxRetryDelayDuration(Duration.ofMillis(retryConfig.getFixedDelayMillis()));
+    } else if (retryConfig.getMode() == RetryConfig.Mode.ADAPTIVE) {
+      // ADAPTIVE mode has no native equivalent in the GCP RetrySettings model, which exposes only
+      // a static exponential-backoff curve and no client-side rate-limiting controller. Rather than
+      // approximate it (which would misrepresent the requested behavior), leave the SDK's default
+      // backoff in place. maxAttempts, totalTimeout and attemptTimeout below still apply.
+      if (retryConfig.isRequireAdaptive()) {
+        throw new UnSupportedOperationException(
+            "RetryConfig.mode=ADAPTIVE with requireAdaptive=true is not supported by the GCP "
+                + "storage SDK, which has no native adaptive/token-bucket retry controller. Either "
+                + "clear requireAdaptive to allow the default-backoff fallback, or use EXPONENTIAL "
+                + "or FIXED mode for this provider.");
+      }
+      logger.warn(
+          "RetryConfig.mode=ADAPTIVE has no native equivalent in the GCP storage SDK; falling back "
+              + "to the default backoff. Client-side adaptive rate-limiting is NOT in effect. Set "
+              + "requireAdaptive=true to fail fast instead of degrading silently.");
     }
 
     // Set total timeout if provided

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpTransformerTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpTransformerTest.java
@@ -32,6 +32,7 @@ import com.salesforce.multicloudj.blob.driver.RetentionMode;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.observability.OperationContext;
 import com.salesforce.multicloudj.common.retries.RetryConfig;
 import java.io.File;
@@ -2099,6 +2100,34 @@ class GcpTransformerTest {
     assertEquals(Duration.ofMillis(1000), settings.getInitialRetryDelayDuration());
     assertEquals(1.0, settings.getRetryDelayMultiplier());
     assertEquals(Duration.ofMillis(1000), settings.getMaxRetryDelayDuration());
+  }
+
+  @Test
+  public void testToGcpRetrySettings_Adaptive() {
+    RetryConfig retryConfig =
+        RetryConfig.builder().mode(RetryConfig.Mode.ADAPTIVE).maxAttempts(4).build();
+
+    RetrySettings settings = transformer.toGcpRetrySettings(retryConfig);
+
+    assertNotNull(settings);
+    assertEquals(4, settings.getMaxAttempts());
+    assertEquals(1.0, settings.getRetryDelayMultiplier());
+  }
+
+  @Test
+  public void testToGcpRetrySettings_AdaptiveRequiredFailsFast() {
+    // requireAdaptive=true must reject the silent fallback on a provider with no native adaptive
+    // controller, so a config that assumes adaptive protection can never run without it.
+    RetryConfig retryConfig =
+        RetryConfig.builder()
+            .mode(RetryConfig.Mode.ADAPTIVE)
+            .requireAdaptive(true)
+            .maxAttempts(4)
+            .build();
+
+    assertThrows(
+        UnSupportedOperationException.class,
+        () -> transformer.toGcpRetrySettings(retryConfig));
   }
 
   @Test

--- a/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/retries/RetryConfig.java
+++ b/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/retries/RetryConfig.java
@@ -10,12 +10,15 @@ import lombok.Getter;
  * cloud providers and services. It abstracts provider-specific retry mechanisms into a common model
  * that can be translated to native retry configurations for each cloud provider.
  *
- * <p>Supports two retry modes:
+ * <p>Supports three retry modes:
  *
  * <ul>
  *   <li><b>EXPONENTIAL</b>: Delay between retries grows exponentially using the formula: {@code
  *       delay = min(maxDelayMillis, initialDelayMillis * multiplier^(attempt-1))}
  *   <li><b>FIXED</b>: Constant delay between retries using {@code fixedDelayMillis}
+ *   <li><b>ADAPTIVE</b>: Rate-limit-aware backoff that dynamically throttles the client request
+ *       rate based on observed throttling, gracefully recovering from server-side rate limiting.
+ *       Provider support varies (see {@link Mode#ADAPTIVE}).
  * </ul>
  *
  * <p>Example usage:
@@ -59,6 +62,24 @@ public final class RetryConfig {
      * <p>Requires: {@code fixedDelayMillis}
      */
     FIXED,
+
+    /**
+     * Adaptive mode: rate-limit-aware backoff. Instead of a fixed delay curve, the client
+     * dynamically throttles its own request rate based on observed server-side throttling
+     * (e.g. HTTP 503 SlowDown), smoothing recovery and avoiding client-side retry storms that
+     * amplify congestion under sustained rate limiting.
+     *
+     * <p>The delay-shaping fields ({@code initialDelayMillis}, {@code multiplier},
+     * {@code maxDelayMillis}, {@code fixedDelayMillis}) do not apply; the adaptive controller
+     * manages timing internally. {@code maxAttempts} is still honored when set.
+     *
+     * <p>Provider support: honored natively where the provider SDK offers an adaptive/token-bucket
+     * retry controller. Where a provider SDK has no adaptive equivalent, this value degrades to the
+     * provider's default backoff. By default the degrade is silent; set {@code requireAdaptive} to
+     * turn it into a fail-fast so a config that assumes adaptive protection cannot run without it
+     * (see {@link RetryConfig#isRequireAdaptive()}).
+     */
+    ADAPTIVE,
   }
 
   /** The retry mode determining delay calculation strategy. */
@@ -108,4 +129,13 @@ public final class RetryConfig {
    * reached. If null, no total timeout limit is applied.
    */
   private final Long totalTimeout;
+
+  /**
+   * When {@code true}, requires that {@link Mode#ADAPTIVE} is honored by a native adaptive retry
+   * controller. Providers whose SDK has no adaptive equivalent throw instead of silently degrading
+   * to their default backoff. Set this when adaptive rate-limiting is a hard requirement and a
+   * silent fallback would be a regression. Ignored for {@code EXPONENTIAL}, {@code FIXED}, and null
+   * modes. Defaults to {@code false} (silent fallback with a warning log).
+   */
+  private final boolean requireAdaptive;
 }

--- a/multicloudj-common/src/test/java/com/salesforce/multicloudj/common/retries/RetryConfigTest.java
+++ b/multicloudj-common/src/test/java/com/salesforce/multicloudj/common/retries/RetryConfigTest.java
@@ -99,8 +99,9 @@ class RetryConfigTest {
 
   @Test
   void testModeEnum() {
-    assertEquals(2, RetryConfig.Mode.values().length);
+    assertEquals(3, RetryConfig.Mode.values().length);
     assertEquals(RetryConfig.Mode.EXPONENTIAL, RetryConfig.Mode.valueOf("EXPONENTIAL"));
     assertEquals(RetryConfig.Mode.FIXED, RetryConfig.Mode.valueOf("FIXED"));
+    assertEquals(RetryConfig.Mode.ADAPTIVE, RetryConfig.Mode.valueOf("ADAPTIVE"));
   }
 }


### PR DESCRIPTION
## Summary

Adds a rate-limit-aware ADAPTIVE retry mode to `RetryConfig` (alongside EXPONENTIAL/FIXED) and wires it through AWS, GCP, and Alibaba blob stores.
  - Graceful recovery under throttling; Adaptive mode throttles the client's own request rate on server-side `503 SlowDown` instead of retry-storming a stressed endpoint; lower tail latency, protected shared-endpoint availability.
  - Native where supported, safe where not; AWS uses the SDK's `AdaptiveRetryStrategy`. GCP/Alibaba have no equivalent, so they fall back to default backoff + warning; `requireAdaptive=true` makes them fail fast instead of running unprotected.
  - Alibaba EXPONENTIAL -> full jitter; for better retry distribution.
  - No breaking changes; additive to the existing builder API.
