### PR TITLE
sts: add scoped-credential downscoping for Alibaba STS

### DIFF
--- a/sts/sts-ali/pom.xml
+++ b/sts/sts-ali/pom.xml
@@ -65,6 +65,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.aliyun</groupId>
             <artifactId>aliyun-java-sdk-core</artifactId>
             <version>4.7.2</version>

--- a/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliSts.java
+++ b/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliSts.java
@@ -263,17 +263,24 @@ public class AliSts extends AbstractSts {
   }
 
   // Extracts the object-key prefix from the availability condition, relative to the bucket, e.g.
-  // "storage://my-bucket/documents/" -> "documents/". Returns null when no prefix is scoped.
+  // "storage://my-bucket/documents/" -> "documents/". Returns null when no prefix is scoped (no
+  // condition or no resourcePrefix). A resourcePrefix that IS present but does not name this rule's
+  // bucket is rejected rather than ignored: silently returning null would widen the grant to the
+  // whole bucket (the unsafe direction), defeating the downscoping.
   private String extractPrefix(CredentialScope.AvailabilityCondition condition, String bucket) {
     if (condition == null || condition.getResourcePrefix() == null) {
       return null;
     }
     String path = condition.getResourcePrefix().substring("storage://".length());
     String bucketSegment = bucket + "/";
-    if (path.startsWith(bucketSegment)) {
-      return path.substring(bucketSegment.length());
+    if (!path.startsWith(bucketSegment)) {
+      throw new InvalidArgumentException(
+          "credential scope resourcePrefix must be under the rule's bucket 'storage://"
+              + bucket
+              + "/'. Found: "
+              + condition.getResourcePrefix());
     }
-    return null;
+    return path.substring(bucketSegment.length());
   }
 
   // Builds the OSS object resource ARN, encoding the key prefix when one is scoped:

--- a/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliSts.java
+++ b/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliSts.java
@@ -14,6 +14,8 @@ import com.aliyuncs.sts.model.v20150401.AssumeRoleWithOIDCResponse;
 import com.aliyuncs.sts.model.v20150401.GetCallerIdentityRequest;
 import com.aliyuncs.sts.model.v20150401.GetCallerIdentityResponse;
 import com.aliyuncs.utils.EnvironmentUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
 import com.salesforce.multicloudj.common.exceptions.ExceptionHandler;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
@@ -24,15 +26,21 @@ import com.salesforce.multicloudj.sts.driver.AbstractSts;
 import com.salesforce.multicloudj.sts.model.AssumeRoleWebIdentityRequest;
 import com.salesforce.multicloudj.sts.model.AssumedRoleRequest;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.CredentialScope;
 import com.salesforce.multicloudj.sts.model.GetAccessTokenRequest;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @AutoService(AbstractSts.class)
 public class AliSts extends AbstractSts {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private IAcsClient stsClient;
 
@@ -163,6 +171,10 @@ public class AliSts extends AbstractSts {
     if (request.getExpiration() > 0) {
       roleRequest.setDurationSeconds((long) request.getExpiration());
     }
+    // If a credential scope is supplied, downscope the assumed role with an inline RAM policy.
+    if (request.getCredentialScope() != null) {
+      roleRequest.setPolicy(convertToRamPolicy(request.getCredentialScope()));
+    }
 
     try {
       AssumeRoleResponse response = stsClient.getAcsResponse(roleRequest);
@@ -173,6 +185,122 @@ public class AliSts extends AbstractSts {
           credentials.getSecurityToken());
     } catch (Exception e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Translates a cloud-agnostic {@link CredentialScope} into an Alibaba RAM policy document (JSON)
+   * suitable for the AssumeRole {@code Policy} parameter.
+   *
+   * <p>Each scope rule becomes up to two RAM statements, because OSS restricts object access and
+   * list access differently:
+   *
+   * <ul>
+   *   <li><b>Object operations</b> ({@code oss:GetObject}/{@code PutObject}/{@code DeleteObject})
+   *       are restricted to a key prefix by encoding the prefix directly in the resource ARN
+   *       ({@code acs:oss:*:*:bucket/prefix/*}).
+   *   <li><b>List</b> ({@code oss:ListObjects}) must target the bucket resource
+   *       ({@code acs:oss:*:*:bucket}); the prefix is enforced with an {@code oss:Prefix} condition
+   *       because OSS evaluates the listable scope from the request prefix parameter, not the ARN.
+   * </ul>
+   *
+   * <p>Region and account fields use the {@code *} wildcard: the bucket name is the meaningful
+   * selector for OSS, and the policy is intersected with an already-assumed role for that account.
+   */
+  private String convertToRamPolicy(CredentialScope credentialScope) {
+    List<Map<String, Object>> statements = new ArrayList<>();
+    for (CredentialScope.ScopeRule rule : credentialScope.getRules()) {
+      String bucket = extractBucket(rule.getAvailableResource());
+      String prefix = extractPrefix(rule.getAvailabilityCondition(), bucket);
+
+      List<String> objectActions = new ArrayList<>();
+      List<String> listActions = new ArrayList<>();
+      for (String permission : rule.getAvailablePermissions()) {
+        String action = toOssAction(permission);
+        if ("oss:ListObjects".equals(action)) {
+          listActions.add(action);
+        } else {
+          objectActions.add(action);
+        }
+      }
+
+      if (!objectActions.isEmpty()) {
+        Map<String, Object> statement = new LinkedHashMap<>();
+        statement.put("Effect", "Allow");
+        statement.put("Action", objectActions);
+        statement.put("Resource", objectResourceArn(bucket, prefix));
+        statements.add(statement);
+      }
+
+      if (!listActions.isEmpty()) {
+        Map<String, Object> statement = new LinkedHashMap<>();
+        statement.put("Effect", "Allow");
+        statement.put("Action", listActions);
+        statement.put("Resource", "acs:oss:*:*:" + bucket);
+        if (prefix != null && !prefix.isEmpty()) {
+          Map<String, Object> stringLike = new LinkedHashMap<>();
+          stringLike.put("oss:Prefix", List.of(prefix, prefix + "*"));
+          Map<String, Object> condition = new LinkedHashMap<>();
+          condition.put("StringLike", stringLike);
+          statement.put("Condition", condition);
+        }
+        statements.add(statement);
+      }
+    }
+
+    Map<String, Object> policy = new LinkedHashMap<>();
+    policy.put("Version", "1");
+    policy.put("Statement", statements);
+    return toJsonString(policy);
+  }
+
+  // Extracts the bucket name from a cloud-agnostic resource, e.g. "storage://my-bucket" or
+  // "storage://my-bucket/*" -> "my-bucket".
+  private String extractBucket(String availableResource) {
+    String remainder = availableResource.substring("storage://".length());
+    int slash = remainder.indexOf('/');
+    return slash >= 0 ? remainder.substring(0, slash) : remainder;
+  }
+
+  // Extracts the object-key prefix from the availability condition, relative to the bucket, e.g.
+  // "storage://my-bucket/documents/" -> "documents/". Returns null when no prefix is scoped.
+  private String extractPrefix(CredentialScope.AvailabilityCondition condition, String bucket) {
+    if (condition == null || condition.getResourcePrefix() == null) {
+      return null;
+    }
+    String path = condition.getResourcePrefix().substring("storage://".length());
+    String bucketSegment = bucket + "/";
+    if (path.startsWith(bucketSegment)) {
+      return path.substring(bucketSegment.length());
+    }
+    return null;
+  }
+
+  // Builds the OSS object resource ARN, encoding the key prefix when one is scoped:
+  // "acs:oss:*:*:bucket/prefix/*", or "acs:oss:*:*:bucket/*" for the whole bucket.
+  private String objectResourceArn(String bucket, String prefix) {
+    if (prefix != null && !prefix.isEmpty()) {
+      return "acs:oss:*:*:" + bucket + "/" + prefix + "*";
+    }
+    return "acs:oss:*:*:" + bucket + "/*";
+  }
+
+  // Maps a cloud-agnostic "storage:<Action>" permission to its OSS action. Object actions map by
+  // suffix (GetObject/PutObject/DeleteObject -> oss:GetObject/...); the list action is renamed
+  // (ListBucket -> oss:ListObjects, the RAM action behind the OSS GetBucket API).
+  private String toOssAction(String permission) {
+    String action = permission.substring("storage:".length());
+    if ("ListBucket".equals(action)) {
+      return "oss:ListObjects";
+    }
+    return "oss:" + action;
+  }
+
+  private String toJsonString(Map<String, Object> map) {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(map);
+    } catch (JsonProcessingException e) {
+      throw new InvalidArgumentException("scoped credentials is not in right format", e);
     }
   }
 

--- a/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliSts.java
+++ b/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliSts.java
@@ -248,6 +248,14 @@ public class AliSts extends AbstractSts {
       }
     }
 
+    // Throw on a scope with no statements so the caller gets an actionable error instead of an
+    // opaque AccessDenied: OSS treats an empty inline policy as deny-all.
+    if (statements.isEmpty()) {
+      throw new InvalidArgumentException(
+          "credential scope produced no RAM statements; supply at least one rule with a resource "
+              + "and permissions");
+    }
+
     Map<String, Object> policy = new LinkedHashMap<>();
     policy.put("Version", "1");
     policy.put("Statement", statements);

--- a/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliSts.java
+++ b/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliSts.java
@@ -288,7 +288,17 @@ public class AliSts extends AbstractSts {
               + "/'. Found: "
               + condition.getResourcePrefix());
     }
-    return path.substring(bucketSegment.length());
+    String prefix = path.substring(bucketSegment.length());
+    // RAM treats '*' and '?' as wildcards in both the resource ARN and the oss:Prefix StringLike
+    // condition, so a literal-looking prefix such as "priv*" would match every key starting with
+    // "priv" — widening the grant beyond what the caller asked for. Reject them (fail closed)
+    // rather than silently broadening the scope.
+    if (prefix.indexOf('*') >= 0 || prefix.indexOf('?') >= 0) {
+      throw new InvalidArgumentException(
+          "credential scope resourcePrefix must not contain wildcard characters ('*' or '?'); "
+              + "they would widen the grant. Found: " + condition.getResourcePrefix());
+    }
+    return prefix;
   }
 
   // Builds the OSS object resource ARN, encoding the key prefix when one is scoped:

--- a/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsTest.java
+++ b/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsTest.java
@@ -14,11 +14,13 @@ import com.aliyuncs.sts.model.v20150401.AssumeRoleWithOIDCRequest;
 import com.aliyuncs.sts.model.v20150401.AssumeRoleWithOIDCResponse;
 import com.aliyuncs.sts.model.v20150401.GetCallerIdentityRequest;
 import com.aliyuncs.sts.model.v20150401.GetCallerIdentityResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.model.AssumeRoleWebIdentityRequest;
 import com.salesforce.multicloudj.sts.model.AssumedRoleRequest;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.CredentialScope;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
 import java.net.URI;
 import org.junit.jupiter.api.Assertions;
@@ -215,5 +217,114 @@ public class AliStsTest {
     String expectedUrl = "http://proxy.example.com:8080";
     Assertions.assertEquals(expectedUrl, config.getHttpProxy());
     Assertions.assertEquals(expectedUrl, config.getHttpsProxy());
+  }
+
+  // Captures the AssumeRoleRequest issued for the given cloud-agnostic request, using a dedicated
+  // mock so the captured request is unambiguous.
+  private static AssumeRoleRequest capturedAssumeRoleRequest(AssumedRoleRequest request)
+      throws ClientException {
+    DefaultAcsClient client = Mockito.mock(DefaultAcsClient.class);
+    AssumeRoleResponse.Credentials creds = new AssumeRoleResponse.Credentials();
+    creds.setAccessKeyId("k");
+    creds.setAccessKeySecret("s");
+    creds.setSecurityToken("t");
+    AssumeRoleResponse response = new AssumeRoleResponse();
+    response.setCredentials(creds);
+    Mockito.when(client.getAcsResponse(any(AssumeRoleRequest.class))).thenReturn(response);
+
+    AliSts sts = new AliSts().builder().build(client);
+    sts.assumeRole(request);
+
+    ArgumentCaptor<AssumeRoleRequest> captor = ArgumentCaptor.forClass(AssumeRoleRequest.class);
+    Mockito.verify(client).getAcsResponse(captor.capture());
+    return captor.getValue();
+  }
+
+  @Test
+  public void testAssumeRoleWithCredentialScope() throws Exception {
+    // The Capstone shape: read-write access downscoped to a bucket + key prefix. Object operations
+    // and the list operation must land in separate RAM statements with different resource forms.
+    CredentialScope credentialScope =
+        CredentialScope.builder()
+            .rule(
+                CredentialScope.ScopeRule.builder()
+                    .availableResource("storage://my-bucket")
+                    .availablePermission("storage:GetObject")
+                    .availablePermission("storage:PutObject")
+                    .availablePermission("storage:ListBucket")
+                    .availabilityCondition(
+                        CredentialScope.AvailabilityCondition.builder()
+                            .resourcePrefix("storage://my-bucket/documents/")
+                            .title("Limit to documents folder")
+                            .description("Only allow access to the documents folder")
+                            .build())
+                    .build())
+            .build();
+
+    AssumedRoleRequest request =
+        AssumedRoleRequest.newBuilder()
+            .withRole("acs:ram::123456789:role/my-bucket-ro")
+            .withSessionName("my-session")
+            .withCredentialScope(credentialScope)
+            .build();
+
+    AssumeRoleRequest captured = capturedAssumeRoleRequest(request);
+
+    String expectedPolicy =
+        "{\"Version\":\"1\",\"Statement\":["
+            + "{\"Effect\":\"Allow\",\"Action\":[\"oss:GetObject\",\"oss:PutObject\"],"
+            + "\"Resource\":\"acs:oss:*:*:my-bucket/documents/*\"},"
+            + "{\"Effect\":\"Allow\",\"Action\":[\"oss:ListObjects\"],"
+            + "\"Resource\":\"acs:oss:*:*:my-bucket\","
+            + "\"Condition\":{\"StringLike\":{\"oss:Prefix\":[\"documents/\",\"documents/*\"]}}}]}";
+    assertJsonEquals(expectedPolicy, captured.getPolicy());
+  }
+
+  @Test
+  public void testAssumeRoleWithCredentialScopeNoPrefix() throws Exception {
+    // No availability condition -> object ops cover the whole bucket, list statement has no
+    // prefix condition.
+    CredentialScope credentialScope =
+        CredentialScope.builder()
+            .rule(
+                CredentialScope.ScopeRule.builder()
+                    .availableResource("storage://my-bucket")
+                    .availablePermission("storage:GetObject")
+                    .availablePermission("storage:ListBucket")
+                    .build())
+            .build();
+
+    AssumedRoleRequest request =
+        AssumedRoleRequest.newBuilder()
+            .withRole("acs:ram::123456789:role/my-bucket-ro")
+            .withSessionName("my-session")
+            .withCredentialScope(credentialScope)
+            .build();
+
+    AssumeRoleRequest captured = capturedAssumeRoleRequest(request);
+
+    String expectedPolicy =
+        "{\"Version\":\"1\",\"Statement\":["
+            + "{\"Effect\":\"Allow\",\"Action\":[\"oss:GetObject\"],"
+            + "\"Resource\":\"acs:oss:*:*:my-bucket/*\"},"
+            + "{\"Effect\":\"Allow\",\"Action\":[\"oss:ListObjects\"],"
+            + "\"Resource\":\"acs:oss:*:*:my-bucket\"}]}";
+    assertJsonEquals(expectedPolicy, captured.getPolicy());
+  }
+
+  @Test
+  public void testAssumeRoleWithoutCredentialScopeSetsNoPolicy() throws Exception {
+    AssumedRoleRequest request =
+        AssumedRoleRequest.newBuilder().withRole("testRole").withSessionName("testSession").build();
+
+    AssumeRoleRequest captured = capturedAssumeRoleRequest(request);
+
+    Assertions.assertNull(captured.getPolicy(), "no credential scope should mean no inline policy");
+  }
+
+  // Compares two JSON strings for structural equality, ignoring object key ordering.
+  private static void assertJsonEquals(String expected, String actual) throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    Assertions.assertEquals(mapper.readTree(expected), mapper.readTree(actual));
   }
 }

--- a/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsTest.java
+++ b/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsTest.java
@@ -351,6 +351,35 @@ public class AliStsTest {
   }
 
   @Test
+  public void testAssumeRoleWithWildcardPrefixThrows() {
+    // A resourcePrefix containing RAM wildcards ('*'/'?') would widen the grant beyond the literal
+    // prefix (RAM treats them as wildcards in both the ARN and the oss:Prefix StringLike). Reject
+    // it rather than silently broadening the scope.
+    CredentialScope credentialScope =
+        CredentialScope.builder()
+            .rule(
+                CredentialScope.ScopeRule.builder()
+                    .availableResource("storage://my-bucket")
+                    .availablePermission("storage:GetObject")
+                    .availabilityCondition(
+                        CredentialScope.AvailabilityCondition.builder()
+                            .resourcePrefix("storage://my-bucket/priv*")
+                            .build())
+                    .build())
+            .build();
+
+    AssumedRoleRequest request =
+        AssumedRoleRequest.newBuilder()
+            .withRole("acs:ram::123456789:role/my-bucket-ro")
+            .withSessionName("my-session")
+            .withCredentialScope(credentialScope)
+            .build();
+
+    AliSts sts = new AliSts().builder().build(mockStsClient);
+    assertThrows(InvalidArgumentException.class, () -> sts.assumeRole(request));
+  }
+
+  @Test
   public void testAssumeRoleWithEmptyCredentialScopeThrows() {
     // A credential scope was supplied but has no rules -> it would downscope to an empty policy.
     // Reject it up front rather than sending a deny-all policy that fails opaquely at request time.

--- a/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsTest.java
+++ b/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsTest.java
@@ -322,6 +322,34 @@ public class AliStsTest {
     Assertions.assertNull(captured.getPolicy(), "no credential scope should mean no inline policy");
   }
 
+  @Test
+  public void testAssumeRoleWithMismatchedPrefixBucketThrows() {
+    // A resourcePrefix that names a different (or missing) bucket than availableResource must be
+    // rejected, not silently ignored -- ignoring it would widen the grant to the whole bucket.
+    CredentialScope credentialScope =
+        CredentialScope.builder()
+            .rule(
+                CredentialScope.ScopeRule.builder()
+                    .availableResource("storage://my-bucket")
+                    .availablePermission("storage:GetObject")
+                    .availabilityCondition(
+                        CredentialScope.AvailabilityCondition.builder()
+                            .resourcePrefix("storage://other-bucket/documents/")
+                            .build())
+                    .build())
+            .build();
+
+    AssumedRoleRequest request =
+        AssumedRoleRequest.newBuilder()
+            .withRole("acs:ram::123456789:role/my-bucket-ro")
+            .withSessionName("my-session")
+            .withCredentialScope(credentialScope)
+            .build();
+
+    AliSts sts = new AliSts().builder().build(mockStsClient);
+    assertThrows(InvalidArgumentException.class, () -> sts.assumeRole(request));
+  }
+
   // Compares two JSON strings for structural equality, ignoring object key ordering.
   private static void assertJsonEquals(String expected, String actual) throws Exception {
     ObjectMapper mapper = new ObjectMapper();

--- a/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsTest.java
+++ b/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsTest.java
@@ -350,6 +350,22 @@ public class AliStsTest {
     assertThrows(InvalidArgumentException.class, () -> sts.assumeRole(request));
   }
 
+  @Test
+  public void testAssumeRoleWithEmptyCredentialScopeThrows() {
+    // A credential scope was supplied but has no rules -> it would downscope to an empty policy.
+    // Reject it up front rather than sending a deny-all policy that fails opaquely at request time.
+    CredentialScope emptyScope = CredentialScope.builder().build();
+    AssumedRoleRequest request =
+        AssumedRoleRequest.newBuilder()
+            .withRole("acs:ram::123456789:role/my-bucket-ro")
+            .withSessionName("my-session")
+            .withCredentialScope(emptyScope)
+            .build();
+
+    AliSts sts = new AliSts().builder().build(mockStsClient);
+    assertThrows(InvalidArgumentException.class, () -> sts.assumeRole(request));
+  }
+
   // Compares two JSON strings for structural equality, ignoring object key ordering.
   private static void assertJsonEquals(String expected, String actual) throws Exception {
     ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
## Summary
Adds credential downscoping (scoped credentials) to the Alibaba STS provider. When an AssumedRoleRequest carries a cloud-agnostic CredentialScope, AliSts now translates it into an Alibaba RAM policy and attaches it to the AssumeRole request, so the returned temporary credentials are restricted to the requested bucket/prefix and operations. Previously the scope was ignored on Ali and callers received the role's full permissions. AWS and GCP already support this; this closes the Ali gap.

## Changes
- `AliSts.convertToRamPolicy` translates CredentialScope -> RAM policy JSON, wired into `getSTSCredentialsWithAssumeRole` via `setPolicy`.
- Object operations (Get/Put/DeleteObject) restrict by prefix in the resource ARN (`acs:oss:*:*:bucket/prefix/*`); list (ListObjects) targets the bucket resource with an `oss:Prefix` StringLike condition, since OSS evaluates listable scope from the request prefix.
- `AliStsTest`: unit tests asserting the generated policy JSON (scoped, no-prefix, null-scope).
- Adds `jackson-databind` (compile) to sts-ali for policy serialization.

## Testing
- Unit tests: `mvn test -pl sts/sts-ali -Dtest=AliStsTest` (14 pass).
- Verified end-to-end against live Alibaba OSS: assumed a role with a prefix scope and confirmed the allow/deny matrix -- operations under the prefix succeed, outside the prefix are denied (403), for object GET/PUT/DELETE and list.

## Cross-cloud
- Alibaba: implemented here.
- AWS/GCP: already support CredentialScope (unchanged).
