### PR TITLE
chore: remove gRPC dependencies from ali commons

### DIFF
--- a/iam/iam-gcp/src/test/java/com/salesforce/multicloudj/iam/gcp/GcpIamIT.java
+++ b/iam/iam-gcp/src/test/java/com/salesforce/multicloudj/iam/gcp/GcpIamIT.java
@@ -1,8 +1,8 @@
 package com.salesforce.multicloudj.iam.gcp;
 
+import static com.salesforce.multicloudj.common.gcp.util.WiremockGrpcUtil.getGrpcTransportChannelWithRecordingInterceptor;
+import static com.salesforce.multicloudj.common.gcp.util.WiremockGrpcUtil.initializeWireMockGrpcService;
 import static com.salesforce.multicloudj.common.util.common.TestsUtil.getCurrentTestPrefix;
-import static com.salesforce.multicloudj.common.util.common.WiremockGrpcUtil.getGrpcTransportChannelWithRecordingInterceptor;
-import static com.salesforce.multicloudj.common.util.common.WiremockGrpcUtil.initializeWireMockGrpcService;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;

--- a/multicloudj-common-ali/src/test/java/com/salesforce/multicloudj/common/ali/util/TestsUtilAli.java
+++ b/multicloudj-common-ali/src/test/java/com/salesforce/multicloudj/common/ali/util/TestsUtilAli.java
@@ -1,4 +1,4 @@
-package com.salesforce.multicloudj.common.util.ali;
+package com.salesforce.multicloudj.common.ali.util;
 
 import java.security.cert.X509Certificate;
 import javax.net.ssl.X509TrustManager;

--- a/multicloudj-common-gcp/pom.xml
+++ b/multicloudj-common-gcp/pom.xml
@@ -62,6 +62,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-grpc-extension</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.salesforce.multicloudj</groupId>
             <artifactId>multicloudj-common</artifactId>
         </dependency>

--- a/multicloudj-common-gcp/src/test/java/com/salesforce/multicloudj/common/gcp/util/WiremockGrpcUtil.java
+++ b/multicloudj-common-gcp/src/test/java/com/salesforce/multicloudj/common/gcp/util/WiremockGrpcUtil.java
@@ -1,4 +1,4 @@
-package com.salesforce.multicloudj.common.util.common;
+package com.salesforce.multicloudj.common.gcp.util;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static org.wiremock.grpc.dsl.WireMockGrpc.json;

--- a/multicloudj-common/pom.xml
+++ b/multicloudj-common/pom.xml
@@ -31,27 +31,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wiremock</groupId>
-            <artifactId>wiremock-grpc-extension</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.25.5</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.google.api</groupId>
-            <artifactId>gax-grpc</artifactId>
-            <version>2.65.0</version>
-        </dependency>
-        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <exclusions>

--- a/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsIT.java
+++ b/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsIT.java
@@ -3,7 +3,7 @@ package com.salesforce.multicloudj.sts.ali;
 import com.aliyuncs.DefaultAcsClient;
 import com.aliyuncs.http.HttpClientConfig;
 import com.aliyuncs.profile.DefaultProfile;
-import com.salesforce.multicloudj.common.util.ali.TestsUtilAli;
+import com.salesforce.multicloudj.common.ali.util.TestsUtilAli;
 import com.salesforce.multicloudj.common.util.common.TestsUtil;
 import com.salesforce.multicloudj.sts.client.AbstractStsIT;
 import com.salesforce.multicloudj.sts.driver.AbstractSts;


### PR DESCRIPTION
## Summary
The PR removed the gRPC dependencies from the ali common module since these dependencies are google specific. 

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
