### PR TITLE
blobstore: update correlation id javadoc to match no auto-generation behavior

### DIFF
--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/client/BucketClient.java
@@ -895,8 +895,8 @@ public class BucketClient implements AutoCloseable {
   /**
    * Returns a copy of {@code req} with the resolved {@link OperationContext} attached so the
    * provider's transformer can read the same correlation id that this call's trace/log/MDC
-   * emit (auto-generating a UUID via {@code MultiCloudJLogger} when the caller didn't supply
-   * one). The transformer then persists that id onto the stored object metadata under
+   * emit (an empty string when the caller didn't supply one; the correlation id is never
+   * auto-generated). The transformer then persists that id onto the stored object metadata under
    * {@link com.salesforce.multicloudj.blob.driver.BlobMetadataKeys#CORRELATION_ID}.
    */
   static UploadRequest withResolvedContext(UploadRequest req, OperationContext ctx) {

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/CopyFromRequest.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/CopyFromRequest.java
@@ -27,8 +27,9 @@ public class CopyFromRequest {
   private final String destKey;
 
   /**
-   * (Optional) Per-call observability context carrying the correlation ID. If null or if its
-   * correlation ID is missing, the SDK auto-generates a UUID and returns it via the response.
+   * (Optional) Per-call observability context carrying the correlation ID. The correlation ID is
+   * never auto-generated; when it is null or missing it defaults to an empty string and tracing is
+   * treated as disabled. When supplied, it is echoed back via the response.
    */
   private final OperationContext operationContext;
 }

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/CopyRequest.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/CopyRequest.java
@@ -27,8 +27,9 @@ public class CopyRequest {
   private final String destKey;
 
   /**
-   * (Optional) Per-call observability context carrying the correlation ID. If null or if its
-   * correlation ID is missing, the SDK auto-generates a UUID and returns it via the response.
+   * (Optional) Per-call observability context carrying the correlation ID. The correlation ID is
+   * never auto-generated; when it is null or missing it defaults to an empty string and tracing is
+   * treated as disabled. When supplied, it is echoed back via the response.
    */
   private final OperationContext operationContext;
 }

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/DownloadRequest.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/DownloadRequest.java
@@ -17,8 +17,9 @@ public class DownloadRequest {
   private final boolean checkArchived;
 
   /**
-   * (Optional) Per-call observability context carrying the correlation ID. If null or if its
-   * correlation ID is missing, the SDK auto-generates a UUID and returns it via the response.
+   * (Optional) Per-call observability context carrying the correlation ID. The correlation ID is
+   * never auto-generated; when it is null or missing it defaults to an empty string and tracing is
+   * treated as disabled. When supplied, it is echoed back via the response.
    */
   private final OperationContext operationContext;
 
@@ -131,8 +132,9 @@ public class DownloadRequest {
     }
 
     /**
-     * Sets the per-call observability context carrying the correlation ID. If not set (or if the
-     * context's correlation ID is null/empty), the SDK auto-generates a UUID.
+     * Sets the per-call observability context carrying the correlation ID. The correlation ID is
+     * never auto-generated; if not set (or if the context's correlation ID is null/empty) it
+     * defaults to an empty string and tracing is treated as disabled.
      *
      * @param operationContext the observability context
      * @return this builder

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/PresignedUrlRequest.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/PresignedUrlRequest.java
@@ -69,8 +69,9 @@ public class PresignedUrlRequest {
   private final ChecksumMethod checksumAlgorithm;
 
   /**
-   * (Optional) Per-call observability context carrying the correlation ID. If null or if its
-   * correlation ID is missing, the SDK auto-generates a UUID for log/trace correlation.
+   * (Optional) Per-call observability context carrying the correlation ID. The correlation ID is
+   * never auto-generated; when it is null or missing it defaults to an empty string and tracing is
+   * treated as disabled for log/trace correlation.
    */
   private final OperationContext operationContext;
 }

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/UploadRequest.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/UploadRequest.java
@@ -66,9 +66,10 @@ public class UploadRequest {
   private final String contentType;
 
   /**
-   * (Optional parameter) Per-call observability context carrying the correlation ID. If null or
-   * if its correlation ID is missing, the SDK auto-generates a UUID and returns it via the
-   * response object.
+   * (Optional parameter) Per-call observability context carrying the correlation ID. The
+   * correlation ID is never auto-generated; when it is null or missing it defaults to an empty
+   * string and tracing is treated as disabled. When supplied, it is echoed back via the response
+   * object.
    */
   private final OperationContext operationContext;
 
@@ -168,8 +169,9 @@ public class UploadRequest {
     }
 
     /**
-     * Sets the per-call observability context carrying the correlation ID. If not set (or if the
-     * context's correlation ID is null/empty), the SDK auto-generates a UUID.
+     * Sets the per-call observability context carrying the correlation ID. The correlation ID is
+     * never auto-generated; if not set (or if the context's correlation ID is null/empty) it
+     * defaults to an empty string and tracing is treated as disabled.
      *
      * @param operationContext the observability context
      * @return this builder

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/UploadResponse.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/UploadResponse.java
@@ -29,9 +29,9 @@ public class UploadResponse {
 
   /**
    * The correlation ID associated with this upload. Echoes the application-supplied value when
-   * provided via {@code OperationContext}, or the SDK-generated UUID when not. Excluded from
-   * {@code equals}/{@code hashCode}/{@code toString} because it is observability metadata, not
-   * part of the resource's identity.
+   * provided via {@code OperationContext}, or an empty string when not (the correlation ID is
+   * never auto-generated). Excluded from {@code equals}/{@code hashCode}/{@code toString} because
+   * it is observability metadata, not part of the resource's identity.
    */
   @EqualsAndHashCode.Exclude
   @ToString.Exclude

--- a/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/observability/MultiCloudJLogger.java
+++ b/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/observability/MultiCloudJLogger.java
@@ -8,7 +8,6 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;

--- a/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/observability/OperationContext.java
+++ b/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/observability/OperationContext.java
@@ -9,15 +9,19 @@ import lombok.Value;
  * <p>Carries the correlation ID and is the extension point for future per-call observability
  * metadata. When an {@code OperationContext} is attached to a request, the SDK uses its
  * correlation ID for the span attribute, the MDC, and echoes it back on the response (where
- * applicable). When no context (or no correlation ID) is supplied, the SDK generates a UUID.
+ * applicable). The correlation ID is optional and never auto-generated; when no context (or no
+ * correlation ID) is supplied, it defaults to an empty string and tracing is treated as disabled
+ * for that operation.
  */
 @Value
 @Builder(toBuilder = true)
 public class OperationContext {
 
   /**
-   * Application-supplied correlation ID. If {@code null} or empty, the SDK generates a UUID and
-   * returns it via the response object so the caller can correlate logs and traces.
+   * Application-supplied correlation ID used to correlate this operation's logs and traces.
+   * Optional; never auto-generated. If {@code null} or empty, it defaults to an empty string and
+   * tracing is treated as disabled for that operation. When provided, it is echoed back via the
+   * response object so the caller can correlate logs and traces.
    */
   String correlationId;
 


### PR DESCRIPTION
## Summary

Fixes a doc/code drift on the `OperationContext` correlation id. The javadoc claimed the SDK **auto-generates a UUID** when a caller doesn't supply a `correlationId`, but the code does not do this — `MultiCloudJLogger.resolveContext()` fills in an empty string `""` and the operation is treated as untraced:

```java
private OperationContext resolveContext(OperationContext context) {
  if (context == null) {
    return OperationContext.builder().correlationId("").build();
  }
  return context; // empty/null correlationId passes through unchanged
}
```

This is the intended behavior (a missing correlation id means tracing is disabled for that operation), so this PR corrects the **documentation** to match, rather than changing behavior.

## What changed

- Rewrote the correlation-id javadoc to state it is **never auto-generated** — when absent it defaults to an empty string and tracing is treated as disabled for that operation. Files: `OperationContext`, `UploadRequest`, `UploadResponse`, `DownloadRequest`, `CopyRequest`, `CopyFromRequest`, `PresignedUrlRequest`, `BucketClient.withResolvedContext`.
- Removed the now-unused `import java.util.UUID;` from `MultiCloudJLogger` (leftover after UUID generation was removed).

## Scope

Documentation only — no behavior change. `+34 / -24`, all javadoc plus one dead import.
