### PR TITLE
docstore: remove explicit flatbuffers-java dependency from all docstore modules

### DIFF
--- a/docstore/docstore-ali/pom.xml
+++ b/docstore/docstore-ali/pom.xml
@@ -172,17 +172,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.google.flatbuffers</groupId>
-            <artifactId>flatbuffers-java</artifactId>
-            <version>1.12.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>failureaccess</artifactId>
             <version>1.0.1</version>

--- a/docstore/docstore-aws/pom.xml
+++ b/docstore/docstore-aws/pom.xml
@@ -182,17 +182,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.google.flatbuffers</groupId>
-            <artifactId>flatbuffers-java</artifactId>
-            <version>1.12.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>failureaccess</artifactId>
             <version>1.0.1</version>

--- a/docstore/docstore-gcp-firestore/pom.xml
+++ b/docstore/docstore-gcp-firestore/pom.xml
@@ -178,17 +178,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.google.flatbuffers</groupId>
-            <artifactId>flatbuffers-java</artifactId>
-            <version>1.12.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>failureaccess</artifactId>
             <version>1.0.1</version>

--- a/docstore/docstore-gcp-spanner/pom.xml
+++ b/docstore/docstore-gcp-spanner/pom.xml
@@ -157,17 +157,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.google.flatbuffers</groupId>
-            <artifactId>flatbuffers-java</artifactId>
-            <version>1.12.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>failureaccess</artifactId>
             <version>1.0.1</version>


### PR DESCRIPTION
## Summary

Removes the explicit `com.google.flatbuffers:flatbuffers-java` dependency from all four docstore modules (`docstore-ali`, `docstore-aws`, `docstore-gcp-firestore`, `docstore-gcp-spanner`), where it was pinned to `1.12.0`.

This dependency was unnecessary in three of the modules and actively incorrect in the fourth:

- **docstore-aws / docstore-gcp-firestore / docstore-gcp-spanner:** nothing on their classpath uses flatbuffers. The explicit dependency resolved to a leaf artifact with no consumer, so removing it leaves zero flatbuffers on the classpath.
- **docstore-ali:** the Tablestore SDK (5.17.x) transitively depends on `flatbuffers-java:1.11.0`, which is the version its generated SQL PlainBuffer classes are compiled against (they access `com.google.flatbuffers.Table.vtable_start`, which is package-accessible in 1.11.0 but became `private` in 1.12.0). Forcing `1.12.0` caused an `IllegalAccessError` when executing SQL queries. Removing the explicit pin lets Tablestore supply the correct `1.11.0` transitively, so the version tracks the SDK automatically instead of drifting.

## Changes

- Deleted the `flatbuffers-java` `<dependency>` block from the four docstore module POMs (4 files, 44 deletions).

## Testing

- `mvn verify` passes for all four docstore modules (unit + conformance integration tests).
- Confirmed via `dependency:tree -Dverbose`, `dependency:list` (all scopes), classpath build, and a class-level scan of every classpath jar that:
  - `docstore-ali` still resolves `flatbuffers-java:1.11.0` transitively from the Tablestore SDK.
  - `docstore-aws`, `docstore-gcp-firestore`, and `docstore-gcp-spanner` pull in no flatbuffers classes at all (neither by artifact nor shaded under another package).
