### PR TITLE
dbbackuprestore: report backup size as -1 when the provider omits it (GCP + AWS)

### DIFF
--- a/dbbackuprestore/dbbackuprestore-aws/src/main/java/com/salesforce/multicloudj/dbbackuprestore/aws/AwsDBBackupRestore.java
+++ b/dbbackuprestore/dbbackuprestore-aws/src/main/java/com/salesforce/multicloudj/dbbackuprestore/aws/AwsDBBackupRestore.java
@@ -182,18 +182,25 @@ public class AwsDBBackupRestore extends AbstractDBBackupRestore {
   }
 
   private Backup convertToBackup(RecoveryPointByResource recoveryPoint) {
+    // backupSizeBytes() is a boxed Long that AWS leaves null until the size is computed (e.g. while
+    // the recovery point is still CREATING/PARTIAL). Guard the unboxing and report -1 (unavailable)
+    // per the Backup.sizeInBytes contract instead of throwing NPE.
+    Long sizeInBytes = recoveryPoint.backupSizeBytes();
     return Backup.builder()
         .backupId(recoveryPoint.recoveryPointArn())
         .resourceName(getResourceName())
         .status(convertRecoveryPointStatus(recoveryPoint.status()))
         .creationTime(recoveryPoint.creationDate())
         .expiryTime(null)
-        .sizeInBytes(recoveryPoint.backupSizeBytes())
+        .sizeInBytes(sizeInBytes != null ? sizeInBytes : -1)
         .vaultId(recoveryPoint.backupVaultName())
         .build();
   }
 
   private Backup convertToBackup(DescribeRecoveryPointResponse response) {
+    // backupSizeInBytes() is a boxed Long that AWS leaves null until the size is computed. Guard
+    // the unboxing and report -1 (unavailable) per the Backup.sizeInBytes contract instead of NPE.
+    Long sizeInBytes = response.backupSizeInBytes();
     return Backup.builder()
         .backupId(response.recoveryPointArn())
         .resourceName(getResourceName())
@@ -203,7 +210,7 @@ public class AwsDBBackupRestore extends AbstractDBBackupRestore {
             response.calculatedLifecycle() != null
                 ? response.calculatedLifecycle().deleteAt()
                 : null)
-        .sizeInBytes(response.backupSizeInBytes())
+        .sizeInBytes(sizeInBytes != null ? sizeInBytes : -1)
         .vaultId(response.backupVaultName())
         .build();
   }

--- a/dbbackuprestore/dbbackuprestore-aws/src/test/java/com/salesforce/multicloudj/dbbackuprestore/aws/AwsDBBackupRestoreTest.java
+++ b/dbbackuprestore/dbbackuprestore-aws/src/test/java/com/salesforce/multicloudj/dbbackuprestore/aws/AwsDBBackupRestoreTest.java
@@ -95,9 +95,40 @@ public class AwsDBBackupRestoreTest {
     assertEquals(2, backups.size());
     assertEquals(BackupStatus.AVAILABLE, backups.get(0).getStatus());
     assertEquals(BackupStatus.CREATING, backups.get(1).getStatus());
+    assertEquals(1024L, backups.get(0).getSizeInBytes());
+    assertEquals(2048L, backups.get(1).getSizeInBytes());
     assertEquals("Default", backups.get(0).getVaultId());
     verify(mockBackupClient, times(1))
         .listRecoveryPointsByResource(any(ListRecoveryPointsByResourceRequest.class));
+  }
+
+  @Test
+  void testListBackups_NullSize_ReturnsMinusOne() {
+    // AWS returns a boxed Long for backupSizeBytes(); it is null when the size has not been
+    // computed yet (e.g. a recovery point still in CREATING/PARTIAL). Unboxing null into the
+    // model's primitive long would throw NPE, so an absent size must map to -1 (unavailable)
+    // per the Backup.sizeInBytes contract.
+    RecoveryPointByResource recoveryNoSize =
+        RecoveryPointByResource.builder()
+            .recoveryPointArn("arn:aws:backup:us-west-2:123456789012:recovery-point:nosize")
+            .backupVaultName("Default")
+            .status(RecoveryPointStatus.CREATING)
+            .creationDate(Instant.now())
+            .build();
+
+    ListRecoveryPointsByResourceResponse response =
+        ListRecoveryPointsByResourceResponse.builder()
+            .recoveryPoints(Arrays.asList(recoveryNoSize))
+            .build();
+
+    when(mockBackupClient.listRecoveryPointsByResource(
+            any(ListRecoveryPointsByResourceRequest.class)))
+        .thenReturn(response);
+
+    List<Backup> backups = dbBackupRestore.listBackups();
+
+    assertEquals(1, backups.size());
+    assertEquals(-1L, backups.get(0).getSizeInBytes());
   }
 
   @Test
@@ -147,6 +178,44 @@ public class AwsDBBackupRestoreTest {
     assertEquals("MyVault", backup.getVaultId());
     verify(mockBackupClient, times(1))
         .describeRecoveryPoint(any(DescribeRecoveryPointRequest.class));
+  }
+
+  @Test
+  void testGetBackup_NullSize_ReturnsMinusOne() {
+    // DescribeRecoveryPoint returns a boxed Long for backupSizeInBytes(); when AWS omits it (size
+    // not yet computed) the unguarded mapper would unbox null and throw NPE. It must instead map to
+    // -1 (unavailable), consistent with the Backup.sizeInBytes contract and the other substrates.
+    RecoveryPointByResource recovery =
+        RecoveryPointByResource.builder()
+            .recoveryPointArn("arn:aws:backup:us-west-2:123456789012:recovery-point:nosize")
+            .backupVaultName("MyVault")
+            .build();
+
+    ListRecoveryPointsByResourceResponse listResponse =
+        ListRecoveryPointsByResourceResponse.builder()
+            .recoveryPoints(Arrays.asList(recovery))
+            .build();
+
+    when(mockBackupClient.listRecoveryPointsByResource(
+            any(ListRecoveryPointsByResourceRequest.class)))
+        .thenReturn(listResponse);
+
+    DescribeRecoveryPointResponse response =
+        DescribeRecoveryPointResponse.builder()
+            .recoveryPointArn("arn:aws:backup:us-west-2:123456789012:recovery-point:nosize")
+            .backupVaultName("MyVault")
+            .status(RecoveryPointStatus.CREATING)
+            .creationDate(Instant.now())
+            .build();
+
+    when(mockBackupClient.describeRecoveryPoint(any(DescribeRecoveryPointRequest.class)))
+        .thenReturn(response);
+
+    Backup backup =
+        dbBackupRestore.getBackup("arn:aws:backup:us-west-2:123456789012:recovery-point:nosize");
+
+    assertNotNull(backup);
+    assertEquals(-1L, backup.getSizeInBytes());
   }
 
   @Test

--- a/dbbackuprestore/dbbackuprestore-gcp-firestore/src/main/java/com/salesforce/multicloudj/dbbackuprestore/gcp/FSDBBackupRestore.java
+++ b/dbbackuprestore/dbbackuprestore-gcp-firestore/src/main/java/com/salesforce/multicloudj/dbbackuprestore/gcp/FSDBBackupRestore.java
@@ -172,7 +172,7 @@ public class FSDBBackupRestore extends AbstractDBBackupRestore {
         .expiryTime(
             Instant.ofEpochSecond(
                 backup.getExpireTime().getSeconds(), backup.getExpireTime().getNanos()))
-        .sizeInBytes(backup.getStats().getSizeBytes())
+        .sizeInBytes(backup.hasStats() ? backup.getStats().getSizeBytes() : -1)
         .build();
   }
 

--- a/dbbackuprestore/dbbackuprestore-gcp-firestore/src/test/java/com/salesforce/multicloudj/dbbackuprestore/gcp/FSDBBackupRestoreTest.java
+++ b/dbbackuprestore/dbbackuprestore-gcp-firestore/src/test/java/com/salesforce/multicloudj/dbbackuprestore/gcp/FSDBBackupRestoreTest.java
@@ -105,6 +105,10 @@ public class FSDBBackupRestoreTest {
     assertEquals(2, backups.size());
     assertEquals(BackupStatus.AVAILABLE, backups.get(0).getStatus());
     assertEquals(BackupStatus.CREATING, backups.get(1).getStatus());
+    // Firestore Admin listBackups omits the stats sub-message, so size must be reported as
+    // unavailable (-1), not a misleading 0. This is the path the client's FirestoreBackupStep uses.
+    assertEquals(-1L, backups.get(0).getSizeInBytes());
+    assertEquals(-1L, backups.get(1).getSizeInBytes());
     assertNull(backups.get(0).getVaultId()); // GCP doesn't use vaults
     verify(mockFirestoreClient, times(1)).listBackups(LOCATION);
   }
@@ -147,6 +151,67 @@ public class FSDBBackupRestoreTest {
     assertNull(result.getVaultId());
     verify(mockFirestoreClient, times(1))
         .getBackup("projects/my-project/locations/us-central1/backups/backup-123");
+  }
+
+  @Test
+  void testGetBackup_NoStats_ReturnsMinusOne() {
+    // Firestore Admin often omits the stats sub-message (e.g. on the REST/HTTP-JSON transport, and
+    // for backups whose stats have not materialized). Absent stats must map to -1 (unavailable),
+    // not the protobuf default 0 that would otherwise leak through getStats().getSizeBytes().
+    Backup backup =
+        Backup.newBuilder()
+            .setName("projects/my-project/locations/us-central1/backups/backup-nostats")
+            .setDatabase("projects/my-project/databases/(default)")
+            .setState(Backup.State.READY)
+            .setSnapshotTime(
+                Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()).build())
+            .setExpireTime(
+                Timestamp.newBuilder()
+                    .setSeconds(Instant.now().plusSeconds(86400).getEpochSecond())
+                    .build())
+            .build();
+
+    when(mockFirestoreClient.getBackup(
+            "projects/my-project/locations/us-central1/backups/backup-nostats"))
+        .thenReturn(backup);
+
+    com.salesforce.multicloudj.dbbackuprestore.driver.Backup result =
+        dbBackupRestore.getBackup(
+            "projects/my-project/locations/us-central1/backups/backup-nostats");
+
+    assertNotNull(result);
+    assertEquals(BackupStatus.AVAILABLE, result.getStatus());
+    assertEquals(-1L, result.getSizeInBytes());
+  }
+
+  @Test
+  void testGetBackup_StatsPresentWithZeroSize_ReturnsZero() {
+    // A genuinely empty backup (stats present, size 0) must report 0, not -1. hasStats() lets us
+    // distinguish "field absent" (unavailable) from "present with a real zero".
+    Backup backup =
+        Backup.newBuilder()
+            .setName("projects/my-project/locations/us-central1/backups/backup-empty")
+            .setDatabase("projects/my-project/databases/(default)")
+            .setState(Backup.State.READY)
+            .setSnapshotTime(
+                Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()).build())
+            .setExpireTime(
+                Timestamp.newBuilder()
+                    .setSeconds(Instant.now().plusSeconds(86400).getEpochSecond())
+                    .build())
+            .setStats(Backup.Stats.newBuilder().setSizeBytes(0).build())
+            .build();
+
+    when(mockFirestoreClient.getBackup(
+            "projects/my-project/locations/us-central1/backups/backup-empty"))
+        .thenReturn(backup);
+
+    com.salesforce.multicloudj.dbbackuprestore.driver.Backup result =
+        dbBackupRestore.getBackup(
+            "projects/my-project/locations/us-central1/backups/backup-empty");
+
+    assertNotNull(result);
+    assertEquals(0L, result.getSizeInBytes());
   }
 
   @Test


### PR DESCRIPTION
## Problem

The `Backup.sizeInBytes` model field documents a clear contract:

> `/** Size of the backup in bytes (if available). -1 if size information is not available. */`
> — `dbbackuprestore-client/.../driver/Backup.java`

Two of the three substrate drivers violated it. This PR brings **both GCP and AWS** in line with the contract (the **Ali** driver already honored it via a `-1` default), so `-1 = unavailable` is now consistent across every substrate.

---

## GCP Firestore — `0` masks "unavailable"

The GCP Firestore driver reported `sizeInBytes = 0` for every backup, even healthy `READY` ones. A client's backup-validation service logged this as `sizeBytes=0` and it looked like an empty backup.

Root cause in `FSDBBackupRestore.convertToBackup(...)`:

```java
.sizeInBytes(backup.getStats().getSizeBytes())
```

`Backup.stats` is an optional proto3 sub-message. When the Firestore Admin API response omits it, `getStats()` returns the **default instance** and `getSizeBytes()` returns `0L` — so "size not reported by the API" is indistinguishable from a genuine zero. Empirically, the recorded Firestore Admin responses in this module's own IT fixtures (`fsdbbackuprestoreit_*`) contain **no `stats` field** across all `READY` backups, so the driver always emitted `0`.

**Fix** — guard the read with `hasStats()` so absent stats map to `-1`, while a genuinely empty backup (stats present, `sizeBytes == 0`) still correctly reports `0`:

```java
.sizeInBytes(backup.hasStats() ? backup.getStats().getSizeBytes() : -1)
```

**Tests** (`FSDBBackupRestoreTest`):
- `testListBackups` — asserts `-1L` for backups with no stats (the list path production callers use).
- `testGetBackup_NoStats_ReturnsMinusOne` — absent stats → `-1L`.
- `testGetBackup_StatsPresentWithZeroSize_ReturnsZero` — stats present with size 0 → `0L` (empty ≠ unavailable).
- `testGetBackup` — unchanged (stats present, `2048` → `2048L`).

No fixture changes: the IT makes no size assertions and the recorded cassettes contain no `stats`, so they exercise the `-1` path and stay green.

---

## AWS Backup — NPE risk + contract gap

Both `AwsDBBackupRestore.convertToBackup(...)` overloads passed the size straight through:

```java
.sizeInBytes(recoveryPoint.backupSizeBytes())   // RecoveryPointByResource
.sizeInBytes(response.backupSizeInBytes())       // DescribeRecoveryPointResponse
```

Both AWS accessors return a **boxed `java.lang.Long`** that AWS leaves `null` until the size is computed (e.g. while a recovery point is still `CREATING`/`PARTIAL`), while the model field is a primitive `long`. So a null size didn't just skip the `-1` contract — auto-unboxing threw a **`NullPointerException`**. This was reproduced by the two new null-size tests before the fix.

**Fix** — guard both overloads, mapping an absent size to `-1`:

```java
Long sizeInBytes = recoveryPoint.backupSizeBytes();
.sizeInBytes(sizeInBytes != null ? sizeInBytes : -1)
```

**Tests** (`AwsDBBackupRestoreTest`):
- `testListBackups` — now asserts the real sizes (`1024L`/`2048L`) that were previously set but never checked.
- `testListBackups_NullSize_ReturnsMinusOne` / `testGetBackup_NullSize_ReturnsMinusOne` — null size → `-1L` (these threw NPE before the fix).
- `testGetBackup` — unchanged (`2048L`).

---

## Verification

```
mvn -pl dbbackuprestore/dbbackuprestore-gcp-firestore -am verify
mvn -pl dbbackuprestore/dbbackuprestore-aws -am verify
```
- GCP unit `FSDBBackupRestoreTest` 13/13, IT `FSDBBackupRestoreIT` 3/3
- AWS unit `AwsDBBackupRestoreTest` 17/17, IT `AwsDBBackupRestoreIT` 3/3
- `checkstyle:check` clean for both modules
