### PR TITLE
blobstore: add the checksum data in the get and metadata

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/AliTransformer.java
@@ -52,6 +52,7 @@ import com.aliyun.sdk.service.oss2.transport.HttpClientOptions;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
+import com.salesforce.multicloudj.blob.driver.Checksum;
 import com.salesforce.multicloudj.blob.driver.ChecksumMethod;
 import com.salesforce.multicloudj.blob.driver.CopyFromRequest;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
@@ -217,6 +218,7 @@ public class AliTransformer {
                 .metadata(result.metadata())
                 .objectSize(objectSize)
                 .contentType(result.contentType())
+                .checksum(toDriverChecksum(result))
                 .build())
         .build();
   }
@@ -239,9 +241,30 @@ public class AliTransformer {
                 .metadata(result.metadata())
                 .objectSize(objectSize)
                 .contentType(result.contentType())
+                .checksum(toDriverChecksum(result))
                 .build())
         .inputStream(inputStream)
         .build();
+  }
+
+  private Checksum toDriverChecksum(GetObjectResult result) {
+    if (result.hashCrc64ecma() != null) {
+      return Checksum.builder()
+          .algorithm(ChecksumMethod.CRC64)
+          .value(result.hashCrc64ecma())
+          .build();
+    }
+    return null;
+  }
+
+  private Checksum toDriverChecksum(HeadObjectResult result) {
+    if (result.hashCrc64ecma() != null) {
+      return Checksum.builder()
+          .algorithm(ChecksumMethod.CRC64)
+          .value(result.hashCrc64ecma())
+          .build();
+    }
+    return null;
   }
 
   public DeleteObjectRequest toDeleteObjectRequest(
@@ -347,6 +370,7 @@ public class AliTransformer {
         .md5(HexUtil.convertToBytes(result.contentMd5()))
         .contentType(result.contentType())
         .objectLockInfo(extractObjectLockInfo(result.headers()))
+        .checksum(toDriverChecksum(result))
         .build();
   }
 

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -992,8 +992,6 @@ public class AliTransformerTest {
         ex.getMessage());
   }
 
-  // ---- toBlobMetadata: objectLockInfo extraction from x-oss-object-worm-* headers ----
-
   @Test
   void testToBlobMetadata_locked_populatesObjectLockInfoFromHeaders() {
     // OSS surfaces object-lock state on HeadObject as response headers (verified live against
@@ -1260,8 +1258,6 @@ public class AliTransformerTest {
     assertNull(actual.headers().get("x-oss-hash-crc64ecma"));
     assertNull(actual.headers().get("x-oss-content-sha256"));
   }
-
-  // ---- toBlobMetadata / toDownloadResponse: checksum mapping from hashCrc64ecma ----
 
   @Test
   void testToBlobMetadata_populatesCrc64ChecksumFromHashCrc64ecma() {

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/AliTransformerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import com.aliyun.sdk.service.oss2.models.CopyObjectResult;
+import com.aliyun.sdk.service.oss2.models.GetObjectResult;
 import com.aliyun.sdk.service.oss2.models.HeadObjectResult;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUpload;
 import com.aliyun.sdk.service.oss2.models.InitiateMultipartUploadResult;
@@ -22,6 +23,7 @@ import com.aliyun.sdk.service.oss2.transport.BinaryData;
 import com.aliyun.sdk.service.oss2.transport.HttpClientOptions;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
+import com.salesforce.multicloudj.blob.driver.Checksum;
 import com.salesforce.multicloudj.blob.driver.ChecksumMethod;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
 import com.salesforce.multicloudj.blob.driver.DownloadRequest;
@@ -1257,5 +1259,45 @@ public class AliTransformerTest {
     assertEquals("rL0Y20zC+Fzt72VPzMSk2A==", actual.contentMd5());
     assertNull(actual.headers().get("x-oss-hash-crc64ecma"));
     assertNull(actual.headers().get("x-oss-content-sha256"));
+  }
+
+  // ---- toBlobMetadata / toDownloadResponse: checksum mapping from hashCrc64ecma ----
+
+  @Test
+  void testToBlobMetadata_populatesCrc64ChecksumFromHashCrc64ecma() {
+    HeadObjectResult result = mock(HeadObjectResult.class);
+    doReturn("ali-crc64-value").when(result).hashCrc64ecma();
+
+    Checksum checksum = transformer.toBlobMetadata("k", result).getChecksum();
+    assertNotNull(checksum);
+    assertEquals(ChecksumMethod.CRC64, checksum.getAlgorithm());
+    assertEquals("ali-crc64-value", checksum.getValue());
+  }
+
+  @Test
+  void testToBlobMetadata_noHashCrc64ecmaReturnsNullChecksum() {
+    HeadObjectResult result = mock(HeadObjectResult.class);
+    doReturn(null).when(result).hashCrc64ecma();
+
+    assertNull(transformer.toBlobMetadata("k", result).getChecksum());
+  }
+
+  @Test
+  void testToDownloadResponse_populatesCrc64ChecksumFromHashCrc64ecma() {
+    GetObjectResult result = mock(GetObjectResult.class);
+    doReturn("ali-crc64-value").when(result).hashCrc64ecma();
+
+    Checksum checksum = transformer.toDownloadResponse("k", result).getMetadata().getChecksum();
+    assertNotNull(checksum);
+    assertEquals(ChecksumMethod.CRC64, checksum.getAlgorithm());
+    assertEquals("ali-crc64-value", checksum.getValue());
+  }
+
+  @Test
+  void testToDownloadResponse_noHashCrc64ecmaReturnsNullChecksum() {
+    GetObjectResult result = mock(GetObjectResult.class);
+    doReturn(null).when(result).hashCrc64ecma();
+
+    assertNull(transformer.toDownloadResponse("k", result).getMetadata().getChecksum());
   }
 }

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -4,6 +4,7 @@ import com.salesforce.multicloudj.blob.aws.async.S3LoggingTransferListener;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
+import com.salesforce.multicloudj.blob.driver.Checksum;
 import com.salesforce.multicloudj.blob.driver.ChecksumMethod;
 import com.salesforce.multicloudj.blob.driver.CopyFromRequest;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
@@ -63,6 +64,7 @@ import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
+import software.amazon.awssdk.services.s3.model.ChecksumMode;
 import software.amazon.awssdk.services.s3.model.CommonPrefix;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
@@ -355,6 +357,7 @@ public class AwsTransformer {
         GetObjectRequest.builder()
             .bucket(getBucket())
             .key(request.getKey())
+            .checksumMode(ChecksumMode.ENABLED)
             .versionId(request.getVersionId());
 
     if (request.getStart() != null || request.getEnd() != null) {
@@ -399,6 +402,7 @@ public class AwsTransformer {
                 .metadata(response.metadata())
                 .objectSize(response.contentLength())
                 .contentType(response.contentType())
+                .checksum(toDriverChecksum(response))
                 .build())
         .build();
   }
@@ -419,9 +423,54 @@ public class AwsTransformer {
                 .metadata(response.metadata())
                 .objectSize(response.contentLength())
                 .contentType(response.contentType())
+                .checksum(toDriverChecksum(response))
                 .build())
         .inputStream(responseInputStream)
         .build();
+  }
+
+  private Checksum toDriverChecksum(GetObjectResponse response) {
+    if (response.checksumSHA256() != null) {
+      return Checksum.builder()
+          .algorithm(ChecksumMethod.SHA256)
+          .value(response.checksumSHA256())
+          .build();
+    }
+    if (response.checksumCRC32C() != null) {
+      return Checksum.builder()
+          .algorithm(ChecksumMethod.CRC32C)
+          .value(response.checksumCRC32C())
+          .build();
+    }
+    if (response.checksumCRC64NVME() != null) {
+      return Checksum.builder()
+          .algorithm(ChecksumMethod.CRC64)
+          .value(response.checksumCRC64NVME())
+          .build();
+    }
+    return null;
+  }
+
+  private Checksum toDriverChecksum(HeadObjectResponse response) {
+    if (response.checksumSHA256() != null) {
+      return Checksum.builder()
+          .algorithm(ChecksumMethod.SHA256)
+          .value(response.checksumSHA256())
+          .build();
+    }
+    if (response.checksumCRC32C() != null) {
+      return Checksum.builder()
+          .algorithm(ChecksumMethod.CRC32C)
+          .value(response.checksumCRC32C())
+          .build();
+    }
+    if (response.checksumCRC64NVME() != null) {
+      return Checksum.builder()
+          .algorithm(ChecksumMethod.CRC64)
+          .value(response.checksumCRC64NVME())
+          .build();
+    }
+    return null;
   }
 
   public DeleteObjectRequest toDeleteRequest(String key, String versionId) {
@@ -466,7 +515,12 @@ public class AwsTransformer {
   }
 
   public HeadObjectRequest toHeadRequest(String key, String versionId) {
-    return HeadObjectRequest.builder().bucket(getBucket()).key(key).versionId(versionId).build();
+    return HeadObjectRequest.builder()
+        .bucket(getBucket())
+        .key(key)
+        .versionId(versionId)
+        .checksumMode(ChecksumMode.ENABLED)
+        .build();
   }
 
   public BlobMetadata toMetadata(HeadObjectResponse response, String key) {
@@ -496,6 +550,7 @@ public class AwsTransformer {
         .md5(eTagToMD5(eTag))
         .contentType(response.contentType())
         .objectLockInfo(objectLockInfo)
+        .checksum(toDriverChecksum(response))
         .build();
   }
 

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobInfo;
+import com.salesforce.multicloudj.blob.driver.Checksum;
 import com.salesforce.multicloudj.blob.driver.ChecksumMethod;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
 import com.salesforce.multicloudj.blob.driver.DirectoryDownloadRequest;
@@ -53,6 +54,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
+import software.amazon.awssdk.services.s3.model.ChecksumMode;
 import software.amazon.awssdk.services.s3.model.CommonPrefix;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
@@ -493,6 +495,73 @@ public class AwsTransformerTest {
     assertEquals(BUCKET, actual.bucket());
     assertEquals(key, actual.key());
     assertEquals(versionId, actual.versionId());
+    assertEquals(ChecksumMode.ENABLED, actual.checksumMode());
+  }
+
+  @Test
+  void testToRequest_downloadEnablesChecksumMode() {
+    var request = DownloadRequest.builder().withKey("some/key").build();
+    var actual = transformer.toRequest(request);
+    assertEquals(ChecksumMode.ENABLED, actual.checksumMode());
+  }
+
+  @Test
+  void testToDownloadResponse_preferSha256OverCrc32c() {
+    var request = DownloadRequest.builder().withKey("k").build();
+    GetObjectResponse response = mock(GetObjectResponse.class);
+    doReturn("sha256-value").when(response).checksumSHA256();
+    doReturn("crc32c-value").when(response).checksumCRC32C();
+
+    Checksum checksum =
+        transformer.toDownloadResponse(request, response).getMetadata().getChecksum();
+    assertNotNull(checksum);
+    assertEquals(ChecksumMethod.SHA256, checksum.getAlgorithm());
+    assertEquals("sha256-value", checksum.getValue());
+  }
+
+  @Test
+  void testToDownloadResponse_preferCrc32cOverCrc64() {
+    var request = DownloadRequest.builder().withKey("k").build();
+    GetObjectResponse response = mock(GetObjectResponse.class);
+    doReturn("crc32c-value").when(response).checksumCRC32C();
+    doReturn("crc64-value").when(response).checksumCRC64NVME();
+
+    Checksum checksum =
+        transformer.toDownloadResponse(request, response).getMetadata().getChecksum();
+    assertNotNull(checksum);
+    assertEquals(ChecksumMethod.CRC32C, checksum.getAlgorithm());
+    assertEquals("crc32c-value", checksum.getValue());
+  }
+
+  @Test
+  void testToDownloadResponse_fallbackToCrc64NvmeMappedAsCrc64() {
+    var request = DownloadRequest.builder().withKey("k").build();
+    GetObjectResponse response = mock(GetObjectResponse.class);
+    doReturn("crc64nvme-value").when(response).checksumCRC64NVME();
+
+    Checksum checksum =
+        transformer.toDownloadResponse(request, response).getMetadata().getChecksum();
+    assertNotNull(checksum);
+    assertEquals(ChecksumMethod.CRC64, checksum.getAlgorithm());
+    assertEquals("crc64nvme-value", checksum.getValue());
+  }
+
+  @Test
+  void testToDownloadResponse_crc32OnlyReturnsNullChecksum() {
+    // SDK's WHEN_SUPPORTED default auto-attaches CRC32 on some PUTs; we intentionally do NOT
+    // surface it since ChecksumMethod does not expose CRC32.
+    var request = DownloadRequest.builder().withKey("k").build();
+    GetObjectResponse response = mock(GetObjectResponse.class);
+    doReturn("crc32-value").when(response).checksumCRC32();
+
+    assertNull(transformer.toDownloadResponse(request, response).getMetadata().getChecksum());
+  }
+
+  @Test
+  void testToDownloadResponse_noChecksumHeadersReturnsNull() {
+    var request = DownloadRequest.builder().withKey("k").build();
+    GetObjectResponse response = mock(GetObjectResponse.class);
+    assertNull(transformer.toDownloadResponse(request, response).getMetadata().getChecksum());
   }
 
   @Test
@@ -514,6 +583,53 @@ public class AwsTransformerTest {
     assertEquals(metadata, actual.getMetadata());
     assertEquals(1024L, actual.getObjectSize());
     assertEquals(now, actual.getLastModified());
+    assertNull(actual.getChecksum());
+  }
+
+  @Test
+  void testToMetadata_preferSha256() {
+    var response =
+        HeadObjectResponse.builder()
+            .contentLength(0L)
+            .checksumSHA256("sha256-value")
+            .checksumCRC32C("crc32c-value")
+            .checksumCRC64NVME("crc64-value")
+            .build();
+    Checksum checksum = transformer.toMetadata(response, "k").getChecksum();
+    assertNotNull(checksum);
+    assertEquals(ChecksumMethod.SHA256, checksum.getAlgorithm());
+    assertEquals("sha256-value", checksum.getValue());
+  }
+
+  @Test
+  void testToMetadata_preferCrc32cOverCrc64() {
+    var response =
+        HeadObjectResponse.builder()
+            .contentLength(0L)
+            .checksumCRC32C("crc32c-value")
+            .checksumCRC64NVME("crc64-value")
+            .build();
+    Checksum checksum = transformer.toMetadata(response, "k").getChecksum();
+    assertNotNull(checksum);
+    assertEquals(ChecksumMethod.CRC32C, checksum.getAlgorithm());
+    assertEquals("crc32c-value", checksum.getValue());
+  }
+
+  @Test
+  void testToMetadata_fallbackToCrc64NvmeMappedAsCrc64() {
+    var response =
+        HeadObjectResponse.builder().contentLength(0L).checksumCRC64NVME("crc64-value").build();
+    Checksum checksum = transformer.toMetadata(response, "k").getChecksum();
+    assertNotNull(checksum);
+    assertEquals(ChecksumMethod.CRC64, checksum.getAlgorithm());
+    assertEquals("crc64-value", checksum.getValue());
+  }
+
+  @Test
+  void testToMetadata_crc32OnlyReturnsNullChecksum() {
+    var response =
+        HeadObjectResponse.builder().contentLength(0L).checksumCRC32("crc32-value").build();
+    assertNull(transformer.toMetadata(response, "k").getChecksum());
   }
 
   @Test

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_createparentpath-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_createparentpath-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "4746989d-5b8c-4c51-886c-fbbe79d07646",
+  "id" : "d2c3083f-ac05-4d03-b992-c7e611e42c3d",
   "name" : "AwsBlobStoreIT_testDownload_createParentPath-DELETE-0",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_create_parent/nested/object_unversioned",
@@ -9,14 +9,14 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "VXEX05CQD0KHCT36",
-      "x-amz-id-2" : "Mlz6UpTuS4EgJLGjOZ8OsyTVCNY1PSNKLoxzFm2Y0O9Tc48yPGdpJexIpNvjm9srWklzqMM8TpWiJRnqpTivEK7Ib/1D/8jh",
-      "Date" : "Wed, 08 Apr 2026 18:25:31 GMT"
+      "x-amz-request-id" : "NASMJ1GB199JJYP7",
+      "x-amz-id-2" : "r8mta3DJd7W63so2NBmSwWl6Y7tKC3t0qH3mxWYMe82Jk2A1TAn7icXxzrTKQ2uTgLUwRY5lmlUCIvNdcXO5Bnn5+vMj3mKX",
+      "Date" : "Sun, 12 Jul 2026 21:12:03 GMT"
     }
   },
-  "uuid" : "4746989d-5b8c-4c51-886c-fbbe79d07646",
+  "uuid" : "d2c3083f-ac05-4d03-b992-c7e611e42c3d",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-conformance-tests-download_create_parent-nested-object_unversioned",
   "requiredScenarioState" : "scenario-1-chameleon-jcloud-conformance-tests-download_create_parent-nested-object_unversioned-2",
-  "insertionIndex" : 611
+  "insertionIndex" : 784
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_createparentpath-delete-3.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_createparentpath-delete-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "3e9969dd-f7e1-4d98-ba06-c5445b2dc705",
+  "id" : "aea3067d-abb3-4b51-b951-6ba84e4cfdf0",
   "name" : "AwsBlobStoreIT_testDownload_createParentPath-DELETE-3",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_create_parent/nested/object_unversioned",
@@ -9,15 +9,15 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "HCB3TTEM4VF0J5XR",
-      "x-amz-id-2" : "9HPuhg2cLJkvpT/Uo0HBOsNKySysE0E+7vBeJ27+axf6KHuJ5ndWDLENRcZhU+xddVmn413e3h5ziU08clcwQRcRvaQbWCgA",
-      "Date" : "Wed, 08 Apr 2026 18:25:30 GMT"
+      "x-amz-request-id" : "FBGP13P69E4AQQSX",
+      "x-amz-id-2" : "X7tvINA4WVuctUwXlyqixiUfeVdSCkUFAg5J6rttnBQ47CiFQO1sroABEW/5/13BtdNGdfYP9Ry0yQlhgZHrzmH3Xmot/rdn",
+      "Date" : "Sun, 12 Jul 2026 21:12:02 GMT"
     }
   },
-  "uuid" : "3e9969dd-f7e1-4d98-ba06-c5445b2dc705",
+  "uuid" : "aea3067d-abb3-4b51-b951-6ba84e4cfdf0",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-conformance-tests-download_create_parent-nested-object_unversioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-chameleon-jcloud-conformance-tests-download_create_parent-nested-object_unversioned-2",
-  "insertionIndex" : 614
+  "insertionIndex" : 787
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_createparentpath-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_createparentpath-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "5f1f134b-b3ee-4151-bd9d-d12f182b65c5",
+  "id" : "8c5f6bd7-ab9d-47e5-9cba-edfe0dec2601",
   "name" : "AwsBlobStoreIT_testDownload_createParentPath-GET-1",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_create_parent/nested/object_unversioned",
@@ -7,23 +7,24 @@
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 08 Apr 2026 18:25:30 GMT",
-      "x-amz-request-id" : "VXESB9G89Y9KD5MC",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 21:12:02 GMT",
+      "x-amz-request-id" : "FBGWSSDW6XMDKJMZ",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "gTtbjpHXcgEIaRPKuv6iFtF5og9wMy0hK1xWi1MDaJ7c7DJ5gt7qzNtyeovpT0cL9n3jA6XKCsDlXf7zvajREmsWo+9Qdms0",
-      "x-amz-transfer-encoding" : "append-md5",
-      "Date" : "Wed, 08 Apr 2026 18:25:31 GMT",
+      "x-amz-id-2" : "hdPXXLHD4QcgTOr4HijK3TCrnTOzZXSYtKfjf4PUHScP6tegPbREv/OtzcOnfgZcYL0MS4b/RJffe1c7xy0tOUkFDWVt7JHw",
+      "Date" : "Sun, 12 Jul 2026 21:12:02 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "5f1f134b-b3ee-4151-bd9d-d12f182b65c5",
+  "uuid" : "8c5f6bd7-ab9d-47e5-9cba-edfe0dec2601",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-conformance-tests-download_create_parent-nested-object_unversioned",
   "requiredScenarioState" : "scenario-2-chameleon-jcloud-conformance-tests-download_create_parent-nested-object_unversioned-2",
-  "insertionIndex" : 612
+  "insertionIndex" : 785
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_createparentpath-get-4.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_createparentpath-get-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "dddd72ba-994f-42ce-a419-8b41493695e4",
+  "id" : "c91267e5-9b8e-4357-8139-01c99583cf50",
   "name" : "AwsBlobStoreIT_testDownload_createParentPath-GET-4",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_create_parent/nested/object_unversioned",
@@ -7,24 +7,25 @@
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 08 Apr 2026 18:25:29 GMT",
-      "x-amz-request-id" : "MESE4HAQ08SHPET3",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 21:12:01 GMT",
+      "x-amz-request-id" : "ATVJCQP3WN9DCBM9",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "wxbH9+r/MD+ScA1mJn0JJrymn8k0DJkG7E7aTVAH8AcHBaipm7TBtq4PDO82SsToSTglTZX6FWHTr/Rdgd0CMiOQzIsN0TwG",
-      "x-amz-transfer-encoding" : "append-md5",
-      "Date" : "Wed, 08 Apr 2026 18:25:29 GMT",
+      "x-amz-id-2" : "t3MR7UjMEdxGEytDqoPDyTcOkp1QFCGlzHGcZOEso3iFGkn4jq0XvxWbTuk57XxoMJfOP03cAr7sm13aI7MV6RXojlluP5WI",
+      "Date" : "Sun, 12 Jul 2026 21:12:01 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "dddd72ba-994f-42ce-a419-8b41493695e4",
+  "uuid" : "c91267e5-9b8e-4357-8139-01c99583cf50",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-conformance-tests-download_create_parent-nested-object_unversioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-2-chameleon-jcloud-conformance-tests-download_create_parent-nested-object_unversioned-2",
-  "insertionIndex" : 615
+  "insertionIndex" : 788
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_createparentpath-put-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_createparentpath-put-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "1fd4aac4-a94e-481d-92fd-4803ecf9b8e9",
+  "id" : "9b5ebf0b-fff9-4553-9dc3-e5e0c5ac5aa5",
   "name" : "AwsBlobStoreIT_testDownload_createParentPath-PUT-2",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_create_parent/nested/object_unversioned",
@@ -15,15 +15,15 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "HCBB47AWN97E3P3X",
+      "x-amz-request-id" : "FBGPXSDX0W5TGFX3",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "8WD8Kbc/RSYeUT/99bgNloFHSY1UwOV9DwWJl4ALpHoMUlv7qVqqUNkzLuViEvo0Jq+7vl+Qk7n8FK/eW0mPcMSJjt6MpJAg",
-      "Date" : "Wed, 08 Apr 2026 18:25:30 GMT"
+      "x-amz-id-2" : "6e5m+TgkBD2iP4WW9DchTAtfNw/aJa1W3tAJtywh65yKzgyISibBScnOdOHbcJGVKA5NBvBDdXzD7gMNedZ4XCQQjGvT0cio",
+      "Date" : "Sun, 12 Jul 2026 21:12:02 GMT"
     }
   },
-  "uuid" : "1fd4aac4-a94e-481d-92fd-4803ecf9b8e9",
+  "uuid" : "9b5ebf0b-fff9-4553-9dc3-e5e0c5ac5aa5",
   "persistent" : true,
   "scenarioName" : "scenario-3-chameleon-jcloud-conformance-tests-download_create_parent-nested-object_unversioned",
   "requiredScenarioState" : "scenario-3-chameleon-jcloud-conformance-tests-download_create_parent-nested-object_unversioned-2",
-  "insertionIndex" : 613
+  "insertionIndex" : 786
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_createparentpath-put-5.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_createparentpath-put-5.json
@@ -1,5 +1,5 @@
 {
-  "id" : "e303f571-78e5-4d9d-8e99-ba7ad93cfa67",
+  "id" : "be2fcbbe-4ec0-4cde-8a84-1e9991565e73",
   "name" : "AwsBlobStoreIT_testDownload_createParentPath-PUT-5",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_create_parent/nested/object_unversioned",
@@ -15,16 +15,16 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "MES8QY0BV3RMMP8C",
+      "x-amz-request-id" : "ATVZX0B5HA29FTS4",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "s2JXrMu6YbChtQZ1wQnJAgwo2n8lGjVgRUzDcgUEVnMZ+sLJdlhoO93bh2/jK1gPxvrMVokyX5zSmnbnGOMgP9rnAFw7eq6A",
-      "Date" : "Wed, 08 Apr 2026 18:25:29 GMT"
+      "x-amz-id-2" : "uVJiwPbU9CqtHrRSQMGSrDoWecs2NDGf3EhNlDnLF+BgwEwF99iobNgcRJsC3PXDEr1DsLFdFNTDAsEmanS2VhkO4QH9ARdF",
+      "Date" : "Sun, 12 Jul 2026 21:12:01 GMT"
     }
   },
-  "uuid" : "e303f571-78e5-4d9d-8e99-ba7ad93cfa67",
+  "uuid" : "be2fcbbe-4ec0-4cde-8a84-1e9991565e73",
   "persistent" : true,
   "scenarioName" : "scenario-3-chameleon-jcloud-conformance-tests-download_create_parent-nested-object_unversioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-3-chameleon-jcloud-conformance-tests-download_create_parent-nested-object_unversioned-2",
-  "insertionIndex" : 616
+  "insertionIndex" : 789
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "ad369e1e-7964-4b2b-a328-1fbc96b453b5",
+  "id" : "2939db22-fb02-44c0-a6d2-bd4df3db4d4c",
   "name" : "AwsBlobStoreIT_testDownload_happy-DELETE-0",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/download_happy_versioned",
@@ -10,15 +10,15 @@
     "headers" : {
       "Server" : "AmazonS3",
       "x-amz-delete-marker" : "true",
-      "x-amz-request-id" : "F9RVC6RCPWS28Z3J",
-      "x-amz-id-2" : "Y/pnAxN2VJNnDRpaY5tUBr0eygwJXif0mWTgOpKjIBeeL4O3/3upCyrJ4FgUIPbAd5OEpwxvU23VkpDIiCzR/A5Dzmp4yy6O",
-      "x-amz-version-id" : "iubONRDxFA8hHu6uz.ErAxdeGOrnsCcI",
-      "Date" : "Wed, 04 Mar 2026 20:58:09 GMT"
+      "x-amz-request-id" : "ERA3ZJTPBNJK4CDK",
+      "x-amz-id-2" : "+YsvO7MG8LCxl4Oz/twR2+AbdnIYlr10lCGjjJaqzLYmfmO+wEgTo1HvLeo+l9V9x9ps0Qp11EP5RqrOquC/MjX7vsVJSELg",
+      "x-amz-version-id" : "__UcZ7BG.zsScmryYQvSWormXB8mHQjn",
+      "Date" : "Sun, 12 Jul 2026 19:42:59 GMT"
     }
   },
-  "uuid" : "ad369e1e-7964-4b2b-a328-1fbc96b453b5",
+  "uuid" : "2939db22-fb02-44c0-a6d2-bd4df3db4d4c",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned",
   "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned-4",
-  "insertionIndex" : 266
+  "insertionIndex" : 771
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-12.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-12.json
@@ -1,5 +1,5 @@
 {
-  "id" : "36ab17b1-e3f2-4249-a6a4-5b618ac143c1",
+  "id" : "4f064b0a-6c12-49bf-a78c-7cf0a8a97741",
   "name" : "AwsBlobStoreIT_testDownload_happy-DELETE-12",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_happy_unversioned",
@@ -9,14 +9,14 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "GV99QSDEW4XA7YNS",
-      "x-amz-id-2" : "ORvhOA70lHJaTe+kZEJmL++/4M2vBqxqufgYIU7rwDCTt/ftx7UKM0CdBymhQRZ2CzSiDfc8RytXvbU9saKei/EswCINSAQd",
-      "Date" : "Wed, 04 Mar 2026 20:58:04 GMT"
+      "x-amz-request-id" : "9B91NYWSGYR6WQ93",
+      "x-amz-id-2" : "maSGyO8luLk9nXVPrcizB7dKaLNkNk4KUawP4Z73u3WybwdHfJwKImmbRfB7plxlD6l0vuFAt5sKVhJfkR2O4Fovh9V1GrBy",
+      "Date" : "Sun, 12 Jul 2026 19:42:53 GMT"
     }
   },
-  "uuid" : "36ab17b1-e3f2-4249-a6a4-5b618ac143c1",
+  "uuid" : "4f064b0a-6c12-49bf-a78c-7cf0a8a97741",
   "persistent" : true,
   "scenarioName" : "scenario-3-chameleon-jcloud-conformance-tests-download_happy_unversioned",
   "requiredScenarioState" : "scenario-3-chameleon-jcloud-conformance-tests-download_happy_unversioned-4",
-  "insertionIndex" : 278
+  "insertionIndex" : 783
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-15.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-15.json
@@ -1,5 +1,5 @@
 {
-  "id" : "395a09dd-10ce-4df9-a631-bdab30ce0d3c",
+  "id" : "b0d46ed7-5071-44ab-a806-5e4eb20f1d59",
   "name" : "AwsBlobStoreIT_testDownload_happy-DELETE-15",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_happy_unversioned",
@@ -9,15 +9,15 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "VCJFSCMMXTGEX4HM",
-      "x-amz-id-2" : "ixHh+5wl6kbS0zRgTpINJIT1idmyq6A0kQA0PqDQyuFXigMJ4LFzINcGgTxIAXcoLIQRe4M/uYdjE9PmnT6ZR+bP2MmNqV8N",
-      "Date" : "Wed, 04 Mar 2026 20:58:02 GMT"
+      "x-amz-request-id" : "MCV505TF2R3N7ADP",
+      "x-amz-id-2" : "bBIcOiqz5HNScJPo0d0+NaSRCqMLE0P39WFmVc3ZKkAVpFxW2dj97TR6ZxB/H6ZkaklSitZQEQbZmeUTgCn8Y77GflQqR9OT",
+      "Date" : "Sun, 12 Jul 2026 19:42:52 GMT"
     }
   },
-  "uuid" : "395a09dd-10ce-4df9-a631-bdab30ce0d3c",
+  "uuid" : "b0d46ed7-5071-44ab-a806-5e4eb20f1d59",
   "persistent" : true,
   "scenarioName" : "scenario-3-chameleon-jcloud-conformance-tests-download_happy_unversioned",
   "requiredScenarioState" : "scenario-3-chameleon-jcloud-conformance-tests-download_happy_unversioned-3",
   "newScenarioState" : "scenario-3-chameleon-jcloud-conformance-tests-download_happy_unversioned-4",
-  "insertionIndex" : 281
+  "insertionIndex" : 786
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-18.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-18.json
@@ -1,5 +1,5 @@
 {
-  "id" : "9c7ddcb2-c5e8-4317-8d99-90b9659ed4aa",
+  "id" : "b37ecfc7-a6f5-448e-8797-3686eb7042b8",
   "name" : "AwsBlobStoreIT_testDownload_happy-DELETE-18",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_happy_unversioned",
@@ -9,15 +9,15 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "FYKSX3KB64SKENFQ",
-      "x-amz-id-2" : "8rxj82ObRCzdG1KJk9plX7l0osjXJgl6e+AujmZYlP/h9YbUkVEjtQ5PwMW8Pk1kd11Q3NsnipLdeQBgUO74awmgEoNzq77M",
-      "Date" : "Wed, 04 Mar 2026 20:58:01 GMT"
+      "x-amz-request-id" : "7TK414DZTCA5X6YH",
+      "x-amz-id-2" : "cJEt+t1jgoZGnN6LFHVTmIuLdbfurTCekpW13NpNpzeYcoRaaArx7YOJTvksyFh/SNxwxZMBg9TI1gvmdrgHftvSHCCgvR/p",
+      "Date" : "Sun, 12 Jul 2026 19:42:51 GMT"
     }
   },
-  "uuid" : "9c7ddcb2-c5e8-4317-8d99-90b9659ed4aa",
+  "uuid" : "b37ecfc7-a6f5-448e-8797-3686eb7042b8",
   "persistent" : true,
   "scenarioName" : "scenario-3-chameleon-jcloud-conformance-tests-download_happy_unversioned",
   "requiredScenarioState" : "scenario-3-chameleon-jcloud-conformance-tests-download_happy_unversioned-2",
   "newScenarioState" : "scenario-3-chameleon-jcloud-conformance-tests-download_happy_unversioned-3",
-  "insertionIndex" : 284
+  "insertionIndex" : 789
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-21.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-21.json
@@ -1,5 +1,5 @@
 {
-  "id" : "8b5b7880-1bd8-4d36-879d-cd1d7925762f",
+  "id" : "9cd7f572-a718-4072-bf51-7a8c6dd1100d",
   "name" : "AwsBlobStoreIT_testDownload_happy-DELETE-21",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_happy_unversioned",
@@ -9,15 +9,15 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "YTAV3G17ASWS934G",
-      "x-amz-id-2" : "6lrMWXPbeXZ3NW14UJDyY9nwoSwuL61rIJvcmK3EMuZxXaFQIBtZXaADWA73l+NbkZFghdzCMAHHdGO3O1ig0DtSU4Annf2E",
-      "Date" : "Wed, 04 Mar 2026 20:58:00 GMT"
+      "x-amz-request-id" : "NG26CXWVTS3VTQ5Y",
+      "x-amz-id-2" : "2xtoPYSoAutsv/xL3FvdgoJ75v7U1OTTFHG0rwq+BJaThuVdQZQyU+kD/Q7nZtUF3n6G9Orh8RNj4d13pTDROoCKDI5btzc+",
+      "Date" : "Sun, 12 Jul 2026 19:42:50 GMT"
     }
   },
-  "uuid" : "8b5b7880-1bd8-4d36-879d-cd1d7925762f",
+  "uuid" : "9cd7f572-a718-4072-bf51-7a8c6dd1100d",
   "persistent" : true,
   "scenarioName" : "scenario-3-chameleon-jcloud-conformance-tests-download_happy_unversioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-3-chameleon-jcloud-conformance-tests-download_happy_unversioned-2",
-  "insertionIndex" : 287
+  "insertionIndex" : 792
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-3.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "197908aa-064b-4c05-91cb-99528cd78ad0",
+  "id" : "8365c3a0-5f3d-4bb0-b5dc-ce575c02f804",
   "name" : "AwsBlobStoreIT_testDownload_happy-DELETE-3",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/download_happy_versioned",
@@ -10,16 +10,16 @@
     "headers" : {
       "Server" : "AmazonS3",
       "x-amz-delete-marker" : "true",
-      "x-amz-request-id" : "DGX50YA23HDVA600",
-      "x-amz-id-2" : "p1cr+K10CrRJRu0NcULv2BXU6YRXlLmRUy3+/JomQ8kUoAxfQow+YafH1iWL44EDwy+flZ4o5xAd7y9e189o/yVvQ8gRqvg+",
-      "x-amz-version-id" : "6Puui5W6Pxj2shtMpxMxuLhn3otbqBYL",
-      "Date" : "Wed, 04 Mar 2026 20:58:08 GMT"
+      "x-amz-request-id" : "9F7E6VFAFT72WWNJ",
+      "x-amz-id-2" : "4fwqjtYq2PABpWarmBeW3a/YGbyN7zcknSOhZmR/QfTCeL3upsB6uqmX1D9C2MdJpizNnmFbehBisvi3+s4+aHo1Vdes3nKc",
+      "x-amz-version-id" : "A9wd7PtdvTmcSvlqK4lTGDPaZP84gSMj",
+      "Date" : "Sun, 12 Jul 2026 19:42:58 GMT"
     }
   },
-  "uuid" : "197908aa-064b-4c05-91cb-99528cd78ad0",
+  "uuid" : "8365c3a0-5f3d-4bb0-b5dc-ce575c02f804",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned",
   "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned-3",
   "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned-4",
-  "insertionIndex" : 269
+  "insertionIndex" : 774
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-6.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-6.json
@@ -1,5 +1,5 @@
 {
-  "id" : "d55c9b24-a394-4e05-b2f8-5e62f28f1903",
+  "id" : "1d4a33f2-b4af-496f-8c26-db0a381ce06a",
   "name" : "AwsBlobStoreIT_testDownload_happy-DELETE-6",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/download_happy_versioned",
@@ -10,16 +10,16 @@
     "headers" : {
       "Server" : "AmazonS3",
       "x-amz-delete-marker" : "true",
-      "x-amz-request-id" : "RQ2W9Y65WSS2B5BM",
-      "x-amz-id-2" : "j6uVOYFYFD0Vx1cu4/Oht9spxl5NxFXmveKo47lpfR0+N2lZ34iCQZg/fFha2CKUtdYG1/a39xEpdohSPjIuPhR/58+qahDl",
-      "x-amz-version-id" : "J.LyBN06gwl48jWFy9E1e1u5IBMAMo5i",
-      "Date" : "Wed, 04 Mar 2026 20:58:06 GMT"
+      "x-amz-request-id" : "86J1W3HJ4TV96WG4",
+      "x-amz-id-2" : "V53ERkib3/9iY8qxCyLl6nvetuE+oYqGRzgs7DSQrqw1v4xgz+AOhgzxIEc+an6YSQRb3UDo1hW7SPm7cI5/DL54v2rNg4/D",
+      "x-amz-version-id" : "S_p7UduyQTTzR6IN3R75q6W5JulwnMpx",
+      "Date" : "Sun, 12 Jul 2026 19:42:57 GMT"
     }
   },
-  "uuid" : "d55c9b24-a394-4e05-b2f8-5e62f28f1903",
+  "uuid" : "1d4a33f2-b4af-496f-8c26-db0a381ce06a",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned",
   "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned-2",
   "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned-3",
-  "insertionIndex" : 272
+  "insertionIndex" : 777
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-9.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-delete-9.json
@@ -1,5 +1,5 @@
 {
-  "id" : "62fcb57f-5722-42dc-803d-8f9e3b66fd47",
+  "id" : "894f63e5-1357-4e4e-b371-d52ea3753e13",
   "name" : "AwsBlobStoreIT_testDownload_happy-DELETE-9",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/download_happy_versioned",
@@ -10,16 +10,16 @@
     "headers" : {
       "Server" : "AmazonS3",
       "x-amz-delete-marker" : "true",
-      "x-amz-request-id" : "9SMSEGRW901MJJ7Y",
-      "x-amz-id-2" : "Us4QTnFQ/r1vQnrdsSYSkRsO31Dmn/WSGxHJ545ipWRTNZFmF6AC8lmO269HTr/90fi+ZcSP/M4SKvG78c7Pe//LB17Dxg3X",
-      "x-amz-version-id" : "adZZd34xi2CiUsgbQjjshC3_lUNjtjlt",
-      "Date" : "Wed, 04 Mar 2026 20:58:05 GMT"
+      "x-amz-request-id" : "HAMJ23MFMJSHC42G",
+      "x-amz-id-2" : "3FEGboWNkvY58vg9PokBMID4G0+ZHuRPtzth8nqUesVJL9THEVRthnFwRuy4PBJmX2mWwlya1flhl3vBab6YtBWrEThVuQYR",
+      "x-amz-version-id" : "3M3qA4K7LKhV6R4YFfc.O7QHbwWVOiDc",
+      "Date" : "Sun, 12 Jul 2026 19:42:55 GMT"
     }
   },
-  "uuid" : "62fcb57f-5722-42dc-803d-8f9e3b66fd47",
+  "uuid" : "894f63e5-1357-4e4e-b371-d52ea3753e13",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned-2",
-  "insertionIndex" : 275
+  "insertionIndex" : 780
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "57e12861-675a-4275-98bc-d83121216ebc",
+  "id" : "fe6e19c5-18ee-4183-9af1-1a144e91ab43",
   "name" : "AwsBlobStoreIT_testDownload_happy-GET-1",
   "request" : {
     "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/download_happy_versioned",
@@ -12,29 +12,30 @@
     "queryParameters" : {
       "versionId" : {
         "hasExactly" : [ {
-          "equalTo" : "XDan8AP7R0kUltLfiWnd3o6I0.HRgS1L"
+          "equalTo" : "66rN2qe4FmL6pgfPFdPk4wbylnY5hNjD"
         } ]
       }
     }
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:58:08 GMT",
-      "x-amz-request-id" : "F9RN8BBMBKTX4VM4",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 19:42:58 GMT",
+      "x-amz-request-id" : "ERAF4AQ95D8NEE12",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "Ik1laApf2t3RacVDnlambUjBgwLp3SGfZTqky/4dUf/IMY972I5NfWc+3+hl0jxlFUKcbwJ88uMEDtX8U677snjpCNPsKW4z",
-      "x-amz-transfer-encoding" : "append-md5",
-      "x-amz-version-id" : "XDan8AP7R0kUltLfiWnd3o6I0.HRgS1L",
-      "Date" : "Wed, 04 Mar 2026 20:58:09 GMT",
+      "x-amz-id-2" : "DuszOA0JVeN0/Vb/wivJGahPPdh5LlZA0mNRjCr6RYz6j5n2vS867n+8VlUtqolWY1hs7AhHAfuQpc88YAn65ljCJdw2+MD7",
+      "x-amz-version-id" : "66rN2qe4FmL6pgfPFdPk4wbylnY5hNjD",
+      "Date" : "Sun, 12 Jul 2026 19:42:59 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "57e12861-675a-4275-98bc-d83121216ebc",
+  "uuid" : "fe6e19c5-18ee-4183-9af1-1a144e91ab43",
   "persistent" : true,
-  "insertionIndex" : 267
+  "insertionIndex" : 772
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-10.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-10.json
@@ -1,5 +1,5 @@
 {
-  "id" : "091b601d-ba19-4600-af54-2b67c4527cca",
+  "id" : "1e5d0160-3319-404f-a8bd-d2788f372ccd",
   "name" : "AwsBlobStoreIT_testDownload_happy-GET-10",
   "request" : {
     "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/download_happy_versioned",
@@ -12,29 +12,30 @@
     "queryParameters" : {
       "versionId" : {
         "hasExactly" : [ {
-          "equalTo" : "ARrb67OlnCAbywNmptBH1aeDXjOmt.So"
+          "equalTo" : "yD5ps0UM2Srmg6GXCWNuv_IFD1eFJDZB"
         } ]
       }
     }
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:58:04 GMT",
-      "x-amz-request-id" : "9SMRHYSJC89ZN2ZS",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 19:42:54 GMT",
+      "x-amz-request-id" : "HAMZ4WAJQXFAY07K",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "AQBB4aUP9OuXPbWwm+pqR7QTNz2cF5o8Ga2BxRieely5HcBf7x0SldD3WqwquvOY+SNGUdeVpFbg319d5wTHuNMqZZ2KIab9",
-      "x-amz-transfer-encoding" : "append-md5",
-      "x-amz-version-id" : "ARrb67OlnCAbywNmptBH1aeDXjOmt.So",
-      "Date" : "Wed, 04 Mar 2026 20:58:05 GMT",
+      "x-amz-id-2" : "yUbT1AfGbiJLUEwTfMjHJIRUT5sT0FruX2NhQN/d/Ynril3yeP1Jmv7bzZudUDYrkvsOLme4QJUX0JBRW90NLl3YNoZ/d3L8",
+      "x-amz-version-id" : "yD5ps0UM2Srmg6GXCWNuv_IFD1eFJDZB",
+      "Date" : "Sun, 12 Jul 2026 19:42:55 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "091b601d-ba19-4600-af54-2b67c4527cca",
+  "uuid" : "1e5d0160-3319-404f-a8bd-d2788f372ccd",
   "persistent" : true,
-  "insertionIndex" : 276
+  "insertionIndex" : 781
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-13.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-13.json
@@ -1,5 +1,5 @@
 {
-  "id" : "85fe2826-c116-4ed6-bed3-e1d5fc620127",
+  "id" : "6076d9b1-6744-4abb-b568-2383c47d76cd",
   "name" : "AwsBlobStoreIT_testDownload_happy-GET-13",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_happy_unversioned",
@@ -7,23 +7,24 @@
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:58:03 GMT",
-      "x-amz-request-id" : "FJ4BEBM64BYMD9WX",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 19:42:53 GMT",
+      "x-amz-request-id" : "9B99TXZ43D5BSCM3",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "uiVZ9jpN/4uaCY//KrFvIvNmngg2f9ZwHc343vF/yhv3vNqX8MuGYGe/iMHp64/QHAsT7a5sUKdb028OOgvAmY46VgNvtBUR",
-      "x-amz-transfer-encoding" : "append-md5",
-      "Date" : "Wed, 04 Mar 2026 20:58:03 GMT",
+      "x-amz-id-2" : "GQBLZYoZ0DnE+gWdSiIzSpgtF40rKkNhaosAkw/dMupWL4m8/q0LW9sjyB8C+EXd/tRLLRltdB1zjLu0TthBreXCsBPdVVXe",
+      "Date" : "Sun, 12 Jul 2026 19:42:53 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "85fe2826-c116-4ed6-bed3-e1d5fc620127",
+  "uuid" : "6076d9b1-6744-4abb-b568-2383c47d76cd",
   "persistent" : true,
   "scenarioName" : "scenario-4-chameleon-jcloud-conformance-tests-download_happy_unversioned",
   "requiredScenarioState" : "scenario-4-chameleon-jcloud-conformance-tests-download_happy_unversioned-4",
-  "insertionIndex" : 279
+  "insertionIndex" : 784
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-16.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-16.json
@@ -1,5 +1,5 @@
 {
-  "id" : "789ad458-d52e-4ccc-a4a6-b53f5b53ce7b",
+  "id" : "d11e81b4-c378-4894-bfdf-e70ddab81ef0",
   "name" : "AwsBlobStoreIT_testDownload_happy-GET-16",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_happy_unversioned",
@@ -7,24 +7,25 @@
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:58:02 GMT",
-      "x-amz-request-id" : "VCJ480SD0KHAZ38G",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 19:42:51 GMT",
+      "x-amz-request-id" : "MCVC083CXDX0QP8C",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "ZN8kXfnjikdYpOHGtsOmqb7ASZzBIqyHXEeMObxHoNXRyNn0rRQETYlaHE4PI1W6FcArm2yKn8b63DTqDYLE4QjdOToW75ev",
-      "x-amz-transfer-encoding" : "append-md5",
-      "Date" : "Wed, 04 Mar 2026 20:58:02 GMT",
+      "x-amz-id-2" : "PK+qMaFF4ZOlk2pNIha+r952SJdMAGvYJuUxo0QRlYKnbA+2KOmgC8f0zAJqsju34GoyFR8JppaIcLRZfyEQWUsUZkZll9my",
+      "Date" : "Sun, 12 Jul 2026 19:42:52 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "789ad458-d52e-4ccc-a4a6-b53f5b53ce7b",
+  "uuid" : "d11e81b4-c378-4894-bfdf-e70ddab81ef0",
   "persistent" : true,
   "scenarioName" : "scenario-4-chameleon-jcloud-conformance-tests-download_happy_unversioned",
   "requiredScenarioState" : "scenario-4-chameleon-jcloud-conformance-tests-download_happy_unversioned-3",
   "newScenarioState" : "scenario-4-chameleon-jcloud-conformance-tests-download_happy_unversioned-4",
-  "insertionIndex" : 282
+  "insertionIndex" : 787
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-19.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-19.json
@@ -1,5 +1,5 @@
 {
-  "id" : "7e811c48-4af9-4dc0-87ff-4d5085960096",
+  "id" : "25bcc813-9ff3-48a4-a22f-8cdc2471c806",
   "name" : "AwsBlobStoreIT_testDownload_happy-GET-19",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_happy_unversioned",
@@ -7,24 +7,25 @@
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:58:00 GMT",
-      "x-amz-request-id" : "FYKWPMW3SJQEQV07",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 19:42:50 GMT",
+      "x-amz-request-id" : "NG275Q2E8CXWVKZ5",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "b28d7TfukFeejJ9Fn2yg8Fal+N/bGm5SwdX2ACoixvN9JqXd294opLcLuz4JdnkUkiumQFVjrZBlwX2bD1lBx6pZ+qpX28XD",
-      "x-amz-transfer-encoding" : "append-md5",
-      "Date" : "Wed, 04 Mar 2026 20:58:01 GMT",
+      "x-amz-id-2" : "IYaRBWMnoOTp1RLHbl8BTuvGhWX0K4AIhYUeSba/HlS3hxoxoFVf/L9nlJ/70hxxFlShKfdoiXk0zDPVD/sTsrN+ZfKca3XF",
+      "Date" : "Sun, 12 Jul 2026 19:42:50 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "7e811c48-4af9-4dc0-87ff-4d5085960096",
+  "uuid" : "25bcc813-9ff3-48a4-a22f-8cdc2471c806",
   "persistent" : true,
   "scenarioName" : "scenario-4-chameleon-jcloud-conformance-tests-download_happy_unversioned",
   "requiredScenarioState" : "scenario-4-chameleon-jcloud-conformance-tests-download_happy_unversioned-2",
   "newScenarioState" : "scenario-4-chameleon-jcloud-conformance-tests-download_happy_unversioned-3",
-  "insertionIndex" : 285
+  "insertionIndex" : 790
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-22.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-22.json
@@ -1,5 +1,5 @@
 {
-  "id" : "2d59aa08-e56b-4eed-8a59-0c20878f4b6d",
+  "id" : "a04fcc44-3a72-4e27-bf29-4ea590d4adcc",
   "name" : "AwsBlobStoreIT_testDownload_happy-GET-22",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_happy_unversioned",
@@ -7,24 +7,25 @@
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:57:59 GMT",
-      "x-amz-request-id" : "P6DC27Z2KNS3RB3A",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 19:42:48 GMT",
+      "x-amz-request-id" : "F0TQDV0G553BSH6D",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "WN83HRQeRsMU0JiH8xO0VebTrsdss4TWuxouzUX0ImHIq5g622E0kiBiitEciM7C4iF/jf3vzaSCINynCx2qwsMSRHAElrXx",
-      "x-amz-transfer-encoding" : "append-md5",
-      "Date" : "Wed, 04 Mar 2026 20:57:59 GMT",
+      "x-amz-id-2" : "lmId+CFjwMU/WguT/XT7u8exTjG79N3zOd6XJ0/Z3cFJLRlXb0IortBkFmzr5lxVlWVCRApZv0UQy3V3QRXsUueuR2IxXdT8",
+      "Date" : "Sun, 12 Jul 2026 19:42:49 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "2d59aa08-e56b-4eed-8a59-0c20878f4b6d",
+  "uuid" : "a04fcc44-3a72-4e27-bf29-4ea590d4adcc",
   "persistent" : true,
   "scenarioName" : "scenario-4-chameleon-jcloud-conformance-tests-download_happy_unversioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-4-chameleon-jcloud-conformance-tests-download_happy_unversioned-2",
-  "insertionIndex" : 288
+  "insertionIndex" : 793
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-4.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "d482aed4-ba10-42e7-a377-895080038602",
+  "id" : "60137c9a-b041-4696-96cb-89fddc980bf4",
   "name" : "AwsBlobStoreIT_testDownload_happy-GET-4",
   "request" : {
     "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/download_happy_versioned",
@@ -12,29 +12,30 @@
     "queryParameters" : {
       "versionId" : {
         "hasExactly" : [ {
-          "equalTo" : "1606SfDHAC8P0iWZbEK3wQyWRJDi6SIh"
+          "equalTo" : "MiUZ85OA.DH4cvrhmkqeDTbL0D_zfL.e"
         } ]
       }
     }
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:58:07 GMT",
-      "x-amz-request-id" : "QFGK06QH71QVWVJF",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 19:42:57 GMT",
+      "x-amz-request-id" : "86JBT0XY7X8QM73K",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "R085VOsNRv2Bfv0rrCXcOsy70+xgt0Jau9J+wCGjQWFLfdZ5MaMuWN50/T2r5YIGIoXU80G3iRFRJqw3n5H+DSaPOCQiBU/i",
-      "x-amz-transfer-encoding" : "append-md5",
-      "x-amz-version-id" : "1606SfDHAC8P0iWZbEK3wQyWRJDi6SIh",
-      "Date" : "Wed, 04 Mar 2026 20:58:07 GMT",
+      "x-amz-id-2" : "LduAmib7qeX1yNMHkonLOiw8BP8GL+2wiSYsW16Nzp2eQ5/2A+oioeZl1HrEp8zMBn/Vkt5fOVN8f4J2pH3atjJ/P0I9uMbG",
+      "x-amz-version-id" : "MiUZ85OA.DH4cvrhmkqeDTbL0D_zfL.e",
+      "Date" : "Sun, 12 Jul 2026 19:42:57 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "d482aed4-ba10-42e7-a377-895080038602",
+  "uuid" : "60137c9a-b041-4696-96cb-89fddc980bf4",
   "persistent" : true,
-  "insertionIndex" : 270
+  "insertionIndex" : 775
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-7.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-get-7.json
@@ -1,5 +1,5 @@
 {
-  "id" : "f6bf4b9f-5925-4f14-91aa-22aeeccef5fd",
+  "id" : "c1728c73-3bf0-4cf6-b565-4f48a3cdce53",
   "name" : "AwsBlobStoreIT_testDownload_happy-GET-7",
   "request" : {
     "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/download_happy_versioned",
@@ -12,29 +12,30 @@
     "queryParameters" : {
       "versionId" : {
         "hasExactly" : [ {
-          "equalTo" : "EVhIcf.fjHpDPLYqE.x4camYQFgIEZH_"
+          "equalTo" : "o6QisGtDRj.sZhA1mbdNPc7O6WRw95aP"
         } ]
       }
     }
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:58:05 GMT",
-      "x-amz-request-id" : "RQ2NDJTB5W2B4QQA",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 19:42:56 GMT",
+      "x-amz-request-id" : "ZCT9EWWRHS2KC74D",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "LddZxifdmAxCew70pj/wLLvSVhgbargvdxXiYEI+jgbk4eQtBXGSGh4sOPbVE/8vPkg91cxqtRZu23xaM7dzMI2czVvJnVpu",
-      "x-amz-transfer-encoding" : "append-md5",
-      "x-amz-version-id" : "EVhIcf.fjHpDPLYqE.x4camYQFgIEZH_",
-      "Date" : "Wed, 04 Mar 2026 20:58:06 GMT",
+      "x-amz-id-2" : "W/egB5B2GkhMasrHhQo6Bf2Ifp3ehMfUlTI/tWLacBjNbNx5vAgsUhJp27Gmh17LE66rER26Q74iAacn98mXHFfYam4O6Y8a",
+      "x-amz-version-id" : "o6QisGtDRj.sZhA1mbdNPc7O6WRw95aP",
+      "Date" : "Sun, 12 Jul 2026 19:42:56 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "f6bf4b9f-5925-4f14-91aa-22aeeccef5fd",
+  "uuid" : "c1728c73-3bf0-4cf6-b565-4f48a3cdce53",
   "persistent" : true,
-  "insertionIndex" : 273
+  "insertionIndex" : 778
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-11.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-11.json
@@ -1,5 +1,5 @@
 {
-  "id" : "f11d97ed-7ab2-4bea-8ddf-006939e971ae",
+  "id" : "1bec5304-56a6-4f1d-9a0b-1c4125569849",
   "name" : "AwsBlobStoreIT_testDownload_happy-PUT-11",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/download_happy_versioned",
@@ -15,17 +15,17 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "GV96V8K9TQ90N94D",
+      "x-amz-request-id" : "8D3NCNPX6N4JC8V2",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "1sD9yNc/ARTr2y2H0vvEE32LEQ8N/oHbjKqe9IU0/twdZS58sLlxA9KU4faqVQh1+K57uNnnu01Sx8vMfD1GM7T2MxmR58Jl",
-      "x-amz-version-id" : "ARrb67OlnCAbywNmptBH1aeDXjOmt.So",
-      "Date" : "Wed, 04 Mar 2026 20:58:04 GMT"
+      "x-amz-id-2" : "SFFGjJBMDj4xTQcwkuuJTR71u7fWAkD9FLBTaKri/Vk5234Nl/HY5Ui4sgPjTsXkHjfKYGNHYYbBOyJhSjk0N6kTm+s5O79S",
+      "x-amz-version-id" : "yD5ps0UM2Srmg6GXCWNuv_IFD1eFJDZB",
+      "Date" : "Sun, 12 Jul 2026 19:42:54 GMT"
     }
   },
-  "uuid" : "f11d97ed-7ab2-4bea-8ddf-006939e971ae",
+  "uuid" : "1bec5304-56a6-4f1d-9a0b-1c4125569849",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned-2",
-  "insertionIndex" : 277
+  "insertionIndex" : 782
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-14.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-14.json
@@ -1,5 +1,5 @@
 {
-  "id" : "1b9a71dc-163a-4d58-a388-66f505b154ad",
+  "id" : "11e3c812-ad31-4560-be1d-d254e540aaba",
   "name" : "AwsBlobStoreIT_testDownload_happy-PUT-14",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_happy_unversioned",
@@ -15,15 +15,15 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "FJ494TATBQ1X3E54",
+      "x-amz-request-id" : "9B9C75XNX06RD3T8",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "Ug8qRrxo3ihJu9fUAQtk4iTZKw9q3sRnLu70Au30tVSnIFrGZzSWxMtJPSBmwIWTRi53wffdC0TPzKe3UhIKHSmyGhIQ89PD",
-      "Date" : "Wed, 04 Mar 2026 20:58:03 GMT"
+      "x-amz-id-2" : "S/xdZtP101yy1kDJaecbGDaggoYC+HiKTIgAFLZw8OjLDDxByEacQIi4XieNOiVZnIjVynORJtkqVQhr0tptXubFIukAMp3R",
+      "Date" : "Sun, 12 Jul 2026 19:42:53 GMT"
     }
   },
-  "uuid" : "1b9a71dc-163a-4d58-a388-66f505b154ad",
+  "uuid" : "11e3c812-ad31-4560-be1d-d254e540aaba",
   "persistent" : true,
   "scenarioName" : "scenario-5-chameleon-jcloud-conformance-tests-download_happy_unversioned",
   "requiredScenarioState" : "scenario-5-chameleon-jcloud-conformance-tests-download_happy_unversioned-4",
-  "insertionIndex" : 280
+  "insertionIndex" : 785
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-17.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-17.json
@@ -1,5 +1,5 @@
 {
-  "id" : "806de803-9cf6-40d0-bd1f-c5e02be27a98",
+  "id" : "a0c180ca-d727-4ad7-bff9-55424eff4cfe",
   "name" : "AwsBlobStoreIT_testDownload_happy-PUT-17",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_happy_unversioned",
@@ -15,16 +15,16 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "VCJ4GNDRREBH65BS",
+      "x-amz-request-id" : "7TK33888DGWED06K",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "kdGDfSehbOKJaZIOm0yr7TwQZkinkkAKttNqz0m/i0C8y+oY6q2CASH1Xp50TGSlO+ffr4OguRPyZEOvlYzGxEJfnwR3r2Uq",
-      "Date" : "Wed, 04 Mar 2026 20:58:02 GMT"
+      "x-amz-id-2" : "d8o5E6KUkL7/BEeM7to2ya524AmROhzzDTg0RZKSylN2ywSpygHnezZIEZmpr2WydZ3x9Uovf4Q2ybl4ZdgUna5aPHl6bXfK",
+      "Date" : "Sun, 12 Jul 2026 19:42:51 GMT"
     }
   },
-  "uuid" : "806de803-9cf6-40d0-bd1f-c5e02be27a98",
+  "uuid" : "a0c180ca-d727-4ad7-bff9-55424eff4cfe",
   "persistent" : true,
   "scenarioName" : "scenario-5-chameleon-jcloud-conformance-tests-download_happy_unversioned",
   "requiredScenarioState" : "scenario-5-chameleon-jcloud-conformance-tests-download_happy_unversioned-3",
   "newScenarioState" : "scenario-5-chameleon-jcloud-conformance-tests-download_happy_unversioned-4",
-  "insertionIndex" : 283
+  "insertionIndex" : 788
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "e67299c9-f91d-435b-8881-b1a8f24dff05",
+  "id" : "276f4fea-d589-4414-a3de-a938d47a36fb",
   "name" : "AwsBlobStoreIT_testDownload_happy-PUT-2",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/download_happy_versioned",
@@ -15,16 +15,16 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "DGX7P6SCNB5Q7H5K",
+      "x-amz-request-id" : "9F7837Q9K1HBK6QC",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "hYUYY1XLf3bfQfwSysnd893XWhKa1dBb2XbBrRdomCbBflyxQ2aD1ukru3NUCqKWrXKWqvuExbdO8/HNS2vaA7fTrzOw1XJw",
-      "x-amz-version-id" : "XDan8AP7R0kUltLfiWnd3o6I0.HRgS1L",
-      "Date" : "Wed, 04 Mar 2026 20:58:08 GMT"
+      "x-amz-id-2" : "3tKyFrx9+HLb/CromRb+AYOrvCDMS86CBUAKqnXCGAgVJTcC52bgg+TlxOdfx8BssIEGgkGaf06TTvVtTMz2x6yvGCH6nLDn",
+      "x-amz-version-id" : "66rN2qe4FmL6pgfPFdPk4wbylnY5hNjD",
+      "Date" : "Sun, 12 Jul 2026 19:42:58 GMT"
     }
   },
-  "uuid" : "e67299c9-f91d-435b-8881-b1a8f24dff05",
+  "uuid" : "276f4fea-d589-4414-a3de-a938d47a36fb",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned",
   "requiredScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned-4",
-  "insertionIndex" : 268
+  "insertionIndex" : 773
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-20.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-20.json
@@ -1,5 +1,5 @@
 {
-  "id" : "a8ad2f0a-18e0-4c1a-8ce4-6c60cafd5c4a",
+  "id" : "5ddbfd72-5c42-4971-bbca-d6a713d2b9c2",
   "name" : "AwsBlobStoreIT_testDownload_happy-PUT-20",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_happy_unversioned",
@@ -15,16 +15,16 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "YTAJ1QRK3YDFVKQN",
+      "x-amz-request-id" : "NG27K0K4RWR5889P",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "Sudc9tH3nZlLiho6Lxrqw8YCALyhnwVMBy7XnaehZyukmLxjX/xiGEBYjBTj0FsNHvIalBEd6KsSi78QTcf22cVtUmlO8Wcl",
-      "Date" : "Wed, 04 Mar 2026 20:58:00 GMT"
+      "x-amz-id-2" : "lnHJk/h3IAUAknGiFPAYX9UkvxSLiAb+uflVArbxdMdSfq6ejIcsOQvh7qEoLPpZVLBLktmMO+Yotqz1zc8KWptvIgxJ68+l",
+      "Date" : "Sun, 12 Jul 2026 19:42:50 GMT"
     }
   },
-  "uuid" : "a8ad2f0a-18e0-4c1a-8ce4-6c60cafd5c4a",
+  "uuid" : "5ddbfd72-5c42-4971-bbca-d6a713d2b9c2",
   "persistent" : true,
   "scenarioName" : "scenario-5-chameleon-jcloud-conformance-tests-download_happy_unversioned",
   "requiredScenarioState" : "scenario-5-chameleon-jcloud-conformance-tests-download_happy_unversioned-2",
   "newScenarioState" : "scenario-5-chameleon-jcloud-conformance-tests-download_happy_unversioned-3",
-  "insertionIndex" : 286
+  "insertionIndex" : 791
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-23.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-23.json
@@ -1,5 +1,5 @@
 {
-  "id" : "06031e58-e5a7-44cf-a9b4-a2362a98d8b5",
+  "id" : "acccf84e-488a-4251-bdfd-bf7413b5ab1c",
   "name" : "AwsBlobStoreIT_testDownload_happy-PUT-23",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/download_happy_unversioned",
@@ -15,16 +15,16 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "P6D8YYFWQ8C8CJ3S",
+      "x-amz-request-id" : "637HCJSPVMNZ5CER",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "BhZ9hUCBtp0MeaiyaY4gqOsYJpAn7nMexc1woMngaQG4reguefJmFvnn1OJ9SZT1AsgFkHkFAvXr8Z1GGBDueI5eO0/MYdyL",
-      "Date" : "Wed, 04 Mar 2026 20:57:59 GMT"
+      "x-amz-id-2" : "JMpJOAiU346MW3xjTnlA8BZsFEyuDh9uXbVtKJBusIm3EwIcow6vWGQK4WKHBPBZR7poPXdUm7NUDmNguLA6p26CYQBHpucQ",
+      "Date" : "Sun, 12 Jul 2026 19:42:48 GMT"
     }
   },
-  "uuid" : "06031e58-e5a7-44cf-a9b4-a2362a98d8b5",
+  "uuid" : "acccf84e-488a-4251-bdfd-bf7413b5ab1c",
   "persistent" : true,
   "scenarioName" : "scenario-5-chameleon-jcloud-conformance-tests-download_happy_unversioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-5-chameleon-jcloud-conformance-tests-download_happy_unversioned-2",
-  "insertionIndex" : 289
+  "insertionIndex" : 794
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-5.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-5.json
@@ -1,5 +1,5 @@
 {
-  "id" : "6aad6feb-056d-40c6-b07a-5abcbb403200",
+  "id" : "0feec347-555a-4503-97df-be79f91e59fe",
   "name" : "AwsBlobStoreIT_testDownload_happy-PUT-5",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/download_happy_versioned",
@@ -15,17 +15,17 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "QFGRK2FDXMB90C66",
+      "x-amz-request-id" : "86JFJWVEJY8JX4R5",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "ElZUIUqTBA1yyZEwZnVjBgjNaysbHa3N/m36E3Hh6osj1oKxw8skpP6FYOV1BaJSs6LZzJ7fb9nfK7rl9qqQtTkCrtsydZco",
-      "x-amz-version-id" : "1606SfDHAC8P0iWZbEK3wQyWRJDi6SIh",
-      "Date" : "Wed, 04 Mar 2026 20:58:07 GMT"
+      "x-amz-id-2" : "YEajWIu/i9VXzCsKY7E4aPGJVCI42RenALPN4LzDBNuVkDyLuORLgXsJORB5PyhMAZlTdgBfcu6itWHkNv35+QQJSlf7j3K3",
+      "x-amz-version-id" : "MiUZ85OA.DH4cvrhmkqeDTbL0D_zfL.e",
+      "Date" : "Sun, 12 Jul 2026 19:42:57 GMT"
     }
   },
-  "uuid" : "6aad6feb-056d-40c6-b07a-5abcbb403200",
+  "uuid" : "0feec347-555a-4503-97df-be79f91e59fe",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned",
   "requiredScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned-3",
   "newScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned-4",
-  "insertionIndex" : 271
+  "insertionIndex" : 776
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-8.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testdownload_happy-put-8.json
@@ -1,5 +1,5 @@
 {
-  "id" : "3996fd96-883d-4e75-acf6-d478e5e4a650",
+  "id" : "1be7c127-f358-4dd3-b26a-fcd19157d8e3",
   "name" : "AwsBlobStoreIT_testDownload_happy-PUT-8",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/download_happy_versioned",
@@ -15,17 +15,17 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "9SMSQSMMKHBCF333",
+      "x-amz-request-id" : "ZCT7TPDMVYTZDS49",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "wMH9tkBXx4K2/RIEgmT/7C016wjZdtmNxFQRbciM3J+6T/Q7Tqrk70oGHnKpP/BkM20eAu2MbxeSNAI4UdIbVe2dB2exuFrn",
-      "x-amz-version-id" : "EVhIcf.fjHpDPLYqE.x4camYQFgIEZH_",
-      "Date" : "Wed, 04 Mar 2026 20:58:05 GMT"
+      "x-amz-id-2" : "Fy0ru0fcIseAtjckf/08kRpOaDoc4/rHRy9kO27QVaYpOODKtIiIJzmvT6zRpOMSg+M1S0eKydtRHcLCsvFnH4CMBSHjbl7o",
+      "x-amz-version-id" : "o6QisGtDRj.sZhA1mbdNPc7O6WRw95aP",
+      "Date" : "Sun, 12 Jul 2026 19:42:56 GMT"
     }
   },
-  "uuid" : "3996fd96-883d-4e75-acf6-d478e5e4a650",
+  "uuid" : "1be7c127-f358-4dd3-b26a-fcd19157d8e3",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned",
   "requiredScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned-2",
   "newScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-download_happy_versioned-3",
-  "insertionIndex" : 274
+  "insertionIndex" : 779
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetmetadata-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetmetadata-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "4c2016a3-76d5-4e94-b12c-299b166f2a96",
+  "id" : "f82b8baf-3a6c-4ace-a44c-ab1baca49553",
   "name" : "AwsBlobStoreIT_testGetMetadata-DELETE-0",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/blob-for-metadata",
@@ -9,12 +9,12 @@
     "status" : 204,
     "headers" : {
       "Server" : "AmazonS3",
-      "x-amz-request-id" : "PC5HGAD94MJRK965",
-      "x-amz-id-2" : "4XTpPKEsRlKdnlNELQAuA3qk1ZhjvyR3ug+Mdax6s8iOIb64RxsUCshUIt9eyLCopwdUj/tAS3Fm86WjtXt59VHgNetk0mgM",
-      "Date" : "Wed, 04 Mar 2026 20:59:13 GMT"
+      "x-amz-request-id" : "M0759FZMH05DCV1P",
+      "x-amz-id-2" : "ouqO2PjLr7Ak5pmL1+mtsSABIjwlCXQ8Q/lnDs5gVmZpKG6YFXipMpy6Yp+vQeBF/5Ne9DtgkICfI4Yp/MtIyzo2lX1uqxNg",
+      "Date" : "Sun, 12 Jul 2026 20:59:22 GMT"
     }
   },
-  "uuid" : "4c2016a3-76d5-4e94-b12c-299b166f2a96",
+  "uuid" : "f82b8baf-3a6c-4ace-a44c-ab1baca49553",
   "persistent" : true,
-  "insertionIndex" : 431
+  "insertionIndex" : 771
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetmetadata-head-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetmetadata-head-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "9faf69ae-bf7e-4300-b6d5-0427966df007",
+  "id" : "04bbf6bf-5887-40c3-b0d5-f8a0fda3dde0",
   "name" : "AwsBlobStoreIT_testGetMetadata-HEAD-1",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/blob-for-metadata3",
@@ -8,20 +8,22 @@
   "response" : {
     "status" : 200,
     "headers" : {
-      "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "x-amz-meta-abc" : "foo",
-      "ETag" : "\"70936fa816e1a46688cab3b78c74a8cc\"",
-      "x-amz-meta-def" : "bar",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:59:12 GMT",
-      "x-amz-request-id" : "FZQ71810Y4Y756DW",
+      "Last-Modified" : "Sun, 12 Jul 2026 20:59:21 GMT",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "q7Lvok4l6kYpb06QIwsJeuxqH5Eskw40K5z9fbaHiDwC21Bcsge7nt5f7NbkrWPiA2jBzokIByrozGoT6jeHeAzxwDn/5KtL",
-      "Date" : "Wed, 04 Mar 2026 20:59:12 GMT",
+      "Date" : "Sun, 12 Jul 2026 20:59:22 GMT",
+      "Accept-Ranges" : "bytes",
+      "ETag" : "\"70936fa816e1a46688cab3b78c74a8cc\"",
+      "x-amz-checksum-crc64nvme" : "FYQWcW2DJHo=",
+      "x-amz-meta-def" : "bar",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "M0739JN2KS7PCCWE",
+      "x-amz-id-2" : "JrPIG6whgJPyzTSnkLR9PLtdNLm9BOJ/8dA1+Opg5QzGlReBtpVdxrcYcOqRRPLoP3/NjGDNgRvx4UORVsrLpz+hSiheUA78",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "9faf69ae-bf7e-4300-b6d5-0427966df007",
+  "uuid" : "04bbf6bf-5887-40c3-b0d5-f8a0fda3dde0",
   "persistent" : true,
-  "insertionIndex" : 432
+  "insertionIndex" : 772
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetmetadata-head-3.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetmetadata-head-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "cfd36fae-36b7-4414-bc50-b15d20723a69",
+  "id" : "f3479541-2a8d-425f-bb2f-ddce9b61353b",
   "name" : "AwsBlobStoreIT_testGetMetadata-HEAD-3",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/blob-for-metadata",
@@ -11,15 +11,17 @@
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"70936fa816e1a46688cab3b78c74a8cc\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:59:11 GMT",
-      "x-amz-request-id" : "72P98SR2386ZX8FV",
+      "x-amz-checksum-crc64nvme" : "FYQWcW2DJHo=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 20:59:20 GMT",
+      "x-amz-request-id" : "Z96RZCF6VX677V3Z",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "0d72DHg2aHAuPb53L1zS8CavfXHQPYc/yAEVUWWfGTHuFVA3STDKOLQE2x3q7mYCG2LCKsSlL6+cv3HWi3bQRX8Zg6lHxuIK",
-      "Date" : "Wed, 04 Mar 2026 20:59:11 GMT",
+      "x-amz-id-2" : "VFiX1LVLF3nSaBNXE85qGbXfIBxr1zXmfen+fZespzArfF8LBfvla9pzo6cTB5LGa6NxC9yYiMR98jZ/ZZhwny4XyhKfU5G8",
+      "Date" : "Sun, 12 Jul 2026 20:59:21 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "cfd36fae-36b7-4414-bc50-b15d20723a69",
+  "uuid" : "f3479541-2a8d-425f-bb2f-ddce9b61353b",
   "persistent" : true,
-  "insertionIndex" : 434
+  "insertionIndex" : 774
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetmetadata-put-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetmetadata-put-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "397c6016-94c7-4111-aadb-75b75aa7065f",
+  "id" : "54dd91f0-9949-4800-b0e0-6458c81d0173",
   "name" : "AwsBlobStoreIT_testGetMetadata-PUT-2",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/blob-for-metadata3",
@@ -15,13 +15,13 @@
       "ETag" : "\"70936fa816e1a46688cab3b78c74a8cc\"",
       "x-amz-checksum-crc64nvme" : "FYQWcW2DJHo=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "FZQ5ZVAV4T2EEWSY",
+      "x-amz-request-id" : "Z96HY7ZC8W1GKAYD",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "D97BKKdI2dcbIUea5Y6KyYOrYXP1PNAQrjBcPOrb5Gs15WTWDo0fligNBd6pcL0+W0QPAWLczqz5L9IuQOOLyQi/31zYYQo4",
-      "Date" : "Wed, 04 Mar 2026 20:59:12 GMT"
+      "x-amz-id-2" : "f4xze0PcsCJp2XAqt8IaZa0+tVSo3CzXRz981kk53J/qmOqqHzXdACeldByvRQl3yjz/COMXFPlKfLcrPWRhDsLouaVhZy7Q",
+      "Date" : "Sun, 12 Jul 2026 20:59:21 GMT"
     }
   },
-  "uuid" : "397c6016-94c7-4111-aadb-75b75aa7065f",
+  "uuid" : "54dd91f0-9949-4800-b0e0-6458c81d0173",
   "persistent" : true,
-  "insertionIndex" : 433
+  "insertionIndex" : 773
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetmetadata-put-4.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testgetmetadata-put-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "5da0dabd-f9d9-4b45-a62c-4d137724bddd",
+  "id" : "62757df8-97eb-4707-8d2d-79c1d6f77b7f",
   "name" : "AwsBlobStoreIT_testGetMetadata-PUT-4",
   "request" : {
     "url" : "/chameleon-jcloud/conformance-tests/blob-for-metadata",
@@ -15,13 +15,13 @@
       "ETag" : "\"70936fa816e1a46688cab3b78c74a8cc\"",
       "x-amz-checksum-crc64nvme" : "FYQWcW2DJHo=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "72PD2VADV7QEF5YA",
+      "x-amz-request-id" : "K45FCMKPF78VP6FH",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "0MdiS9p0vJU8dmnJtiig4YKM1AiFU/wy05loCx26sX3sRfGY5X3CQgG5Fm3McZAEOhxZoHqWIFFOvGEMoacfrDxRHMID91OW",
-      "Date" : "Wed, 04 Mar 2026 20:59:11 GMT"
+      "x-amz-id-2" : "DC5i9O3SaIFsIe3krDbXwiaIBTWBf+d3oQXdkdORbU2Ki7rH+N1YJ/UlzTp+FlDu8Uwp75xD3CHgqOnOOVxnyPtDgqUu0Pfd",
+      "Date" : "Sun, 12 Jul 2026 20:59:20 GMT"
     }
   },
-  "uuid" : "5da0dabd-f9d9-4b45-a62c-4d137724bddd",
+  "uuid" : "62757df8-97eb-4707-8d2d-79c1d6f77b7f",
   "persistent" : true,
-  "insertionIndex" : 435
+  "insertionIndex" : 775
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "323d1b1a-920d-43cf-9392-57468c371fa4",
+  "id" : "933ca791-5479-41d2-823d-622e40961f77",
   "name" : "AwsBlobStoreIT_testVersionedDownload_happy-DELETE-0",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_happy_versioned",
@@ -10,15 +10,15 @@
     "headers" : {
       "Server" : "AmazonS3",
       "x-amz-delete-marker" : "true",
-      "x-amz-request-id" : "HRY4ERHZE4E40YNS",
-      "x-amz-id-2" : "FORElono/7+go73gmJ76Ai9ndzTm6orNH1CDn8KAoMolLq+7aBSI3S2eWmYs4uzm1IxDm4LJTkQwqqbGichtSM0ZbQ0DzIkn",
-      "x-amz-version-id" : "RVi.8w4QFv5d6zkApaXc7Gfe7UbQGVM1",
-      "Date" : "Wed, 04 Mar 2026 20:59:28 GMT"
+      "x-amz-request-id" : "9Q193PFR2Z1N8HZN",
+      "x-amz-id-2" : "rV9oGPsY8vcUrWNvED7+DKigqsNh7zh5pv5SefHgSpiT8TG5VeHw3f7B4CI9Yzea69sn6i+S2OSJrH2X+TuxltPMLYBoXXdy",
+      "x-amz-version-id" : "MlIYLE8B8ZDLn95rAm1WpyVrpABs9KkH",
+      "Date" : "Sun, 12 Jul 2026 21:12:08 GMT"
     }
   },
-  "uuid" : "323d1b1a-920d-43cf-9392-57468c371fa4",
+  "uuid" : "933ca791-5479-41d2-823d-622e40961f77",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned",
   "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned-4",
-  "insertionIndex" : 455
+  "insertionIndex" : 791
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-delete-3.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-delete-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "849099ca-43ab-40dd-a121-31cee55e33b8",
+  "id" : "005d0706-4ed1-49d8-93c8-415e5342399c",
   "name" : "AwsBlobStoreIT_testVersionedDownload_happy-DELETE-3",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_happy_versioned",
@@ -10,16 +10,16 @@
     "headers" : {
       "Server" : "AmazonS3",
       "x-amz-delete-marker" : "true",
-      "x-amz-request-id" : "J5N6FJFWK3YQ4HWQ",
-      "x-amz-id-2" : "+81p4FYgSsjNeZ02QvUvFM10Hiwwc0vllLTiF7j33jJrYRSbiLpAd/WJoTsEvNdjQYq0w5J31IOsMWfa9lF93csUU8qPqP0P",
-      "x-amz-version-id" : "B5TPOt3IxMj1.HPlBEKGylpZ12gLHRm1",
-      "Date" : "Wed, 04 Mar 2026 20:59:26 GMT"
+      "x-amz-request-id" : "VC98GQ7MKM0K9RP9",
+      "x-amz-id-2" : "IhKaA5Gf4z2hAjj+Bs1CZ9r9ZH0UeAfjrF7rE/sUEyAkw6uocFeSFk13Ql756V/g4r5l2EQPJVvwhSP81ySDkghgzfrPIzV3",
+      "x-amz-version-id" : "LZMW9GHI7fIL.6FFqKTySmMpozStOmeU",
+      "Date" : "Sun, 12 Jul 2026 21:12:07 GMT"
     }
   },
-  "uuid" : "849099ca-43ab-40dd-a121-31cee55e33b8",
+  "uuid" : "005d0706-4ed1-49d8-93c8-415e5342399c",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned",
   "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned-3",
   "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned-4",
-  "insertionIndex" : 458
+  "insertionIndex" : 794
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-delete-6.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-delete-6.json
@@ -1,5 +1,5 @@
 {
-  "id" : "c303f0d2-27a8-491d-856b-5eb982feb78c",
+  "id" : "d32eec55-02d6-45f3-b9b4-d24a3a50a0ef",
   "name" : "AwsBlobStoreIT_testVersionedDownload_happy-DELETE-6",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_happy_versioned",
@@ -10,16 +10,16 @@
     "headers" : {
       "Server" : "AmazonS3",
       "x-amz-delete-marker" : "true",
-      "x-amz-request-id" : "FBF433DEJYKYWPY9",
-      "x-amz-id-2" : "0sf46ZYyvnOvGIgIArD34YMAOjj0je9USlE4kpGIbhxofg01uLKYqvwH41XDoDzKG5Nz2Em+Q4KMBO7DN3unJpnwxHpMLZIv",
-      "x-amz-version-id" : "qRjnR.VmG4KqtKYbimSwm4zU4gQEtZUJ",
-      "Date" : "Wed, 04 Mar 2026 20:59:25 GMT"
+      "x-amz-request-id" : "2A4MM910M1D41PRJ",
+      "x-amz-id-2" : "YwAuHhznIpGoFNW7IzZRUABvMts0WnQ5J69xRBJiFXBE9O6c4NaLMbAlV4SnCaXFVqtepobZQ6PZ4sc5LmY2KDdjf5gAZQUl",
+      "x-amz-version-id" : "nVbRtXKqGPR2AftpEXfnUCEqnv0pdRiU",
+      "Date" : "Sun, 12 Jul 2026 21:12:06 GMT"
     }
   },
-  "uuid" : "c303f0d2-27a8-491d-856b-5eb982feb78c",
+  "uuid" : "d32eec55-02d6-45f3-b9b4-d24a3a50a0ef",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned",
   "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned-2",
   "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned-3",
-  "insertionIndex" : 461
+  "insertionIndex" : 797
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-delete-9.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-delete-9.json
@@ -1,5 +1,5 @@
 {
-  "id" : "599ef39d-e181-4c35-b839-12193958056d",
+  "id" : "811f391e-982a-40f1-991d-efc39d07a483",
   "name" : "AwsBlobStoreIT_testVersionedDownload_happy-DELETE-9",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_happy_versioned",
@@ -10,16 +10,16 @@
     "headers" : {
       "Server" : "AmazonS3",
       "x-amz-delete-marker" : "true",
-      "x-amz-request-id" : "FFNA0VT9ZFJ6AF5F",
-      "x-amz-id-2" : "L8snHNWmLogTybZ7vmxID9c447d6swU91xjk1ULJTwjb+QdAmR3cNDguQM9ptCwAae7U/3xXFxIlsrfKXyIitBA8iCzzpt0C",
-      "x-amz-version-id" : "yqvleTh.VK1u5o0CYTgeVKcNfwXcsZe6",
-      "Date" : "Wed, 04 Mar 2026 20:59:24 GMT"
+      "x-amz-request-id" : "3KKKA57DN2Q9RNRA",
+      "x-amz-id-2" : "F5IDKswZQ9M439IjizPYxKqC14baz7qxoSDzlyMgSgFgGeRFGHM/e1m/DWoHwji9DIZPfFqFLiwTP+C7I/OKCcshC8/XXrHK",
+      "x-amz-version-id" : "mL.DY6jnEffX6eYPnazsn8U2eDz.xyil",
+      "Date" : "Sun, 12 Jul 2026 21:12:04 GMT"
     }
   },
-  "uuid" : "599ef39d-e181-4c35-b839-12193958056d",
+  "uuid" : "811f391e-982a-40f1-991d-efc39d07a483",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned-2",
-  "insertionIndex" : 464
+  "insertionIndex" : 800
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "48d50196-fb7d-40d1-b9ff-3a42fa5dcbbb",
+  "id" : "b87b3cb5-23ab-4349-9adf-871094122d5f",
   "name" : "AwsBlobStoreIT_testVersionedDownload_happy-GET-1",
   "request" : {
     "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_happy_versioned",
@@ -12,29 +12,30 @@
     "queryParameters" : {
       "versionId" : {
         "hasExactly" : [ {
-          "equalTo" : "v1o3xl26WLC0wY0zvVS0CxlDVHB4B72P"
+          "equalTo" : "c3qG27FoIyufZ04vZatrWLjksQaI9Yo6"
         } ]
       }
     }
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:59:27 GMT",
-      "x-amz-request-id" : "JNGNP9QHZY2VGP6S",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 21:12:07 GMT",
+      "x-amz-request-id" : "9Q12WEBTFMTZ5B1A",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "l5ErwIldx0BbwF4T7Ajn7UuzHqGJtsX4fRfvyS6bog1KVGCrZlnYfb8IDoNuOVSpcic81zTy9H+dip8zpFvlTOcYXrbLEGpb",
-      "x-amz-transfer-encoding" : "append-md5",
-      "x-amz-version-id" : "v1o3xl26WLC0wY0zvVS0CxlDVHB4B72P",
-      "Date" : "Wed, 04 Mar 2026 20:59:27 GMT",
+      "x-amz-id-2" : "XyQkg+V9+F8hOsu8jXwwIwI3zC+WYhsbIzrRnyL0GS7G/7wgAM2pcispvJTIvamBDx1mZRMKF7TFbUQ/uowgDiQSBoBbmTcp",
+      "x-amz-version-id" : "c3qG27FoIyufZ04vZatrWLjksQaI9Yo6",
+      "Date" : "Sun, 12 Jul 2026 21:12:08 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "48d50196-fb7d-40d1-b9ff-3a42fa5dcbbb",
+  "uuid" : "b87b3cb5-23ab-4349-9adf-871094122d5f",
   "persistent" : true,
-  "insertionIndex" : 456
+  "insertionIndex" : 792
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-get-10.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-get-10.json
@@ -1,5 +1,5 @@
 {
-  "id" : "3efe6fd1-9a07-4ef0-b77c-a22c374ae17a",
+  "id" : "1f8064fd-956e-4048-8489-616ce87cff9f",
   "name" : "AwsBlobStoreIT_testVersionedDownload_happy-GET-10",
   "request" : {
     "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_happy_versioned",
@@ -12,29 +12,30 @@
     "queryParameters" : {
       "versionId" : {
         "hasExactly" : [ {
-          "equalTo" : "iFrmFsI4HM2hteBu8hmYcCyRzrV6sOWs"
+          "equalTo" : "WtM3EvZaDX2z6PhW054dwY_Ao4uWM_Io"
         } ]
       }
     }
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:59:23 GMT",
-      "x-amz-request-id" : "0EDAPZ87R567DH61",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 21:12:03 GMT",
+      "x-amz-request-id" : "3KKGNSG6B7Q8VKHZ",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "9NC2C147/8rCDKhaMHLMl1GZLPRlm+TFSAnoUQOmxgMEzpfL85thMdLb+V6oILpxBwoha8T9ju5Q0I3hXAtER/m/1p5sr+FH",
-      "x-amz-transfer-encoding" : "append-md5",
-      "x-amz-version-id" : "iFrmFsI4HM2hteBu8hmYcCyRzrV6sOWs",
-      "Date" : "Wed, 04 Mar 2026 20:59:23 GMT",
+      "x-amz-id-2" : "sV/9obcLWnk1wMKnMSydDUz9nY5/yOA+O/y5YAu6BERs8rZmWg9BL/yOS6JGwYFZ8wQHb2B0JH/6ANxmnQ14rvOKCLmJQYHl",
+      "x-amz-version-id" : "WtM3EvZaDX2z6PhW054dwY_Ao4uWM_Io",
+      "Date" : "Sun, 12 Jul 2026 21:12:04 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "3efe6fd1-9a07-4ef0-b77c-a22c374ae17a",
+  "uuid" : "1f8064fd-956e-4048-8489-616ce87cff9f",
   "persistent" : true,
-  "insertionIndex" : 465
+  "insertionIndex" : 801
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-get-4.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-get-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "cef2a182-fa10-4df0-b4c7-9d3aa6b92d87",
+  "id" : "6b4b2cd8-409d-4d8e-9354-291269064371",
   "name" : "AwsBlobStoreIT_testVersionedDownload_happy-GET-4",
   "request" : {
     "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_happy_versioned",
@@ -12,29 +12,30 @@
     "queryParameters" : {
       "versionId" : {
         "hasExactly" : [ {
-          "equalTo" : "8Hg9E4NFzWUjoNsKVih9.31aOt34_XH3"
+          "equalTo" : "7euYoQvbY8OLe0ddef6Jb1qlhVrAj8f7"
         } ]
       }
     }
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:59:25 GMT",
-      "x-amz-request-id" : "J5N9CA0JN6RFPPXB",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 21:12:06 GMT",
+      "x-amz-request-id" : "VC93NZGQNCQ0A15G",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "04+fkNghscoSwJCYpWPvaZw6dKvGZQAIaeQMd2k/Unn/jQP5j3ftmPbLD2Cojch63//KkGpmnlvnl4ez8abfYmUtZ/1Gm01E",
-      "x-amz-transfer-encoding" : "append-md5",
-      "x-amz-version-id" : "8Hg9E4NFzWUjoNsKVih9.31aOt34_XH3",
-      "Date" : "Wed, 04 Mar 2026 20:59:26 GMT",
+      "x-amz-id-2" : "s/25KMmzox9tkd8surlpVr7+N1ov/meKqBV68kih1YeoHNMR5XCHJsgCW2aFhY/te9txqt2EyYu1niRgLuajUgiiIrmgnWuN",
+      "x-amz-version-id" : "7euYoQvbY8OLe0ddef6Jb1qlhVrAj8f7",
+      "Date" : "Sun, 12 Jul 2026 21:12:07 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "cef2a182-fa10-4df0-b4c7-9d3aa6b92d87",
+  "uuid" : "6b4b2cd8-409d-4d8e-9354-291269064371",
   "persistent" : true,
-  "insertionIndex" : 459
+  "insertionIndex" : 795
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-get-7.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-get-7.json
@@ -1,5 +1,5 @@
 {
-  "id" : "20197dcc-cd59-4361-850d-a2718adfc7f2",
+  "id" : "29b9bcf2-8b14-446e-a1b2-6e94161d0509",
   "name" : "AwsBlobStoreIT_testVersionedDownload_happy-GET-7",
   "request" : {
     "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_happy_versioned",
@@ -12,29 +12,30 @@
     "queryParameters" : {
       "versionId" : {
         "hasExactly" : [ {
-          "equalTo" : "BRBblR5yR8TB5pyb3oJfTnee3LdrhiYv"
+          "equalTo" : "DXeTDhLTIoSweB7XiTM2YhFnZCn3BKj5"
         } ]
       }
     }
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:59:24 GMT",
-      "x-amz-request-id" : "FBF18FVXYP60CZ86",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 21:12:05 GMT",
+      "x-amz-request-id" : "SR21CT2J4R186RGA",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "mBEuGBbuGJY/iFNZFyc7Yxt+QaFVsjxL5/gWqRbnzULaXZbezJsOQumYXQTKbaRzrGAJqdnOZGvx8FwVtwAnAQVOl870J0Pc",
-      "x-amz-transfer-encoding" : "append-md5",
-      "x-amz-version-id" : "BRBblR5yR8TB5pyb3oJfTnee3LdrhiYv",
-      "Date" : "Wed, 04 Mar 2026 20:59:25 GMT",
+      "x-amz-id-2" : "GI5IUokBlf82NDykDwAVDl42yyG+yU9W7CP4imLPhQ3bboJTqDmxmH+4rpPZObxNB/vDbtMpMwM5+IqaFaEQE+OfTgbxuJvE",
+      "x-amz-version-id" : "DXeTDhLTIoSweB7XiTM2YhFnZCn3BKj5",
+      "Date" : "Sun, 12 Jul 2026 21:12:05 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "20197dcc-cd59-4361-850d-a2718adfc7f2",
+  "uuid" : "29b9bcf2-8b14-446e-a1b2-6e94161d0509",
   "persistent" : true,
-  "insertionIndex" : 462
+  "insertionIndex" : 798
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-put-11.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-put-11.json
@@ -1,5 +1,5 @@
 {
-  "id" : "d6a7d5fc-f6b0-48ba-8ca6-59466652e4c4",
+  "id" : "0139100d-4a58-443a-b08e-6b98f03056c9",
   "name" : "AwsBlobStoreIT_testVersionedDownload_happy-PUT-11",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_happy_versioned",
@@ -15,17 +15,17 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "0EDBTRGAGCKNMYMS",
+      "x-amz-request-id" : "NASHG109GVRD118E",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "0A0ouF9jgYHU5c1xdQbz50xraPue8NaA27BxuS0uIwigy9ooP+qb2zJcB0FV2HjJw6E7oj1L61rla1Jofxm/9ekFLQfxwu8Q",
-      "x-amz-version-id" : "iFrmFsI4HM2hteBu8hmYcCyRzrV6sOWs",
-      "Date" : "Wed, 04 Mar 2026 20:59:23 GMT"
+      "x-amz-id-2" : "1OO0T4ekvsrwpANXpp/sgeceN7gnXvU8rumsbq/X92L1eZ5wHRtH6/SAcsmN+Rpn+FGG9pNuFzEsotp3dLO0keVZ3sbQQxYS",
+      "x-amz-version-id" : "WtM3EvZaDX2z6PhW054dwY_Ao4uWM_Io",
+      "Date" : "Sun, 12 Jul 2026 21:12:03 GMT"
     }
   },
-  "uuid" : "d6a7d5fc-f6b0-48ba-8ca6-59466652e4c4",
+  "uuid" : "0139100d-4a58-443a-b08e-6b98f03056c9",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned-2",
-  "insertionIndex" : 466
+  "insertionIndex" : 802
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-put-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-put-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "aa7d046c-c328-4ebb-84a8-02f86fc04b5f",
+  "id" : "50e0516e-48bc-4df8-8665-528085567b35",
   "name" : "AwsBlobStoreIT_testVersionedDownload_happy-PUT-2",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_happy_versioned",
@@ -15,16 +15,16 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "JNGN0WSBVY1GJKY4",
+      "x-amz-request-id" : "VC97ZHS8T8PTSMVN",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "ZQWpjNX5Gvs2VPAEWW097ic5Hb/TgJmyPZICZOE3npXT3Cp3JnGmjnO1CgnWhLW9uV30YGVuFY5YyN6CmTDMxdUL1pdHuKti",
-      "x-amz-version-id" : "v1o3xl26WLC0wY0zvVS0CxlDVHB4B72P",
-      "Date" : "Wed, 04 Mar 2026 20:59:27 GMT"
+      "x-amz-id-2" : "77ojy4EmKpt938MR2GAMp0gY9niMXesDX/jG5SSr3ttvh8Xlb+/1bgQznoRyfXpWX37gNj/HigJvOCmDtB0oTkU13Oulu0Xp",
+      "x-amz-version-id" : "c3qG27FoIyufZ04vZatrWLjksQaI9Yo6",
+      "Date" : "Sun, 12 Jul 2026 21:12:07 GMT"
     }
   },
-  "uuid" : "aa7d046c-c328-4ebb-84a8-02f86fc04b5f",
+  "uuid" : "50e0516e-48bc-4df8-8665-528085567b35",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned",
   "requiredScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned-4",
-  "insertionIndex" : 457
+  "insertionIndex" : 793
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-put-5.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-put-5.json
@@ -1,5 +1,5 @@
 {
-  "id" : "0e924ce2-4ae2-459d-ad21-3276ddee9d78",
+  "id" : "ac902ae6-da26-4cc0-af8a-1c66f1561fb6",
   "name" : "AwsBlobStoreIT_testVersionedDownload_happy-PUT-5",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_happy_versioned",
@@ -15,17 +15,17 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "FBFETK6X5FGRQQK3",
+      "x-amz-request-id" : "2A4RNRZ56251ZCW7",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "BCDkFpC5gpQfC/RcWUSSrKqjxw2RGfsWFh4lCUyOgy5tLUFVeVA5V42wuVxzNT53Ilp4PwsxElLgDRX9pmbrE5LrIUNTw02B",
-      "x-amz-version-id" : "8Hg9E4NFzWUjoNsKVih9.31aOt34_XH3",
-      "Date" : "Wed, 04 Mar 2026 20:59:25 GMT"
+      "x-amz-id-2" : "xFr5i9X9+nE492DNL+9wUgA9ThdtHh0HGaVtp45nPerUmzdRrgz2DOoRcnDiaQnkUqxHWYG59SjSPditksp12KRraQEk+TL1",
+      "x-amz-version-id" : "7euYoQvbY8OLe0ddef6Jb1qlhVrAj8f7",
+      "Date" : "Sun, 12 Jul 2026 21:12:06 GMT"
     }
   },
-  "uuid" : "0e924ce2-4ae2-459d-ad21-3276ddee9d78",
+  "uuid" : "ac902ae6-da26-4cc0-af8a-1c66f1561fb6",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned",
   "requiredScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned-3",
   "newScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned-4",
-  "insertionIndex" : 460
+  "insertionIndex" : 796
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-put-8.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_happy-put-8.json
@@ -1,5 +1,5 @@
 {
-  "id" : "d753b4c3-70bd-4834-9e6f-3de8837b8664",
+  "id" : "53af7c4f-a4eb-430b-b3f0-494c9d3980b8",
   "name" : "AwsBlobStoreIT_testVersionedDownload_happy-PUT-8",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_happy_versioned",
@@ -15,17 +15,17 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "FFNACTZG764EKR37",
+      "x-amz-request-id" : "SR2B4NA1BY4YFN72",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "rwUQ94Ug7WPHFmGoC+lW/jNnZa6q1NpbxL/U9vzL9yEdNYmEe9f8AaEE734qXZ0SPrlIih67kIpLLENHJtnb0cXj9FZdkRw9",
-      "x-amz-version-id" : "BRBblR5yR8TB5pyb3oJfTnee3LdrhiYv",
-      "Date" : "Wed, 04 Mar 2026 20:59:24 GMT"
+      "x-amz-id-2" : "NDwa2hGVGx9np7intX+cCumnKUez92P7GTafdicYmrmzHhupzHlVdd98pC12VSpleksYBZAhbXUBqchtWnyvbOlDVxizmjlM",
+      "x-amz-version-id" : "DXeTDhLTIoSweB7XiTM2YhFnZCn3BKj5",
+      "Date" : "Sun, 12 Jul 2026 21:12:05 GMT"
     }
   },
-  "uuid" : "d753b4c3-70bd-4834-9e6f-3de8837b8664",
+  "uuid" : "53af7c4f-a4eb-430b-b3f0-494c9d3980b8",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned",
   "requiredScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned-2",
   "newScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_happy_versioned-3",
-  "insertionIndex" : 463
+  "insertionIndex" : 799
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-delete-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-delete-0.json
@@ -1,5 +1,5 @@
 {
-  "id" : "52aba43c-dcda-4d14-98c1-a044d843c29b",
+  "id" : "dbeab829-5c8e-42d8-aa6b-876802a770b1",
   "name" : "AwsBlobStoreIT_testVersionedDownload_noVersionId-DELETE-0",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_no_versionId_versioned",
@@ -10,15 +10,15 @@
     "headers" : {
       "Server" : "AmazonS3",
       "x-amz-delete-marker" : "true",
-      "x-amz-request-id" : "9HQ0XVXT7JQ6HAS6",
-      "x-amz-id-2" : "exeAGNdKZBDtkdNG42X0OGMrIxGp3GPkf9tFCyQyGWewUW780sh4kchhUIAQ4W1tfD4qeYaLvTQOZnvB3AuHpmIUtKunD+e0",
-      "x-amz-version-id" : "QSm2hcr.mM8doy5x5fdT7KVvDbAI.DM2",
-      "Date" : "Wed, 04 Mar 2026 20:56:29 GMT"
+      "x-amz-request-id" : "8QMPKZS3B5RZMDFY",
+      "x-amz-id-2" : "ezgbEh9QuSx5z1GI3uspDD/dPX9N5/0S/cLq1W8JJMwFhxrFzF/bTXFJpal3uOhZm/T9L3zypvIbnB6GIbFAaehsJ1qKzFfC",
+      "x-amz-version-id" : "U6VFwoE2D0uRcNjiLcxdkM2y_SB.gMOI",
+      "Date" : "Sun, 12 Jul 2026 21:12:00 GMT"
     }
   },
-  "uuid" : "52aba43c-dcda-4d14-98c1-a044d843c29b",
+  "uuid" : "dbeab829-5c8e-42d8-aa6b-876802a770b1",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned",
   "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-4",
-  "insertionIndex" : 58
+  "insertionIndex" : 771
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-delete-3.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-delete-3.json
@@ -1,5 +1,5 @@
 {
-  "id" : "9cf319ae-4018-465e-9946-22ad87b76a45",
+  "id" : "85a32607-c8db-49a5-b37a-fce85622522c",
   "name" : "AwsBlobStoreIT_testVersionedDownload_noVersionId-DELETE-3",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_no_versionId_versioned",
@@ -10,16 +10,16 @@
     "headers" : {
       "Server" : "AmazonS3",
       "x-amz-delete-marker" : "true",
-      "x-amz-request-id" : "8D7XA6A1A3GK1AJ6",
-      "x-amz-id-2" : "gE18Fiuu0H8VeaD+V4/8Or+d415aATO26wKGPdrn4SO093XT1Jo6Hh82BQva4ezWsB7FTxZJ6W4eLvxviBCmg5Ii3ntHly0t",
-      "x-amz-version-id" : "_iJBn.kkOEpwh6H7l4WDLBLgSma8X.zU",
-      "Date" : "Wed, 04 Mar 2026 20:56:28 GMT"
+      "x-amz-request-id" : "VB7SJQK6W76W77H3",
+      "x-amz-id-2" : "dTizvNlkN68xSNZNfpBEaQ/jtxNWT37SiOEr+OOFkkjrVCsUlqb+dMvwSTOio2vwzbIphSC54fKZqpnwAQ+vCHmVrjdgZqCe",
+      "x-amz-version-id" : "fQ5X0RG2JlS.2mTEZDogX8mNjMf7KVST",
+      "Date" : "Sun, 12 Jul 2026 21:11:59 GMT"
     }
   },
-  "uuid" : "9cf319ae-4018-465e-9946-22ad87b76a45",
+  "uuid" : "85a32607-c8db-49a5-b37a-fce85622522c",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned",
   "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-3",
   "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-4",
-  "insertionIndex" : 61
+  "insertionIndex" : 774
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-delete-6.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-delete-6.json
@@ -1,5 +1,5 @@
 {
-  "id" : "0eb10015-cf09-476e-bfd7-5d3014dd7ff7",
+  "id" : "873e55c5-5a23-4b71-989e-e23c296c09db",
   "name" : "AwsBlobStoreIT_testVersionedDownload_noVersionId-DELETE-6",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_no_versionId_versioned",
@@ -10,16 +10,16 @@
     "headers" : {
       "Server" : "AmazonS3",
       "x-amz-delete-marker" : "true",
-      "x-amz-request-id" : "4RE3FMJKQ6WZ0Z59",
-      "x-amz-id-2" : "WEQ2ri5hMhIzqDj2jguOqkvVspekTlTwOQJetO5iV9eKiFC+s6/02NdkzGmGzYdBtA7OuTh7zFM78WRQKQf1HN89Uibzs/V6",
-      "x-amz-version-id" : "dh6.mYRKrJI9oUkrdLO4zEhThA704sTJ",
-      "Date" : "Wed, 04 Mar 2026 20:56:26 GMT"
+      "x-amz-request-id" : "JD008BT8SZF0NKPV",
+      "x-amz-id-2" : "NLK1fn3CJgVzG9rw41Zq2KVPZfdqXFE/z7+aujndRL/olkK8GSYC1hNyDcrWbmThmVZYaCss3NCmMipd5bYuftU4DRhbrae6",
+      "x-amz-version-id" : "cIRHkC7Ef6TIF3uf91rDDe5ld9uq8jH0",
+      "Date" : "Sun, 12 Jul 2026 21:11:57 GMT"
     }
   },
-  "uuid" : "0eb10015-cf09-476e-bfd7-5d3014dd7ff7",
+  "uuid" : "873e55c5-5a23-4b71-989e-e23c296c09db",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned",
   "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-2",
   "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-3",
-  "insertionIndex" : 64
+  "insertionIndex" : 777
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-delete-9.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-delete-9.json
@@ -1,5 +1,5 @@
 {
-  "id" : "ce38d5f0-b423-40d8-9ad0-e5a2112a40bb",
+  "id" : "d93ccec1-2c45-4e6b-832b-228d181756ee",
   "name" : "AwsBlobStoreIT_testVersionedDownload_noVersionId-DELETE-9",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_no_versionId_versioned",
@@ -10,16 +10,16 @@
     "headers" : {
       "Server" : "AmazonS3",
       "x-amz-delete-marker" : "true",
-      "x-amz-request-id" : "YEWC87RWKJ44F2YK",
-      "x-amz-id-2" : "dukGjuyqtJwc5ZQUYMT6jkV9+9EmXpHN0fOfanbz0wuKbFi+4sXleneUjXGO8GcCSZ79jhw6btZR9QwXksgldE5dHwqbedUk",
-      "x-amz-version-id" : "o35zPOsyZe5R6JcrUtI0QYqA06ZXqH5f",
-      "Date" : "Wed, 04 Mar 2026 20:56:25 GMT"
+      "x-amz-request-id" : "NHF56S66JS5JNBXT",
+      "x-amz-id-2" : "4FTi7m0gwl80RiiMOmPRG/ldZtIhM2DQPTuBfupzRv+KoWGaeUCDnSfvvnZiEWD/BdGQLtRisVvW76M0YXrfk3nUNbOqGVd9",
+      "x-amz-version-id" : "18lJG4q7IazqO2x67fRXhmPqLmjRqDFZ",
+      "Date" : "Sun, 12 Jul 2026 21:11:56 GMT"
     }
   },
-  "uuid" : "ce38d5f0-b423-40d8-9ad0-e5a2112a40bb",
+  "uuid" : "d93ccec1-2c45-4e6b-832b-228d181756ee",
   "persistent" : true,
   "scenarioName" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-2",
-  "insertionIndex" : 67
+  "insertionIndex" : 780
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-get-1.json
@@ -1,5 +1,5 @@
 {
-  "id" : "eb37183a-ca52-48df-9ea3-4e3da89de543",
+  "id" : "02a8d05d-2526-4349-b363-5c81491d3c5b",
   "name" : "AwsBlobStoreIT_testVersionedDownload_noVersionId-GET-1",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_no_versionId_versioned",
@@ -7,24 +7,25 @@
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:56:28 GMT",
-      "x-amz-request-id" : "9HQ5G1SW52T778BA",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 21:11:59 GMT",
+      "x-amz-request-id" : "8QMNHVHPAEAZTXZM",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "2ouWYT2YxbtvWR4lA2m99nFRrBsZq7cxtGWHE3D0dQebNyjCfrbUnlq9yEUDpyay92Ew+A86lgoo5lp64NbAEpAeJF67HK7e",
-      "x-amz-transfer-encoding" : "append-md5",
-      "x-amz-version-id" : "uYM_yydtPwKs_jJvFUnLDk4b_qSyRJGY",
-      "Date" : "Wed, 04 Mar 2026 20:56:29 GMT",
+      "x-amz-id-2" : "LQpIMSdXH3ndVzUjSOOChC7GDnt8VbBAwqA+TKiKHq/efMwxTFzmLpwZSS/EhmHwDG6C3nSO//OBv+Tybtvbak5ftB0dQbop",
+      "x-amz-version-id" : "aylTawGKsv7K1_TMTJAjW8lPo4FuRAOO",
+      "Date" : "Sun, 12 Jul 2026 21:12:00 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "eb37183a-ca52-48df-9ea3-4e3da89de543",
+  "uuid" : "02a8d05d-2526-4349-b363-5c81491d3c5b",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned",
   "requiredScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-4",
-  "insertionIndex" : 59
+  "insertionIndex" : 772
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-get-10.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-get-10.json
@@ -1,5 +1,5 @@
 {
-  "id" : "c9fd7156-87a3-4a8e-aca1-38cb6a738e73",
+  "id" : "11fe5da1-ad84-41a3-99bd-ccbceee9301a",
   "name" : "AwsBlobStoreIT_testVersionedDownload_noVersionId-GET-10",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_no_versionId_versioned",
@@ -7,25 +7,26 @@
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:56:24 GMT",
-      "x-amz-request-id" : "YEW77M7V8607Q592",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 21:11:55 GMT",
+      "x-amz-request-id" : "6F7H4DBCA1MFW5NV",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "G4yLc+uHdJBsALDHMTTxoCW1ictc+ZXCoqL2VYsjInk/X9CQfnTKfRCGBeePde+Z5EbtEj7JRb9NQS2YfdjBKQb11VbXhnOk",
-      "x-amz-transfer-encoding" : "append-md5",
-      "x-amz-version-id" : "4h5pkj1MKmKpKk6Ybp3qlvJawq6P5GQA",
-      "Date" : "Wed, 04 Mar 2026 20:56:25 GMT",
+      "x-amz-id-2" : "kmzvNA0M8KyMy30XmTjELRZgsSYIFZCUGv3POXT2tAeLrXlUkPzmvD6t3LbhL2PjoZyh28fIRNJvabkPfOhpGA6SRa1xcQgh",
+      "x-amz-version-id" : "Lsw_hBEQR9NwER0Aw99bjhi0exh0hmkK",
+      "Date" : "Sun, 12 Jul 2026 21:11:55 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "c9fd7156-87a3-4a8e-aca1-38cb6a738e73",
+  "uuid" : "11fe5da1-ad84-41a3-99bd-ccbceee9301a",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-2",
-  "insertionIndex" : 68
+  "insertionIndex" : 781
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-get-4.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-get-4.json
@@ -1,5 +1,5 @@
 {
-  "id" : "682d9d57-b82b-45a5-8cae-80313f013c7b",
+  "id" : "e3ca0f52-23e1-46a0-968c-f3daa4ae3ef5",
   "name" : "AwsBlobStoreIT_testVersionedDownload_noVersionId-GET-4",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_no_versionId_versioned",
@@ -7,25 +7,26 @@
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:56:27 GMT",
-      "x-amz-request-id" : "2EESY0Z5BHT3K3SV",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 21:11:58 GMT",
+      "x-amz-request-id" : "9FX3T6MRNRZNJRET",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "8lpHPQ3Te5WLrIpZsVd4V5lFFTCCOl3Fgk2f206M77GKhli5WXmCjeEfvcpQcgovGPCfYxaxzrhT/rcz3HX24ybgIjifiQHn",
-      "x-amz-transfer-encoding" : "append-md5",
-      "x-amz-version-id" : "8rUxKIEpoiN_l2fvRLrv_twVGT9NF9M0",
-      "Date" : "Wed, 04 Mar 2026 20:56:27 GMT",
+      "x-amz-id-2" : "8eFv/I/ozbf6h8h9hQQ1dWRRjCYsb5t4kTGFZXJ6dsD3xzaWmo6HJQ/uNbtVaGH17vXBkHiVfLoIPog2JCZA9Z6XeI4vn0ei",
+      "x-amz-version-id" : "MC4lz0HNu82J9PSNPa2PZIZ5lmrAo5J_",
+      "Date" : "Sun, 12 Jul 2026 21:11:58 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "682d9d57-b82b-45a5-8cae-80313f013c7b",
+  "uuid" : "e3ca0f52-23e1-46a0-968c-f3daa4ae3ef5",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned",
   "requiredScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-3",
   "newScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-4",
-  "insertionIndex" : 62
+  "insertionIndex" : 775
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-get-7.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-get-7.json
@@ -1,5 +1,5 @@
 {
-  "id" : "ee1a1862-c2ab-47aa-a7a0-f5839badd23d",
+  "id" : "4d68c2af-f6e2-4f5e-8647-17fcb2832ad2",
   "name" : "AwsBlobStoreIT_testVersionedDownload_noVersionId-GET-7",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_no_versionId_versioned",
@@ -7,25 +7,26 @@
   },
   "response" : {
     "status" : 200,
-    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGFwG71L3h7gTjsFlvY5lOuu",
+    "base64Body" : "VGhpcyBpcyB0ZXN0IGRhdGE=",
     "headers" : {
       "Accept-Ranges" : "bytes",
       "Server" : "AmazonS3",
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
-      "Last-Modified" : "Wed, 04 Mar 2026 20:56:25 GMT",
-      "x-amz-request-id" : "4RECDZDFWB89V669",
+      "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Sun, 12 Jul 2026 21:11:56 GMT",
+      "x-amz-request-id" : "JD07YY97YN3K3CBN",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "140TwWgpURQTKBjqrY0wiTCzwHUVPGZ6lQ1LWx0m66Jhd0cMwxpXjsRMybe30//Vfv65DrG7zfi13lzrXK4TyphrunaZP11t",
-      "x-amz-transfer-encoding" : "append-md5",
-      "x-amz-version-id" : "oegi4zt1GEMKA5Yz3zUoM9NR.Y.pIuYq",
-      "Date" : "Wed, 04 Mar 2026 20:56:26 GMT",
+      "x-amz-id-2" : "CAldoe3yguNfiXHji3KwaaWWko3Mcesl6THCEaGYeHkpiQLHMC6WbBlJamu28sDKCIOUCJ3OHrLvhf+eiggxs/ZiOOLIHHHG",
+      "x-amz-version-id" : "7n8x12M2AT9FLQrYQ4Ras3q7s8E51.OX",
+      "Date" : "Sun, 12 Jul 2026 21:11:57 GMT",
       "Content-Type" : "application/octet-stream"
     }
   },
-  "uuid" : "ee1a1862-c2ab-47aa-a7a0-f5839badd23d",
+  "uuid" : "4d68c2af-f6e2-4f5e-8647-17fcb2832ad2",
   "persistent" : true,
   "scenarioName" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned",
   "requiredScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-2",
   "newScenarioState" : "scenario-2-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-3",
-  "insertionIndex" : 65
+  "insertionIndex" : 778
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-put-11.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-put-11.json
@@ -1,5 +1,5 @@
 {
-  "id" : "e222d4c0-57bf-4586-a356-8e5e26366d6a",
+  "id" : "f409d822-134a-4fe2-b511-c97a7f6441e0",
   "name" : "AwsBlobStoreIT_testVersionedDownload_noVersionId-PUT-11",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_no_versionId_versioned",
@@ -15,17 +15,17 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "CFFWDK0VQESTH4SV",
+      "x-amz-request-id" : "6F7SD2PDEFGPC0JB",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "tfx3Ch2ONARDlOYSdo3IHKtuGx3MNOUjQCr5dVgv3Nrsuak4OLNmknPHesxdjcn8Vx1e2g58wZdNM86yUAN443mzLmJZSdKK",
-      "x-amz-version-id" : "4h5pkj1MKmKpKk6Ybp3qlvJawq6P5GQA",
-      "Date" : "Wed, 04 Mar 2026 20:56:24 GMT"
+      "x-amz-id-2" : "VGqv+S5rflXxCDyP1OHxYJ4yToUAjJ5jkfyW0MwGRybqV5bOt3sAVoIsmQu3fTjdUcjk8T61jnqcQky15wPn4Xk08A8dGmB+",
+      "x-amz-version-id" : "Lsw_hBEQR9NwER0Aw99bjhi0exh0hmkK",
+      "Date" : "Sun, 12 Jul 2026 21:11:55 GMT"
     }
   },
-  "uuid" : "e222d4c0-57bf-4586-a356-8e5e26366d6a",
+  "uuid" : "f409d822-134a-4fe2-b511-c97a7f6441e0",
   "persistent" : true,
   "scenarioName" : "scenario-3-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned",
   "requiredScenarioState" : "Started",
   "newScenarioState" : "scenario-3-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-2",
-  "insertionIndex" : 69
+  "insertionIndex" : 782
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-put-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-put-2.json
@@ -1,5 +1,5 @@
 {
-  "id" : "1c8b64ef-d103-411a-b852-3266f64b4f6b",
+  "id" : "a3b1c90e-4f0c-4b7e-b7de-ac41d86c6eef",
   "name" : "AwsBlobStoreIT_testVersionedDownload_noVersionId-PUT-2",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_no_versionId_versioned",
@@ -15,16 +15,16 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "8D7QWW391M3B9FHK",
+      "x-amz-request-id" : "VB7HN1K4AJZHJSBC",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "Ny6pIieFI1kXbiovszzTf+AAMS1azVyMlDEHN1mRkSmsr7Ki3MABbcPEBh6++zwg4Ig3rMte1ikCStgRZBJYL/B6K5f1AdwN",
-      "x-amz-version-id" : "uYM_yydtPwKs_jJvFUnLDk4b_qSyRJGY",
-      "Date" : "Wed, 04 Mar 2026 20:56:28 GMT"
+      "x-amz-id-2" : "FI8qlk4C0UA3OnYCGnXgFDxolN6jNraaEeK689p6l0zCYw1fqrI9/Usc9MEgqgEQNlHmX5PCbFMk7bzhOCYYY1tU0LndzmbA",
+      "x-amz-version-id" : "aylTawGKsv7K1_TMTJAjW8lPo4FuRAOO",
+      "Date" : "Sun, 12 Jul 2026 21:11:59 GMT"
     }
   },
-  "uuid" : "1c8b64ef-d103-411a-b852-3266f64b4f6b",
+  "uuid" : "a3b1c90e-4f0c-4b7e-b7de-ac41d86c6eef",
   "persistent" : true,
   "scenarioName" : "scenario-3-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned",
   "requiredScenarioState" : "scenario-3-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-4",
-  "insertionIndex" : 60
+  "insertionIndex" : 773
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-put-5.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-put-5.json
@@ -1,5 +1,5 @@
 {
-  "id" : "9b215186-f808-4d6d-a219-47c12af13aba",
+  "id" : "1276f41a-e424-4c7b-8781-eb2e41034d17",
   "name" : "AwsBlobStoreIT_testVersionedDownload_noVersionId-PUT-5",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_no_versionId_versioned",
@@ -15,17 +15,17 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "2EEYPVD06XQRGX9Z",
+      "x-amz-request-id" : "9FXF4YWDQ1CG71FR",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "J2TOxyj+MkYqX8V6Nm1l/QrhAh9YhXyU4WUvUN+mBhqXiGQJbMKrj2g4NFSLFsDAf3aeSqz1IubQHxSmXPPys9E1UCUnkkgR",
-      "x-amz-version-id" : "8rUxKIEpoiN_l2fvRLrv_twVGT9NF9M0",
-      "Date" : "Wed, 04 Mar 2026 20:56:27 GMT"
+      "x-amz-id-2" : "xQsKhBn7PZbXZpctllz3YPdKuOeG23lpiuTB7fmNgC93CD6MI6W+fQFiV8Sw8d4g9liV31BZQy4EprUzBNFmbYUVGW2cztTw",
+      "x-amz-version-id" : "MC4lz0HNu82J9PSNPa2PZIZ5lmrAo5J_",
+      "Date" : "Sun, 12 Jul 2026 21:11:58 GMT"
     }
   },
-  "uuid" : "9b215186-f808-4d6d-a219-47c12af13aba",
+  "uuid" : "1276f41a-e424-4c7b-8781-eb2e41034d17",
   "persistent" : true,
   "scenarioName" : "scenario-3-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned",
   "requiredScenarioState" : "scenario-3-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-3",
   "newScenarioState" : "scenario-3-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-4",
-  "insertionIndex" : 63
+  "insertionIndex" : 776
 }

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-put-8.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testversioneddownload_noversionid-put-8.json
@@ -1,5 +1,5 @@
 {
-  "id" : "3e546a8a-d8e4-426b-ada7-5a10a50dad45",
+  "id" : "f6e07226-03f4-4a56-9a3d-e05a266c4d1e",
   "name" : "AwsBlobStoreIT_testVersionedDownload_noVersionId-PUT-8",
   "request" : {
     "url" : "/chameleon-jcloud-versioned/conformance-tests/versioned_download_no_versionId_versioned",
@@ -15,17 +15,17 @@
       "ETag" : "\"701bbd4bde1ee04e3b0596f63994ebae\"",
       "x-amz-checksum-crc64nvme" : "4G16TxxAsWw=",
       "x-amz-checksum-type" : "FULL_OBJECT",
-      "x-amz-request-id" : "YEWF1ME8NPCK0511",
+      "x-amz-request-id" : "NHF26BA8ZA4ZYDRY",
       "x-amz-server-side-encryption" : "AES256",
-      "x-amz-id-2" : "dsGKGxaGds0WWJWozRbxa1VAD86GDhKSWrVof9r84F5MZO+6jSPQOIbTShzQ3RhHLgNleKE7Kc5PSy20mEiMaAFcYbtMDcdh",
-      "x-amz-version-id" : "oegi4zt1GEMKA5Yz3zUoM9NR.Y.pIuYq",
-      "Date" : "Wed, 04 Mar 2026 20:56:25 GMT"
+      "x-amz-id-2" : "JicsVjVBCoRMYcyCwzWSqzJTqk94LvwyDFfPH0v9QXMoYedmR0qdSxHQy/yRIPsaAecl/cAM4KjUHZNYl6Rggl1V+tcEF1FW",
+      "x-amz-version-id" : "7n8x12M2AT9FLQrYQ4Ras3q7s8E51.OX",
+      "Date" : "Sun, 12 Jul 2026 21:11:56 GMT"
     }
   },
-  "uuid" : "3e546a8a-d8e4-426b-ada7-5a10a50dad45",
+  "uuid" : "f6e07226-03f4-4a56-9a3d-e05a266c4d1e",
   "persistent" : true,
   "scenarioName" : "scenario-3-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned",
   "requiredScenarioState" : "scenario-3-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-2",
   "newScenarioState" : "scenario-3-chameleon-jcloud-versioned-conformance-tests-versioned_download_no_versionId_versioned-3",
-  "insertionIndex" : 66
+  "insertionIndex" : 779
 }

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
@@ -867,6 +867,7 @@ public class BucketClient implements AutoCloseable {
         .key(m.getKey())
         .versionId(m.getVersionId())
         .eTag(m.getETag())
+        .checksum(m.getChecksum())
         .objectSize(m.getObjectSize())
         .metadata(m.getMetadata())
         .lastModified(m.getLastModified())

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobMetadata.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobMetadata.java
@@ -39,6 +39,12 @@ public class BlobMetadata {
   /** Object lock information for this blob. null if object lock is not configured. */
   private final ObjectLockInfo objectLockInfo;
 
+  /**
+   * Checksum of the object as reported by the store, or {@code null} if the store does not report
+   * one. Populated on responses from {@code getMetadata} and {@code download}.
+   */
+  private final Checksum checksum;
+
   /** The correlation ID associated with the operation that produced this metadata. */
   private final String correlationId;
 }

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/Checksum.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/Checksum.java
@@ -1,0 +1,21 @@
+package com.salesforce.multicloudj.blob.driver;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Checksum reported by the cloud store for a blob.
+ *
+ * <p>Carries the algorithm and the Base64-encoded checksum value produced by that algorithm. The
+ * algorithm is drawn from {@link ChecksumMethod}; the value's format is defined by that algorithm.
+ */
+@Builder
+@Getter
+@EqualsAndHashCode
+@ToString
+public class Checksum {
+  private final ChecksumMethod algorithm;
+  private final String value;
+}

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/Checksum.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/Checksum.java
@@ -8,8 +8,9 @@ import lombok.ToString;
 /**
  * Checksum reported by the cloud store for a blob.
  *
- * <p>Carries the algorithm and the Base64-encoded checksum value produced by that algorithm. The
- * algorithm is drawn from {@link ChecksumMethod}; the value's format is defined by that algorithm.
+ * <p>Carries the algorithm and the checksum value produced by that algorithm. The value format is
+ * provider-specific and should be treated as an opaque string - use it with the same provider that
+ * produced it.
  */
 @Builder
 @Getter

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/ChecksumMethod.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/ChecksumMethod.java
@@ -11,11 +11,5 @@ public enum ChecksumMethod {
   CRC32C,
   SHA256,
   CRC64,
-  /**
-   * MD5, sent as the RFC 1864 {@code Content-MD5} header. Validated as a caller-supplied digest
-   * on single-object and presigned-URL uploads by every substrate this SDK supports. Not used for
-   * multipart uploads (per-part {@code Content-MD5} is not available on every substrate's
-   * multipart API).
-   */
   MD5
 }

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -841,7 +841,8 @@ public abstract class AbstractBlobStoreIT {
         Assertions.assertEquals(
             blobBytes.length, content.length, testName + ": Content-Length did not match");
         Assertions.assertArrayEquals(blobBytes, content, testName + ": Bytes arrays did not match");
-        Assertions.assertNotNull(response.getMetadata().getChecksum(), testName + ": checksum is not there");
+        Assertions.assertNotNull(response.getMetadata().getChecksum(),
+            testName + ": checksum is not there");
       } catch (SubstrateSdkException e) {
         Assertions.assertTrue(wantError, testName + ": Did not expect error. " + e.getMessage());
         return;

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -791,30 +791,6 @@ public abstract class AbstractBlobStoreIT {
       boolean downloadUsingVersionId,
       boolean useCorrectVersionId,
       boolean wantError,
-      boolean parallelDownload)
-      throws IOException {
-    runDownloadTest(
-        testName,
-        uploadKey,
-        downloadKey,
-        useVersionedBucket,
-        downloadType,
-        downloadUsingVersionId,
-        useCorrectVersionId,
-        wantError,
-        parallelDownload,
-        false);
-  }
-
-  private void runDownloadTest(
-      String testName,
-      String uploadKey,
-      String downloadKey,
-      boolean useVersionedBucket,
-      DownloadType downloadType,
-      boolean downloadUsingVersionId,
-      boolean useCorrectVersionId,
-      boolean wantError,
       boolean parallelDownload,
       boolean createParentPath)
       throws IOException {
@@ -865,6 +841,7 @@ public abstract class AbstractBlobStoreIT {
         Assertions.assertEquals(
             blobBytes.length, content.length, testName + ": Content-Length did not match");
         Assertions.assertArrayEquals(blobBytes, content, testName + ": Bytes arrays did not match");
+        Assertions.assertNotNull(response.getMetadata().getChecksum(), testName + ": checksum is not there");
       } catch (SubstrateSdkException e) {
         Assertions.assertTrue(wantError, testName + ": Did not expect error. " + e.getMessage());
         return;

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -2567,6 +2567,7 @@ public abstract class AbstractBlobStoreIT {
             testConfig.testName + ": The metadata does not match the original");
         Assertions.assertNotNull(blobMetadata.getLastModified());
         Assertions.assertNotNull(blobMetadata.getCreatedTime());
+        Assertions.assertNotNull(blobMetadata.getChecksum());
       }
     } finally {
       // Delete our blob to clean up the test

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpTransformer.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpTransformer.java
@@ -10,6 +10,7 @@ import com.google.cloud.storage.StorageClass;
 import com.google.common.collect.ImmutableMap;
 import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
+import com.salesforce.multicloudj.blob.driver.Checksum;
 import com.salesforce.multicloudj.blob.driver.ChecksumMethod;
 import com.salesforce.multicloudj.blob.driver.CopyFromRequest;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
@@ -232,7 +233,18 @@ public class GcpTransformer {
         .md5(HexUtil.convertToBytes(blob.getMd5()))
         .contentType(blob.getContentType())
         .objectLockInfo(objectLockInfo)
+        .checksum(toDriverChecksum(blob))
         .build();
+  }
+
+  private Checksum toDriverChecksum(Blob blob) {
+    if (blob.getCrc32c() != null) {
+      return Checksum.builder()
+          .algorithm(ChecksumMethod.CRC32C)
+          .value(blob.getCrc32c())
+          .build();
+    }
+    return null;
   }
 
   public Storage.CopyRequest toCopyRequest(CopyRequest request) {

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpTransformerTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpTransformerTest.java
@@ -16,6 +16,7 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BlobInfo.Retention;
 import com.google.cloud.storage.Storage;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
+import com.salesforce.multicloudj.blob.driver.Checksum;
 import com.salesforce.multicloudj.blob.driver.ChecksumMethod;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
 import com.salesforce.multicloudj.blob.driver.CopyResponse;
@@ -657,6 +658,25 @@ class GcpTransformerTest {
     assertEquals(expectedMetadata, blobMetadata.getMetadata());
 
     assertEquals(updateTime.toInstant(), blobMetadata.getLastModified());
+  }
+
+  @Test
+  void testToBlobMetadata_populatesCrc32cChecksum() {
+    when(mockBlob.getName()).thenReturn(TEST_KEY);
+    when(mockBlob.getCrc32c()).thenReturn("abc123==");
+
+    Checksum checksum = transformer.toBlobMetadata(mockBlob).getChecksum();
+    assertNotNull(checksum);
+    assertEquals(ChecksumMethod.CRC32C, checksum.getAlgorithm());
+    assertEquals("abc123==", checksum.getValue());
+  }
+
+  @Test
+  void testToBlobMetadata_noCrc32cReturnsNullChecksum() {
+    when(mockBlob.getName()).thenReturn(TEST_KEY);
+    when(mockBlob.getCrc32c()).thenReturn(null);
+
+    assertNull(transformer.toBlobMetadata(mockBlob).getChecksum());
   }
 
   @Test

--- a/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
+++ b/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
@@ -7,6 +7,7 @@ import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.ByteArray;
+import com.salesforce.multicloudj.blob.driver.Checksum;
 import com.salesforce.multicloudj.blob.driver.ChecksumMethod;
 import com.salesforce.multicloudj.blob.driver.CopyFromRequest;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
@@ -529,6 +530,14 @@ public class InMemoryBlobStore extends AbstractBlobStore {
         .createdTime(blob.getLastModified())
         .contentType(blob.getContentType())
         .objectLockInfo(OBJECT_LOCKS.get(versionedKey))
+        .checksum(toDriverChecksum(blob.getData()))
+        .build();
+  }
+
+  private Checksum toDriverChecksum(byte[] data) {
+    return Checksum.builder()
+        .algorithm(ChecksumMethod.CRC32C)
+        .value(computeCrc32cChecksum(data))
         .build();
   }
 
@@ -1072,6 +1081,7 @@ public class InMemoryBlobStore extends AbstractBlobStore {
                 .createdTime(blob.getLastModified())
                 .contentType(blob.getContentType())
                 .objectLockInfo(OBJECT_LOCKS.get(versionedKey))
+                .checksum(toDriverChecksum(blob.getData()))
                 .build())
         .build();
   }
@@ -1092,6 +1102,7 @@ public class InMemoryBlobStore extends AbstractBlobStore {
                 .createdTime(blob.getLastModified())
                 .contentType(blob.getContentType())
                 .objectLockInfo(OBJECT_LOCKS.get(versionedKey))
+                .checksum(toDriverChecksum(blob.getData()))
                 .build())
         .inputStream(inputStream)
         .build();


### PR DESCRIPTION
## Summary

The PR adds an ability to add the checksum data in the download response. GCP and Ali always have the checksum attached in the response by default. AWS only add the checksum in the response when checksum is enabled.

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
