### PR TITLE
test: reset WireMock scenario state before each conformance test

### DIFF
--- a/multicloudj-common/src/test/java/com/salesforce/multicloudj/common/util/common/TestsUtil.java
+++ b/multicloudj-common/src/test/java/com/salesforce/multicloudj/common/util/common/TestsUtil.java
@@ -303,6 +303,19 @@ public class TestsUtil {
     wireMockServer.stop();
   }
 
+  /**
+   * In replay mode, resets every WireMock stateful-scenario cursor back to its initial "Started"
+   * state. Recordings are captured per-test from a fresh server, so each test's stub-walk starts at
+   * "Started"; resetting before each test restores that precondition and removes cross-test
+   * scenario-state contamination that otherwise makes replay depend on JUnit method order.
+   * No-op during recording (scenario state is only consumed on replay).
+   */
+  public static void resetWireMockScenarios() {
+    if (wireMockServer != null && System.getProperty("record") == null) {
+      wireMockServer.resetScenarios();
+    }
+  }
+
   public static void startWireMockRecording(
       String targetEndpoint, String testClassName, String testMethodName) {
     startWireMockRecording(
@@ -316,6 +329,12 @@ public class TestsUtil {
       List<String> captureHeaders) {
     currentTestPrefix = testClassName + "_" + testMethodName;
     stubCounter.set(0);
+
+    // Reset every stateful-scenario cursor to its initial "Started" state before each test (replay
+    // only). This runs at the single chokepoint every Abstract*IT @BeforeEach calls, so it applies
+    // uniformly across all services/substrates. Removes cross-test scenario-state contamination
+    // that otherwise makes replay depend on JUnit method execution order.
+    resetWireMockScenarios();
 
     boolean isRecordingEnabled = System.getProperty("record") != null;
     RecordSpecBuilder recordSpec =


### PR DESCRIPTION
## Summary

Fixes an order-dependent flake in the WireMock replay conformance tests. The shared WireMock server used by the `Abstract*IT` suites lives for the whole test class and its stateful-scenario state is never reset between tests, so test-method execution order can leave a scenario cursor in the wrong state — causing a stub miss that browser-proxies to the real cloud service and fails with an auth error.

Most visibly this surfaces as `GcpBlobStoreIT` multipart tests failing in CI with `Failed to check bucket existence` → `401 Unauthorized`, while passing locally.

## Root cause

- WireMock records repeated same-URL/different-response requests as a **stateful scenario** (`Started → …-2 → …-3 …`). This is WireMock's default (`recordRepeatsAsScenarios`).
- Because the recordings were captured against one long-lived server, unrelated test methods that hit the same URL end up sharing a single URL-named scenario, e.g. `scenario-1-storage-v1-b-…-o` (71 stubs across ~30 test methods for GCP blob).
- The scenario **state cursor is process-global and never reset between tests** (`@BeforeEach`/`@AfterEach` only start/stop recording). Each test's stubs were recorded from a fresh server, so they all begin at `Started`.
- The suites declare no `@TestMethodOrder`, so method order is JUnit's default — which varies by environment/instrumentation. If a scenario-advancing test (e.g. a paginated list) runs before a test whose stub requires `Started`, the cursor is already advanced → **no stub matches** → with `enableBrowserProxying(true)` the request is forwarded to the real service → **401**.

The recordings themselves are correct; this is a test-harness state-lifecycle issue, not a missing/stale stub.

## Change

Reset every scenario cursor back to its initial `Started` state **before each test**, at the single `TestsUtil.startWireMockRecording(...)` chokepoint that every `Abstract*IT` `@BeforeEach` already calls. This applies uniformly across all services and substrates with one change.

- Replay-only: guarded to run when not in record mode; a no-op during recording (scenario state is only consumed on replay).
- `resetScenarios()` resets only scenario **state**, not stubs — safe with persistent stubs.

## Why this is the right layer

Each test's stub-walk was recorded starting from `Started`, so resetting before each test simply restores the precondition every recording already assumes. Static analysis of all recorded mappings confirms that for **every** (test-method, scenario) group repo-wide, every required scenario state is reachable from `Started` using only that test's own stubs — i.e. no test depends on a prior test having advanced a scenario. So the reset strands nothing.

## Testing

- **Cure:** `GcpBlobStoreIT` under forced alphabetical method order goes from `123/0/8/6` (8 multipart errors, the CI failure reproduced locally) to `123/0/0/6` with this change.
- **No regressions:** ran the replay conformance suites across substrates (AWS/GCP/Ali/InMemory) in both default and alphabetical order with and without the change; every suite that passes on `main` still passes, and the few pre-existing failures are unchanged by this commit (they are unrelated harness gaps, not affected by scenario reset).
- Record mode is unaffected by construction (guarded off).
