### PR TITLE
sts: add signed-identity output and WIF signing options for GCP federation

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -73,6 +73,11 @@
         </dependency>
         <dependency>
             <groupId>com.salesforce.multicloudj</groupId>
+            <artifactId>blob-gcp</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.salesforce.multicloudj</groupId>
             <artifactId>sts-aws</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -108,16 +113,6 @@
         </dependency>
         <dependency>
             <groupId>com.salesforce.multicloudj</groupId>
-            <artifactId>iam-aws</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.salesforce.multicloudj</groupId>
-            <artifactId>iam-gcp</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.salesforce.multicloudj</groupId>
             <artifactId>registry-client</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -130,6 +125,11 @@
             <groupId>com.salesforce.multicloudj</groupId>
             <artifactId>registry-aws</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/examples/src/main/java/com/salesforce/multicloudj/blob/CrossCloudAwsToGcp.java
+++ b/examples/src/main/java/com/salesforce/multicloudj/blob/CrossCloudAwsToGcp.java
@@ -1,0 +1,117 @@
+package com.salesforce.multicloudj.blob;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import com.salesforce.multicloudj.blob.driver.ListBlobsPageRequest;
+import com.salesforce.multicloudj.blob.driver.ListBlobsPageResponse;
+import com.salesforce.multicloudj.sts.client.StsUtilities;
+import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
+import com.salesforce.multicloudj.sts.model.SignOptions;
+import com.salesforce.multicloudj.sts.model.SignedAuthRequest;
+import java.net.URLEncoder;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+
+/**
+ * Cross-cloud example: an AWS workload accessing Google Cloud Storage.
+ *
+ * <p>The pod runs on AWS with an ambient AWS role (e.g. IRSA). Google Cloud Workload Identity
+ * Federation exchanges a signed AWS GetCallerIdentity request for a short-lived GCP access token,
+ * so the same {@code BucketClient} API works against GCP with no static GCP keys.
+ */
+public class CrossCloudAwsToGcp {
+
+  private static final String REGION = "us-west-2";
+
+  private static final String BUCKET = "palsfdc";
+
+  // The audience is the full Workload Identity Pool provider resource name. We grant the bucket
+  // role directly to this pool principal (direct pool access), so no service account sits in the
+  // middle.
+  private static final String AUDIENCE =
+      "//iam.googleapis.com/projects/599653580068/locations/global/workloadIdentityPools/"
+          + "substrate-sdk/providers/substrate-gcp";
+
+  public static void main(String[] args) {
+    Supplier<String> webIdentityTokenSupplier = CrossCloudAwsToGcp::buildSubjectToken;
+
+    CredentialsOverrider overrider =
+        new CredentialsOverrider.Builder(CredentialsType.ASSUME_ROLE_WEB_IDENTITY)
+            .withRole(AUDIENCE)
+            .withWebIdentityTokenSupplier(webIdentityTokenSupplier)
+            .build();
+
+    BucketClient bucketClient =
+        BucketClient.builder("gcp")
+            .withBucket(BUCKET)
+            .withCredentialsOverrider(overrider)
+            .build();
+
+    ListBlobsPageResponse page =
+        bucketClient.listPage(ListBlobsPageRequest.builder().withMaxResults(10).build());
+    page.getBlobs().forEach(b -> System.out.println(b.getKey()));
+  }
+
+  // Signs a GetCallerIdentity request with the pod's AWS role, then shapes the
+  // signed request into the URL-encoded JSON envelope that Google STS expects
+  // as an AWS4 subject token.
+  private static String buildSubjectToken() {
+    // Google requires the audience to travel inside the signed headers, so it is
+    // bound to the signature and the request cannot be replayed against any other
+    // target.
+    // GCP replays the signed request from its URL and headers alone, with no body, so the action
+    // and version must be signed as query parameters rather than in a form body.
+    SignOptions options =
+        SignOptions.builder()
+            .withCustomHeader("x-goog-cloud-target-resource", AUDIENCE)
+            .withActionInQueryString(true)
+            .build();
+
+    // No credentials are supplied, so the signer resolves the pod's AWS role from the ambient
+    // default credential chain (IRSA, environment, container, or instance metadata).
+    StsUtilities stsUtil = StsUtilities.builder("aws").withRegion(REGION).build();
+
+    // Passing null means "just sign a GetCallerIdentity request, there is no
+    // service payload to hash." The library fills in Action=GetCallerIdentity.
+    SignedAuthRequest signed = stsUtil.newCloudNativeAuthSignedRequest(null, options);
+    HttpRequest signedRequest = signed.getRequest();
+
+    // Shape the signed request into Google's GetCallerIdentity envelope:
+    // { "url": ..., "method": ..., "headers": [ { "key":..., "value":... } ] }
+    JsonArray headers = new JsonArray();
+    signedRequest
+        .headers()
+        .map()
+        .forEach(
+            (name, values) -> {
+              JsonObject header = new JsonObject();
+              // SigV4 canonicalizes header names to lowercase before signing, so the envelope
+              // must carry lowercase keys to match the SignedHeaders list that the verifier
+              // recomputes.
+              header.addProperty("key", name.toLowerCase());
+              header.addProperty("value", values.get(0));
+              headers.add(header);
+            });
+
+    // SigV4 always signs the Host header, but the JDK HTTP client manages Host itself and does not
+    // expose it in the request headers. Google recomputes the signature and requires the host
+    // header, so add it back from the request URI.
+    JsonObject hostHeader = new JsonObject();
+    hostHeader.addProperty("key", "host");
+    hostHeader.addProperty("value", signedRequest.uri().getHost());
+    headers.add(hostHeader);
+
+    JsonObject envelope = new JsonObject();
+    envelope.addProperty("url", signedRequest.uri().toString());
+    envelope.addProperty("method", signedRequest.method());
+    envelope.add("headers", headers);
+
+    // Google STS reads the subject token URL-encoded. The provider infers the
+    // AWS4 token type from the leading brace, so the encoded envelope is what
+    // it expects.
+    return URLEncoder.encode(envelope.toString(), StandardCharsets.UTF_8);
+  }
+}

--- a/multicloudj-common-gcp/src/main/java/com/salesforce/multicloudj/common/gcp/GcpCredentialsProvider.java
+++ b/multicloudj-common-gcp/src/main/java/com/salesforce/multicloudj/common/gcp/GcpCredentialsProvider.java
@@ -2,15 +2,25 @@ package com.salesforce.multicloudj.common.gcp;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.ExternalAccountCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.IdentityPoolCredentials;
 import com.google.auth.oauth2.ImpersonatedCredentials;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Supplier;
 
 public class GcpCredentialsProvider {
+
+  // Google Security Token Service endpoint used to exchange a federated subject token
+  // for a short-lived GCP access token under Workload Identity Federation.
+  private static final String STS_TOKEN_URL = "https://sts.googleapis.com/v1/token";
+
+  private static final String CLOUD_PLATFORM_SCOPE =
+      "https://www.googleapis.com/auth/cloud-platform";
 
   public static Credentials getCredentials(CredentialsOverrider overrider) {
     if (overrider == null || overrider.getType() == null) {
@@ -35,10 +45,50 @@ public class GcpCredentialsProvider {
             sourceCredentials,
             targetServiceAccount,
             null,
-            List.of("https://www.googleapis.com/auth/cloud-platform"),
+            List.of(CLOUD_PLATFORM_SCOPE),
             overrider.getDurationSeconds() == null ? 0 : overrider.getDurationSeconds());
+      case ASSUME_ROLE_WEB_IDENTITY:
+        if (overrider.getWebIdentityTokenSupplier() == null) {
+          throw new IllegalArgumentException(
+              "webIdentityTokenSupplier must be provided for ASSUME_ROLE_WEB_IDENTITY");
+        }
+        // Workload Identity Federation exchanges an external subject token for a short-lived GCP
+        // access token. IdentityPoolCredentials invokes the supplier on every token refresh, so
+        // the caller's supplier is responsible for returning a fresh token. The audience is the
+        // full Workload Identity Pool provider resource name, carried in the overrider's role
+        // field. The subject token type is inferred from the token the supplier returns so that
+        // both OIDC/JWT tokens and pre-signed GetCallerIdentity tokens are supported.
+        Supplier<String> tokenSupplier = overrider.getWebIdentityTokenSupplier();
+        ExternalAccountCredentials.SubjectTokenTypes subjectTokenType =
+            inferSubjectTokenType(tokenSupplier.get());
+        return IdentityPoolCredentials.newBuilder()
+            .setSubjectTokenSupplier(context -> tokenSupplier.get())
+            .setAudience(overrider.getRole())
+            .setSubjectTokenType(subjectTokenType)
+            .setTokenUrl(STS_TOKEN_URL)
+            .setScopes(List.of(CLOUD_PLATFORM_SCOPE))
+            .build();
       default:
         return null;
     }
+  }
+
+  /**
+   * Infers the Workload Identity Federation subject token type from the token the supplier returns.
+   * GCP also supports the direct SigV4 signed request for workload identity pool.
+   *
+   * <p>A pre-signed GetCallerIdentity subject token is a URL-encoded JSON envelope, so it begins
+   * with an encoded opening brace ("%7B") or, if the caller supplied it unencoded, a literal "{".
+   * Any other value is treated as an OIDC/JWT subject token. The subject token type must match the
+   * format that GCP STS receives or the token exchange is rejected.
+   */
+  private static ExternalAccountCredentials.SubjectTokenTypes inferSubjectTokenType(String token) {
+    if (token != null) {
+      String trimmed = token.trim();
+      if (trimmed.startsWith("{") || trimmed.regionMatches(true, 0, "%7B", 0, 3)) {
+        return ExternalAccountCredentials.SubjectTokenTypes.AWS4;
+      }
+    }
+    return ExternalAccountCredentials.SubjectTokenTypes.JWT;
   }
 }

--- a/multicloudj-common-gcp/src/test/java/com/salesforce/multicloudj/common/gcp/GcpCredentialsProviderTest.java
+++ b/multicloudj-common-gcp/src/test/java/com/salesforce/multicloudj/common/gcp/GcpCredentialsProviderTest.java
@@ -1,5 +1,6 @@
 package com.salesforce.multicloudj.common.gcp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -7,9 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.IdentityPoolCredentials;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.CredentialsType;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 public class GcpCredentialsProviderTest {
@@ -60,5 +63,149 @@ public class GcpCredentialsProviderTest {
           GcpCredentialsProvider.getCredentials(overrider);
         },
         "NullPointerException expected when sessionCredentials is null");
+  }
+
+  @Test
+  void testGetCredentialsWithAssumeRoleWebIdentityType() {
+    // Arrange
+    String audience =
+        "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/"
+            + "test-pool/providers/test-provider";
+    CredentialsOverrider overrider =
+        new CredentialsOverrider.Builder(CredentialsType.ASSUME_ROLE_WEB_IDENTITY)
+            .withRole(audience)
+            .withWebIdentityTokenSupplier(() -> "mock-web-identity-token")
+            .build();
+
+    // Act
+    Credentials credentials = GcpCredentialsProvider.getCredentials(overrider);
+
+    // Assert
+    assertNotNull(credentials, "Credentials should not be null");
+    assertTrue(
+        credentials instanceof IdentityPoolCredentials,
+        "Credentials should be IdentityPoolCredentials");
+    assertEquals(
+        audience,
+        ((IdentityPoolCredentials) credentials).getAudience(),
+        "Audience should be sourced from the overrider role");
+  }
+
+  @Test
+  void testWebIdentityTokenSupplierInvokedOnTokenRefresh() throws Exception {
+    // Arrange - the supplier drives the subject token on each refresh, so that
+    // IdentityPoolCredentials always sees a fresh subject token.
+    AtomicInteger invocationCount = new AtomicInteger(0);
+    CredentialsOverrider overrider =
+        new CredentialsOverrider.Builder(CredentialsType.ASSUME_ROLE_WEB_IDENTITY)
+            .withRole("//iam.googleapis.com/projects/123/locations/global/"
+                + "workloadIdentityPools/test-pool/providers/test-provider")
+            .withWebIdentityTokenSupplier(
+                () -> {
+                  invocationCount.incrementAndGet();
+                  return "mock-web-identity-token";
+                })
+            .build();
+
+    IdentityPoolCredentials credentials =
+        (IdentityPoolCredentials) GcpCredentialsProvider.getCredentials(overrider);
+    assertNotNull(credentials);
+
+    // Act - retrieving the subject token drives the supplier.
+    String subjectToken = credentials.retrieveSubjectToken();
+
+    // Assert - the supplier feeds the retrieved subject token.
+    assertEquals("mock-web-identity-token", subjectToken);
+    assertTrue(
+        invocationCount.get() >= 1, "Supplier should be invoked to retrieve subject token");
+  }
+
+  @Test
+  void testJwtSubjectTokenTypeInferredForJwtToken() {
+    // Arrange - a raw JWT-style token should be exchanged as a JWT subject token.
+    CredentialsOverrider overrider =
+        new CredentialsOverrider.Builder(CredentialsType.ASSUME_ROLE_WEB_IDENTITY)
+            .withRole("//iam.googleapis.com/projects/123/locations/global/"
+                + "workloadIdentityPools/test-pool/providers/test-provider")
+            .withWebIdentityTokenSupplier(() -> "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjMifQ.sig")
+            .build();
+
+    // Act
+    IdentityPoolCredentials credentials =
+        (IdentityPoolCredentials) GcpCredentialsProvider.getCredentials(overrider);
+
+    // Assert
+    assertNotNull(credentials);
+    assertEquals(
+        "urn:ietf:params:oauth:token-type:jwt",
+        credentials.getSubjectTokenType(),
+        "A JWT token should be exchanged with the JWT subject token type");
+  }
+
+  @Test
+  void testAwsSubjectTokenTypeInferredForUrlEncodedSignedRequest() {
+    // Arrange - a pre-signed GetCallerIdentity token is a URL-encoded JSON envelope, so it starts
+    // with an encoded opening brace ("%7B").
+    String signedRequest =
+        "%7B%22url%22%3A%22https%3A%2F%2Fsts.amazonaws.com%22%2C%22method%22%3A%22POST%22%7D";
+    CredentialsOverrider overrider =
+        new CredentialsOverrider.Builder(CredentialsType.ASSUME_ROLE_WEB_IDENTITY)
+            .withRole("//iam.googleapis.com/projects/123/locations/global/"
+                + "workloadIdentityPools/test-pool/providers/test-provider")
+            .withWebIdentityTokenSupplier(() -> signedRequest)
+            .build();
+
+    // Act
+    IdentityPoolCredentials credentials =
+        (IdentityPoolCredentials) GcpCredentialsProvider.getCredentials(overrider);
+
+    // Assert
+    assertNotNull(credentials);
+    assertEquals(
+        "urn:ietf:params:aws:token-type:aws4_request",
+        credentials.getSubjectTokenType(),
+        "A URL-encoded signed request should be exchanged with the AWS4 subject token type");
+  }
+
+  @Test
+  void testAwsSubjectTokenTypeInferredForUnencodedSignedRequest() {
+    // Arrange - a signed GetCallerIdentity envelope supplied as raw (unencoded) JSON starts with a
+    // literal opening brace.
+    String signedRequest = "{\"url\":\"https://sts.amazonaws.com\",\"method\":\"POST\"}";
+    CredentialsOverrider overrider =
+        new CredentialsOverrider.Builder(CredentialsType.ASSUME_ROLE_WEB_IDENTITY)
+            .withRole("//iam.googleapis.com/projects/123/locations/global/"
+                + "workloadIdentityPools/test-pool/providers/test-provider")
+            .withWebIdentityTokenSupplier(() -> signedRequest)
+            .build();
+
+    // Act
+    IdentityPoolCredentials credentials =
+        (IdentityPoolCredentials) GcpCredentialsProvider.getCredentials(overrider);
+
+    // Assert
+    assertNotNull(credentials);
+    assertEquals(
+        "urn:ietf:params:aws:token-type:aws4_request",
+        credentials.getSubjectTokenType(),
+        "An unencoded signed request should be exchanged with the AWS4 subject token type");
+  }
+
+  @Test
+  void testGetCredentialsWithAssumeRoleWebIdentityAndNullTokenSupplier() {
+    // Arrange
+    CredentialsOverrider overrider =
+        new CredentialsOverrider.Builder(CredentialsType.ASSUME_ROLE_WEB_IDENTITY)
+            .withRole("//iam.googleapis.com/projects/123/locations/global/"
+                + "workloadIdentityPools/test-pool/providers/test-provider")
+            .build();
+
+    // Act & Assert
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> GcpCredentialsProvider.getCredentials(overrider),
+            "IllegalArgumentException expected when webIdentityTokenSupplier is null");
+    assertTrue(ex.getMessage().contains("webIdentityTokenSupplier"));
   }
 }

--- a/registry/registry-gcp/pom.xml
+++ b/registry/registry-gcp/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
-            <version>1.19.0</version>
+            <version>1.40.0</version>
         </dependency>
         <dependency>
             <groupId>com.salesforce.multicloudj</groupId>

--- a/sts/sts-aws/src/main/java/com/salesforce/multicloudj/sts/aws/AwsStsUtilities.java
+++ b/sts/sts-aws/src/main/java/com/salesforce/multicloudj/sts/aws/AwsStsUtilities.java
@@ -12,38 +12,52 @@ import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.driver.AbstractStsUtilities;
 import com.salesforce.multicloudj.sts.driver.FlowCollector;
+import com.salesforce.multicloudj.sts.model.SignOptions;
 import com.salesforce.multicloudj.sts.model.SignedAuthRequest;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
-import java.io.ByteArrayInputStream;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpRequest;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.List;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.http.ContentStreamProvider;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
-import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
-import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
 
 @AutoService(AbstractStsUtilities.class)
 public class AwsStsUtilities extends AbstractStsUtilities<AwsStsUtilities> {
-  private static final Set<String> RESTRICTED_HEADERS = Set.of("Content-Length", "Host", "Expect");
   private static final String SIGN_STS_ENDPOINT = "https://sts.%s.amazonaws.com/";
   private static final String DEFAULT_API_ACTION_NAME = "GetCallerIdentity";
   private static final String DEFAULT_API_VERSION = "2011-06-15";
   private static final String SERVICE_SIGNING_NAME = "sts";
-  private static final AwsV4HttpSigner signer = AwsV4HttpSigner.create();
+  private static final String AWS4_HMAC_SHA256 = "AWS4-HMAC-SHA256";
+  private static final String AWS4_REQUEST = "aws4_request";
+  private static final DateTimeFormatter AMZ_DATE_FORMAT =
+      DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withLocale(Locale.US);
+  private static final DateTimeFormatter AMZ_DATESTAMP_FORMAT =
+      DateTimeFormatter.ofPattern("yyyyMMdd").withLocale(Locale.US);
+  private static final String REQUEST_HASH_HEADER = "x-request-hash";
+  private static final String CONTENT_TYPE_HEADER = "content-type";
+  private static final String CONTENT_TYPE_VALUE =
+      "application/x-www-form-urlencoded; charset=utf-8";
+
+  // Resolves credentials from the AWS default chain when the caller supplies none. Built lazily and
+  // reused across sign calls so the chain's cached, auto-refreshing credentials are retained rather
+  // than rebuilt every request.
+  private volatile DefaultCredentialsProvider defaultCredentialsProvider;
 
   public AwsStsUtilities(Builder builder) {
     super(builder);
@@ -60,122 +74,206 @@ public class AwsStsUtilities extends AbstractStsUtilities<AwsStsUtilities> {
 
   @Override
   protected SignedAuthRequest newCloudNativeAuthSignedRequest(HttpRequest request) {
-    // create a StsCredentials object to hold the AWS access key, secret key, and session token
+    return newCloudNativeAuthSignedRequest(request, null);
+  }
+
+  @Override
+  protected SignedAuthRequest newCloudNativeAuthSignedRequest(
+      HttpRequest request, SignOptions options) {
     StsCredentials signingCredentials = getSigningCredentials();
-
-    // if the unsigned request is null, create a default request
-    // The default request is a POST request to the AWS STS service
-    if (request == null) {
-      throw new IllegalArgumentException("input request cannot be null");
+    if (options == null) {
+      options = SignOptions.builder().build();
     }
 
-    // Extract the request body from the unsigned HttpRequest
-    // If the request does not have a body, use HttpRequest.BodyPublishers.noBody()
-    //
-    // Note: We have to use the FlowCollector to collect the request body into a byte array because
-    // we do not know the body contents.
-    // See - https://stackoverflow.com/a/77705720
-    byte[] bytes =
-        request
-            .bodyPublisher()
-            .map(
-                publisher -> {
-                  // collect the HttpRequest request body into bytes (if present)
-                  FlowCollector<ByteBuffer> collector = new FlowCollector<ByteBuffer>();
-                  publisher.subscribe(collector);
-                  return collector
-                      .items()
-                      .thenApply(items -> items.isEmpty() ? null : items.get(0).array());
-                })
-            .orElseGet(() -> completedFuture(null))
-            .join();
+    String stsEndpoint = String.format(SIGN_STS_ENDPOINT, region);
+    URI uri = URI.create(stsEndpoint);
 
-    // create a BodyPublisher from the bytes (if present); will pass it into the signer so it has
-    // the request body
-    HttpRequest.BodyPublisher body;
+    // The request is optional. When one is supplied we sign its body; otherwise there is no service
+    // payload and we sign a bare GetCallerIdentity.
+    byte[] body = extractBody(request);
 
-    // If the request does not have a body, set the body to the following sts request body
-    // Action=GetCallerIdentity&Version=2011-06-15
+    // Action=GetCallerIdentity&Version=2011-06-15 travels either in the URL query string or in the
+    // request body (the AWS Query form). Signing it into the query string keeps the body empty, so
+    // the request can be replayed from its URL and headers alone.
     // See - https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
-    if (bytes == null) {
-      bytes = ("Action=" + DEFAULT_API_ACTION_NAME + "&Version=" + DEFAULT_API_VERSION).getBytes();
+    String canonicalQuery = "";
+    if (options.isActionInQueryString()) {
+      canonicalQuery = "Action=" + DEFAULT_API_ACTION_NAME + "&Version=" + DEFAULT_API_VERSION;
+    } else if (body == null) {
+      body =
+          ("Action=" + DEFAULT_API_ACTION_NAME + "&Version=" + DEFAULT_API_VERSION)
+              .getBytes(StandardCharsets.UTF_8);
     }
-    final byte[] finalBytes = bytes;
-    body = HttpRequest.BodyPublishers.ofByteArray(finalBytes);
+    byte[] payload = body == null ? new byte[0] : body;
+    boolean hasBody = payload.length > 0;
 
-    // Create the canonical request
-    String canonicalUri = request.uri().getPath();
-    String canonicalQuerystring = "";
-    String canonicalHeaders =
-        "content-type:"
-            + request.headers().map().get("Content-Type")
-            + "host:"
-            + request.uri().getHost()
-            + "\n";
-    String signedHeaders = "content-type;host";
-    String payloadHash = getSha256Hash(body.toString());
+    // Assemble the canonical header set. host, the signing date, and the session token (when the
+    // credentials are temporary) are always signed. Header names must be lowercase per the SigV4
+    // canonical rules; the TreeMap keeps them sorted.
+    Instant now = Instant.now();
+    String amzDate = AMZ_DATE_FORMAT.format(now.atOffset(ZoneOffset.UTC));
+    String dateStamp = AMZ_DATESTAMP_FORMAT.format(now.atOffset(ZoneOffset.UTC));
+
+    SortedMap<String, String> headers = new TreeMap<>();
+    headers.put("host", uri.getHost());
+    headers.put("x-amz-date", amzDate);
+    if (signingCredentials.getSecurityToken() != null
+        && !signingCredentials.getSecurityToken().isEmpty()) {
+      headers.put("x-amz-security-token", signingCredentials.getSecurityToken());
+    }
+    // Content-Type describes the request body, so it is only relevant for the body form.
+    if (hasBody && !options.isExcludeContentTypeHeader()) {
+      headers.put(CONTENT_TYPE_HEADER, CONTENT_TYPE_VALUE);
+    }
+    // The request hash header is meaningful only when a caller service request was supplied.
+    if (request != null && !options.isExcludeRequestHashHeader()) {
+      headers.put(REQUEST_HASH_HEADER, getSha256Hash(payload));
+    }
+    // Caller supplied custom headers (e.g. a federation target resource) are always signed. Names
+    // must already be lowercase to satisfy the SigV4 canonical rules.
+    for (Map.Entry<String, String> header : options.getCustomHeaders().entrySet()) {
+      headers.put(header.getKey(), header.getValue());
+    }
+
+    // Authorization is not itself a signed header, so it is added after signing. host was signed
+    // but is dropped now: the JDK HTTP client rejects host as a restricted header, and the STS
+    // endpoint URL already carries it.
+    String authorization =
+        signSigV4(signingCredentials, canonicalQuery, headers, payload, amzDate, dateStamp);
+    headers.put("authorization", authorization);
+    headers.remove("host");
+
+    URI signedUri = canonicalQuery.isEmpty() ? uri : URI.create(stsEndpoint + "?" + canonicalQuery);
+    HttpRequest.BodyPublisher bodyPublisher =
+        hasBody
+            ? HttpRequest.BodyPublishers.ofByteArray(payload)
+            : HttpRequest.BodyPublishers.noBody();
+    HttpRequest.Builder builder = HttpRequest.newBuilder(signedUri).method("POST", bodyPublisher);
+    headers.forEach(builder::setHeader);
+
+    // The signed identity encodes the STS endpoint, action/version, and every request header as
+    // query parameters, so it can be parsed back into a POST and replayed against AWS STS.
+    String signedIdentity = buildSignedIdentity(uri, headers);
+
+    return new SignedAuthRequest(builder.build(), signingCredentials, signedIdentity);
+  }
+
+  /**
+   * Collects the body of an optional unsigned request into a byte array. Returns null when no
+   * request or no body is present.
+   *
+   * <p>A {@link FlowCollector} is used because the body contents are not known in advance. See -
+   * https://stackoverflow.com/a/77705720
+   */
+  private static byte[] extractBody(HttpRequest request) {
+    if (request == null) {
+      return null;
+    }
+    return request
+        .bodyPublisher()
+        .map(
+            publisher -> {
+              FlowCollector<ByteBuffer> collector = new FlowCollector<>();
+              publisher.subscribe(collector);
+              return collector
+                  .items()
+                  .thenApply(items -> items.isEmpty() ? null : items.get(0).array());
+            })
+        .orElseGet(() -> completedFuture(null))
+        .join();
+  }
+
+  /**
+   * Computes the AWS Signature Version 4 over the given canonical query, headers, and payload, and
+   * returns the Authorization header value. The signature covers exactly the supplied headers and
+   * no others.
+   */
+  private String signSigV4(
+      StsCredentials signingCredentials,
+      String canonicalQuery,
+      SortedMap<String, String> headers,
+      byte[] payload,
+      String amzDate,
+      String dateStamp) {
+    String signedHeaders = String.join(";", headers.keySet());
+
+    StringBuilder headerBlock = new StringBuilder();
+    headers.forEach(
+        (name, value) -> headerBlock.append(name).append(':').append(value).append('\n'));
+
     String canonicalRequest =
-        request.method()
+        "POST\n"
+            + "/\n"
+            + canonicalQuery
             + "\n"
-            + canonicalUri
-            + "\n"
-            + canonicalQuerystring
-            + "\n"
-            + canonicalHeaders
+            + headerBlock
             + "\n"
             + signedHeaders
             + "\n"
-            + payloadHash;
-    String canonicalRequestHash = getSha256Hash(canonicalRequest);
+            + getSha256Hash(payload);
 
-    // create the stsRequest which we will sign
-    HttpRequest stsRequest = createStsRequest(canonicalRequestHash);
+    String credentialScope =
+        dateStamp + "/" + region + "/" + SERVICE_SIGNING_NAME + "/" + AWS4_REQUEST;
+    String stringToSign =
+        AWS4_HMAC_SHA256
+            + "\n"
+            + amzDate
+            + "\n"
+            + credentialScope
+            + "\n"
+            + getSha256Hash(canonicalRequest);
 
-    // Convert the above stsRequest to an aws sdk HTTP request, so it can be signed via the aws sdk
-    SdkHttpFullRequest.Builder requestToSign =
-        SdkHttpFullRequest.builder()
-            .method(SdkHttpMethod.valueOf(stsRequest.method()))
-            .headers(stsRequest.headers().map())
-            .uri(stsRequest.uri());
+    byte[] signingKey =
+        deriveSigningKey(
+            signingCredentials.getAccessKeySecret(), dateStamp, region, SERVICE_SIGNING_NAME);
+    String signature = bytesToHex(hmacSha256(signingKey, stringToSign));
 
-    requestToSign.contentStreamProvider(() -> new ByteArrayInputStream(finalBytes));
-    requestToSign.putHeader("Content-Length", String.valueOf(bytes.length));
+    return AWS4_HMAC_SHA256
+        + " Credential="
+        + signingCredentials.getAccessKeyId()
+        + "/"
+        + credentialScope
+        + ", SignedHeaders="
+        + signedHeaders
+        + ", Signature="
+        + signature;
+  }
 
-    // Sign the request. Some services require custom signing configuration properties (e.g. S3).
-    // See AwsV4HttpSigner and AwsV4FamilyHttpSigner for the available signing options.
-    Optional<ContentStreamProvider> requestPayload =
-        Optional.ofNullable(requestToSign.contentStreamProvider());
+  /** Derives the AWS Signature Version 4 signing key for the given scope. */
+  private static byte[] deriveSigningKey(
+      String secretKey, String dateStamp, String region, String service) {
+    byte[] kDate = hmacSha256(("AWS4" + secretKey).getBytes(StandardCharsets.UTF_8), dateStamp);
+    byte[] kRegion = hmacSha256(kDate, region);
+    byte[] kService = hmacSha256(kRegion, service);
+    return hmacSha256(kService, AWS4_REQUEST);
+  }
 
-    final AwsSessionCredentialsIdentity identity =
-        AwsSessionCredentialsIdentity.builder()
-            .accessKeyId(signingCredentials.getAccessKeyId())
-            .secretAccessKey(signingCredentials.getAccessKeySecret())
-            .sessionToken(signingCredentials.getSecurityToken())
-            .build();
+  private static byte[] hmacSha256(byte[] key, String data) {
+    try {
+      Mac mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(key, "HmacSHA256"));
+      return mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+    } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+      throw new UnknownException(e);
+    }
+  }
 
-    final SignedRequest signerOutput =
-        signer.sign(
-            r ->
-                r.identity(identity)
-                    .request(requestToSign.build())
-                    .payload(requestPayload.get())
-                    .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, SERVICE_SIGNING_NAME)
-                    .putProperty(AwsV4HttpSigner.REGION_NAME, region));
+  private static String buildSignedIdentity(URI stsUri, Map<String, String> headers) {
+    StringBuilder query = new StringBuilder();
+    appendQueryParam(query, "Action", DEFAULT_API_ACTION_NAME);
+    appendQueryParam(query, "Version", DEFAULT_API_VERSION);
+    headers.forEach((name, value) -> appendQueryParam(query, name, value));
+    return stsUri.toString() + "?" + query;
+  }
 
-    // extract the signed headers
-    List<Map.Entry<String, List<String>>> signerOutputHeaders =
-        signerOutput.request().headers().entrySet().stream()
-            .filter(entry -> !RESTRICTED_HEADERS.contains(entry.getKey()))
-            .collect(Collectors.toList());
-
-    // build a copy of the HttpRequest with signed headers
-    HttpRequest.Builder builder =
-        HttpRequest.newBuilder(stsRequest.uri()).method(stsRequest.method(), body);
-    signerOutputHeaders.forEach(
-        entry -> builder.setHeader(entry.getKey(), String.join(",", entry.getValue())));
-
-    HttpRequest signed = builder.build();
-    return new SignedAuthRequest(signed, signingCredentials);
+  private static void appendQueryParam(StringBuilder query, String name, String value) {
+    if (query.length() > 0) {
+      query.append('&');
+    }
+    query
+        .append(URLEncoder.encode(name, StandardCharsets.UTF_8))
+        .append('=')
+        .append(URLEncoder.encode(value, StandardCharsets.UTF_8));
   }
 
   private static String bytesToHex(byte[] bytes) {
@@ -187,48 +285,49 @@ public class AwsStsUtilities extends AbstractStsUtilities<AwsStsUtilities> {
   }
 
   private static String getSha256Hash(String data) {
+    return getSha256Hash(data.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String getSha256Hash(byte[] data) {
     try {
-      return bytesToHex(
-          MessageDigest.getInstance("SHA-256").digest(data.getBytes(StandardCharsets.UTF_8)));
+      return bytesToHex(MessageDigest.getInstance("SHA-256").digest(data));
     } catch (NoSuchAlgorithmException e) {
       throw new UnknownException(e);
     }
   }
 
-  private HttpRequest createStsRequest(String canonicalRequestHash) {
-    // interpolate SIGN_STS_ENDPOINT string with region
-    String stsEndpoint = String.format(SIGN_STS_ENDPOINT, region);
-    URI uri = URI.create(stsEndpoint);
-    String stsBody = "Action=" + DEFAULT_API_ACTION_NAME + "&Version=" + DEFAULT_API_VERSION;
-    HttpRequest.BodyPublisher body = HttpRequest.BodyPublishers.ofByteArray(stsBody.getBytes());
-
-    HttpRequest stsRequest =
-        HttpRequest.newBuilder()
-            .POST(body)
-            .uri(uri)
-            .setHeader("X-Request-Hash", canonicalRequestHash)
-            .setHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
-            .build();
-    return stsRequest;
-  }
-
   private StsCredentials getSigningCredentials() {
-    StsCredentials signingCredentials = credentialsOverrider.getSessionCredentials();
-
-    // Determine if we need to use default credentialsOverrider
-    // If the caller has not specified a StsCredentials, we will use the default
-    // credentialsOverrider provider
+    StsCredentials signingCredentials =
+        credentialsOverrider == null ? null : credentialsOverrider.getSessionCredentials();
     if (signingCredentials == null) {
-      DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.builder().build();
-      AwsSessionCredentials sessionCredentials =
-          (AwsSessionCredentials) credentialsProvider.resolveCredentials();
+      AwsCredentials resolved = defaultCredentialsProvider().resolveCredentials();
       signingCredentials =
           new StsCredentials(
-              sessionCredentials.accessKeyId(),
-              sessionCredentials.secretAccessKey(),
-              sessionCredentials.sessionToken());
+              resolved.accessKeyId(), resolved.secretAccessKey(), sessionToken(resolved));
     }
     return signingCredentials;
+  }
+
+  /** Returns the session token for temporary credentials, or null for long-term credentials. */
+  private static String sessionToken(AwsCredentials credentials) {
+    if (credentials instanceof AwsSessionCredentials) {
+      return ((AwsSessionCredentials) credentials).sessionToken();
+    }
+    return null;
+  }
+
+  private DefaultCredentialsProvider defaultCredentialsProvider() {
+    DefaultCredentialsProvider provider = defaultCredentialsProvider;
+    if (provider == null) {
+      synchronized (this) {
+        provider = defaultCredentialsProvider;
+        if (provider == null) {
+          provider = DefaultCredentialsProvider.builder().build();
+          defaultCredentialsProvider = provider;
+        }
+      }
+    }
+    return provider;
   }
 
   public static class Builder extends AbstractStsUtilities.Builder<AwsStsUtilities> {

--- a/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsUtilitiesTest.java
+++ b/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsUtilitiesTest.java
@@ -15,17 +15,14 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class AwsStsUtilitiesTest {
 
-  private static StsUtilities mockStsUtilities;
   private static StsCredentials credentials;
   private static String region;
 
   @BeforeAll
   public static void setUp() {
-    mockStsUtilities = Mockito.mock(StsUtilities.class);
     region = "us-west-2";
     credentials = new StsCredentials("testKeyId", "testSecret", "testToken");
   }
@@ -37,41 +34,15 @@ class AwsStsUtilitiesTest {
   }
 
   @Test
-  void cloudNativeAuthSignedRequest() {
-    String region = "us-west-2";
-    String service = "sts";
-    String apiName = "GetCallerIdentity";
-    String apiVersion = "2011-06-15";
-
-    // create a sample bodypublisher
-    HttpRequest.BodyPublisher body =
-        HttpRequest.BodyPublishers.ofString("Action=" + apiName + "&Version=" + apiVersion);
-
-    // the request object we want to sign
-    HttpRequest fakeRequest =
-        HttpRequest.newBuilder()
-            .POST(body)
-            .uri(URI.create("https://" + service + "." + region + ".amazonaws.com:443"))
-            .build();
-
-    StsUtilities stsUtil =
-        StsUtilities.builder("aws")
-            .withRegion(region)
-            .withCredentialsOverrider(
-                new CredentialsOverrider.Builder(CredentialsType.SESSION)
-                    .withSessionCredentials(credentials)
-                    .build())
-            .build();
-
-    SignedAuthRequest newSignedAuthRequest = stsUtil.newCloudNativeAuthSignedRequest(fakeRequest);
+  void signedRequestEchoesSuppliedCredentials() {
+    SignedAuthRequest signed = stsUtil().newCloudNativeAuthSignedRequest(sampleRequest());
 
     Assertions.assertEquals(
-        credentials.getAccessKeyId(), newSignedAuthRequest.getCredentials().getAccessKeyId());
+        credentials.getAccessKeyId(), signed.getCredentials().getAccessKeyId());
     Assertions.assertEquals(
-        credentials.getAccessKeySecret(),
-        newSignedAuthRequest.getCredentials().getAccessKeySecret());
+        credentials.getAccessKeySecret(), signed.getCredentials().getAccessKeySecret());
     Assertions.assertEquals(
-        credentials.getSecurityToken(), newSignedAuthRequest.getCredentials().getSecurityToken());
+        credentials.getSecurityToken(), signed.getCredentials().getSecurityToken());
   }
 
   private static StsUtilities stsUtil() {
@@ -197,21 +168,6 @@ class AwsStsUtilitiesTest {
   }
 
   @Test
-  void signedIdentityHonorsExcludeContentTypeOption() {
-    SignedAuthRequest signed =
-        stsUtil()
-            .newCloudNativeAuthSignedRequest(
-                sampleRequest(),
-                SignOptions.builder().withExcludeContentTypeHeader(true).build());
-
-    Map<String, String> params =
-        parseQuery(URI.create(signed.getSignedIdentity()).getRawQuery());
-    Assertions.assertFalse(
-        params.containsKey("Content-Type"),
-        "Signed identity should not carry Content-Type when the header is excluded");
-  }
-
-  @Test
   void actionInQueryStringSignsActionAndVersionAsQueryParamsWithEmptyBody() {
     SignedAuthRequest signed =
         stsUtil()
@@ -237,30 +193,6 @@ class AwsStsUtilitiesTest {
     Assertions.assertTrue(
         request.headers().firstValue("Authorization").isPresent(),
         "The request should be signed");
-  }
-
-  @Test
-  void actionInQueryStringSignsCustomHeaders() {
-    SignedAuthRequest signed =
-        stsUtil()
-            .newCloudNativeAuthSignedRequest(
-                null,
-                SignOptions.builder()
-                    .withActionInQueryString(true)
-                    .withCustomHeader("x-goog-cloud-target-resource", "//example/audience")
-                    .build());
-
-    HttpRequest request = signed.getRequest();
-    Assertions.assertEquals(
-        "//example/audience",
-        request.headers().firstValue("x-goog-cloud-target-resource").orElse(null),
-        "Custom headers should be applied to the signed query-string request");
-
-    // The audience header must be covered by the signature, so it appears in SignedHeaders.
-    String authorization = request.headers().firstValue("Authorization").orElse("");
-    Assertions.assertTrue(
-        authorization.contains("x-goog-cloud-target-resource"),
-        "The audience header must be part of the SigV4 SignedHeaders");
   }
 
   @Test

--- a/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsUtilitiesTest.java
+++ b/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsUtilitiesTest.java
@@ -3,10 +3,15 @@ package com.salesforce.multicloudj.sts.aws;
 import com.salesforce.multicloudj.sts.client.StsUtilities;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.CredentialsType;
+import com.salesforce.multicloudj.sts.model.SignOptions;
 import com.salesforce.multicloudj.sts.model.SignedAuthRequest;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -67,5 +72,281 @@ class AwsStsUtilitiesTest {
         newSignedAuthRequest.getCredentials().getAccessKeySecret());
     Assertions.assertEquals(
         credentials.getSecurityToken(), newSignedAuthRequest.getCredentials().getSecurityToken());
+  }
+
+  private static StsUtilities stsUtil() {
+    return StsUtilities.builder("aws")
+        .withRegion(region)
+        .withCredentialsOverrider(
+            new CredentialsOverrider.Builder(CredentialsType.SESSION)
+                .withSessionCredentials(credentials)
+                .build())
+        .build();
+  }
+
+  private static HttpRequest sampleRequest() {
+    HttpRequest.BodyPublisher body =
+        HttpRequest.BodyPublishers.ofString("Action=GetCallerIdentity&Version=2011-06-15");
+    return HttpRequest.newBuilder()
+        .POST(body)
+        .uri(URI.create("https://sts." + region + ".amazonaws.com:443"))
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .build();
+  }
+
+  @Test
+  void defaultOptionsAddRequestHashAndContentTypeHeaders() {
+    SignedAuthRequest signed =
+        stsUtil().newCloudNativeAuthSignedRequest(sampleRequest(), SignOptions.builder().build());
+
+    Assertions.assertTrue(
+        signed.getRequest().headers().firstValue("X-Request-Hash").isPresent(),
+        "X-Request-Hash header should be present by default when a request is supplied");
+    Assertions.assertEquals(
+        "application/x-www-form-urlencoded; charset=utf-8",
+        signed.getRequest().headers().firstValue("Content-Type").orElse(null),
+        "Content-Type header should be present by default");
+  }
+
+  @Test
+  void excludeRequestHashHeaderOptionDropsRequestHashHeader() {
+    SignedAuthRequest signed =
+        stsUtil()
+            .newCloudNativeAuthSignedRequest(
+                sampleRequest(),
+                SignOptions.builder().withExcludeRequestHashHeader(true).build());
+
+    Assertions.assertFalse(
+        signed.getRequest().headers().firstValue("X-Request-Hash").isPresent(),
+        "X-Request-Hash header should be excluded when the option is set");
+    Assertions.assertTrue(
+        signed.getRequest().headers().firstValue("Content-Type").isPresent(),
+        "Content-Type header should still be present");
+  }
+
+  @Test
+  void excludeContentTypeHeaderOptionDropsContentTypeHeader() {
+    SignedAuthRequest signed =
+        stsUtil()
+            .newCloudNativeAuthSignedRequest(
+                sampleRequest(),
+                SignOptions.builder().withExcludeContentTypeHeader(true).build());
+
+    Assertions.assertFalse(
+        signed.getRequest().headers().firstValue("Content-Type").isPresent(),
+        "Content-Type header should be excluded when the option is set");
+    Assertions.assertTrue(
+        signed.getRequest().headers().firstValue("X-Request-Hash").isPresent(),
+        "X-Request-Hash header should still be present");
+  }
+
+  @Test
+  void customHeadersAreAppliedToSignedRequest() {
+    SignedAuthRequest signed =
+        stsUtil()
+            .newCloudNativeAuthSignedRequest(
+                sampleRequest(),
+                SignOptions.builder().withCustomHeader("X-Custom-Header", "custom-value").build());
+
+    Assertions.assertEquals(
+        "custom-value",
+        signed.getRequest().headers().firstValue("X-Custom-Header").orElse(null),
+        "Custom header should be applied to the signed request");
+  }
+
+  @Test
+  void nullRequestOmitsRequestHashHeaderButKeepsContentType() {
+    SignedAuthRequest signed =
+        stsUtil().newCloudNativeAuthSignedRequest(null, SignOptions.builder().build());
+
+    Assertions.assertNotNull(signed.getRequest());
+    Assertions.assertFalse(
+        signed.getRequest().headers().firstValue("X-Request-Hash").isPresent(),
+        "X-Request-Hash header should be absent when no request is supplied");
+    Assertions.assertTrue(
+        signed.getRequest().headers().firstValue("Content-Type").isPresent(),
+        "Content-Type header should still be present for a null request");
+  }
+
+  @Test
+  void signedIdentityIsReplayableUrlRootedAtStsEndpoint() {
+    SignedAuthRequest signed =
+        stsUtil().newCloudNativeAuthSignedRequest(sampleRequest(), SignOptions.builder().build());
+
+    String signedIdentity = signed.getSignedIdentity();
+    Assertions.assertNotNull(signedIdentity, "Signed identity should be produced for AWS");
+
+    URI identityUri = URI.create(signedIdentity);
+    Assertions.assertEquals(
+        "https", identityUri.getScheme(), "Signed identity should be an https URL");
+    Assertions.assertEquals(
+        "sts." + region + ".amazonaws.com",
+        identityUri.getHost(),
+        "Signed identity should be rooted at the STS endpoint");
+
+    Map<String, String> params = parseQuery(identityUri.getRawQuery());
+    Assertions.assertEquals(
+        "GetCallerIdentity",
+        params.get("Action"),
+        "Signed identity should carry the STS action");
+    Assertions.assertEquals(
+        "2011-06-15", params.get("Version"), "Signed identity should carry the STS version");
+    Assertions.assertTrue(
+        params.containsKey("authorization"),
+        "Signed identity should carry the authorization signed header");
+  }
+
+  @Test
+  void signedIdentityHonorsExcludeContentTypeOption() {
+    SignedAuthRequest signed =
+        stsUtil()
+            .newCloudNativeAuthSignedRequest(
+                sampleRequest(),
+                SignOptions.builder().withExcludeContentTypeHeader(true).build());
+
+    Map<String, String> params =
+        parseQuery(URI.create(signed.getSignedIdentity()).getRawQuery());
+    Assertions.assertFalse(
+        params.containsKey("Content-Type"),
+        "Signed identity should not carry Content-Type when the header is excluded");
+  }
+
+  @Test
+  void actionInQueryStringSignsActionAndVersionAsQueryParamsWithEmptyBody() {
+    SignedAuthRequest signed =
+        stsUtil()
+            .newCloudNativeAuthSignedRequest(
+                null, SignOptions.builder().withActionInQueryString(true).build());
+
+    HttpRequest request = signed.getRequest();
+    Assertions.assertEquals("POST", request.method());
+
+    Map<String, String> params = parseQuery(request.uri().getRawQuery());
+    Assertions.assertEquals(
+        "GetCallerIdentity",
+        params.get("Action"),
+        "Action should be carried in the request URL query string");
+    Assertions.assertEquals(
+        "2011-06-15", params.get("Version"), "Version should be carried in the request URL query");
+
+    // The request is signed over an empty body when the action lives in the query string.
+    Assertions.assertEquals(
+        0L,
+        request.bodyPublisher().map(HttpRequest.BodyPublisher::contentLength).orElse(0L),
+        "The signed request should carry an empty body");
+    Assertions.assertTrue(
+        request.headers().firstValue("Authorization").isPresent(),
+        "The request should be signed");
+  }
+
+  @Test
+  void actionInQueryStringSignsCustomHeaders() {
+    SignedAuthRequest signed =
+        stsUtil()
+            .newCloudNativeAuthSignedRequest(
+                null,
+                SignOptions.builder()
+                    .withActionInQueryString(true)
+                    .withCustomHeader("x-goog-cloud-target-resource", "//example/audience")
+                    .build());
+
+    HttpRequest request = signed.getRequest();
+    Assertions.assertEquals(
+        "//example/audience",
+        request.headers().firstValue("x-goog-cloud-target-resource").orElse(null),
+        "Custom headers should be applied to the signed query-string request");
+
+    // The audience header must be covered by the signature, so it appears in SignedHeaders.
+    String authorization = request.headers().firstValue("Authorization").orElse("");
+    Assertions.assertTrue(
+        authorization.contains("x-goog-cloud-target-resource"),
+        "The audience header must be part of the SigV4 SignedHeaders");
+  }
+
+  @Test
+  void actionInQueryStringSignsMinimalHeaderSetWithoutContentHash() {
+    SignedAuthRequest signed =
+        stsUtil()
+            .newCloudNativeAuthSignedRequest(
+                null,
+                SignOptions.builder()
+                    .withActionInQueryString(true)
+                    .withCustomHeader("x-goog-cloud-target-resource", "//example/audience")
+                    .build());
+
+    String authorization = signed.getRequest().headers().firstValue("Authorization").orElse("");
+    String signedHeaders = extractSignedHeaders(authorization);
+
+    // A verifier that replays this request from its URL and headers alone presents only these
+    // headers. The content hash header must NOT be signed, otherwise the replayed request is
+    // missing a signed header and AWS rejects the signature.
+    Assertions.assertEquals(
+        "host;x-amz-date;x-amz-security-token;x-goog-cloud-target-resource",
+        signedHeaders,
+        "SignedHeaders should be the minimal replayable set with no x-amz-content-sha256");
+    Assertions.assertFalse(
+        signedHeaders.contains("x-amz-content-sha256"),
+        "x-amz-content-sha256 must not be part of SignedHeaders for the query-string path");
+  }
+
+  @Test
+  void noCredentialsOverriderFallsBackToDefaultCredentialChain() {
+    // The AWS default credential chain reads these system properties, so no overrider is needed.
+    String priorAccessKey = System.getProperty("aws.accessKeyId");
+    String priorSecretKey = System.getProperty("aws.secretAccessKey");
+    System.setProperty("aws.accessKeyId", "defaultChainKeyId");
+    System.setProperty("aws.secretAccessKey", "defaultChainSecret");
+    try {
+      StsUtilities stsUtil = StsUtilities.builder("aws").withRegion(region).build();
+
+      SignedAuthRequest signed =
+          stsUtil.newCloudNativeAuthSignedRequest(null, SignOptions.builder().build());
+
+      Assertions.assertEquals(
+          "defaultChainKeyId",
+          signed.getCredentials().getAccessKeyId(),
+          "Credentials should be resolved from the default chain when no overrider is supplied");
+      Assertions.assertNull(
+          signed.getCredentials().getSecurityToken(),
+          "Long-term default-chain credentials should carry no session token");
+      // A long-term credential has no session token, so it is not part of SignedHeaders.
+      String authorization =
+          signed.getRequest().headers().firstValue("Authorization").orElse("");
+      String signedHeaders = extractSignedHeaders(authorization);
+      Assertions.assertFalse(
+          signedHeaders.contains("x-amz-security-token"),
+          "x-amz-security-token should be absent when no session token is present");
+    } finally {
+      restoreProperty("aws.accessKeyId", priorAccessKey);
+      restoreProperty("aws.secretAccessKey", priorSecretKey);
+    }
+  }
+
+  private static void restoreProperty(String key, String priorValue) {
+    if (priorValue == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, priorValue);
+    }
+  }
+
+  private static String extractSignedHeaders(String authorization) {
+    for (String part : authorization.split(", ")) {
+      if (part.startsWith("SignedHeaders=")) {
+        return part.substring("SignedHeaders=".length());
+      }
+    }
+    return "";
+  }
+
+  private static Map<String, String> parseQuery(String rawQuery) {
+    Map<String, String> params = new HashMap<>();
+    for (String pair : rawQuery.split("&")) {
+      int idx = pair.indexOf('=');
+      String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
+      String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
+      params.put(key, value);
+    }
+    return params;
   }
 }

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/client/StsUtilities.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/client/StsUtilities.java
@@ -5,6 +5,7 @@ import com.salesforce.multicloudj.common.exceptions.ExceptionHandler;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.sts.driver.AbstractStsUtilities;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.SignOptions;
 import com.salesforce.multicloudj.sts.model.SignedAuthRequest;
 import java.net.http.HttpRequest;
 import java.util.ServiceLoader;
@@ -93,6 +94,23 @@ public class StsUtilities {
   public SignedAuthRequest newCloudNativeAuthSignedRequest(HttpRequest request) {
     try {
       return this.stsUtility.cloudNativeAuthSignedRequest(request);
+    } catch (Throwable t) {
+      throw this.stsUtility.mapException(t);
+    }
+  }
+
+  /**
+   * Signs a request using the supplied options and returns the signed auth request.
+   *
+   * @param request The HttpRequest containing the request details. May be null when the caller only
+   *     needs a signed STS request without a service request to hash.
+   * @param options The SignOptions controlling custom headers and header exclusions.
+   * @return The SignedAuthRequest.
+   */
+  public SignedAuthRequest newCloudNativeAuthSignedRequest(
+      HttpRequest request, SignOptions options) {
+    try {
+      return this.stsUtility.cloudNativeAuthSignedRequest(request, options);
     } catch (Throwable t) {
       throw this.stsUtility.mapException(t);
     }

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/driver/AbstractStsUtilities.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/driver/AbstractStsUtilities.java
@@ -2,8 +2,10 @@ package com.salesforce.multicloudj.sts.driver;
 
 import com.salesforce.multicloudj.common.provider.Provider;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.SignOptions;
 import com.salesforce.multicloudj.sts.model.SignedAuthRequest;
 import java.net.http.HttpRequest;
+import lombok.Getter;
 
 public abstract class AbstractStsUtilities<T extends AbstractStsUtilities<T>> implements Provider {
   protected final String providerId;
@@ -32,8 +34,22 @@ public abstract class AbstractStsUtilities<T extends AbstractStsUtilities<T>> im
     return newCloudNativeAuthSignedRequest(request);
   }
 
+  /**
+   * signs a passed in request using the supplied options and returns
+   *
+   * @param request The HttpRequest containing the request details. May be null when the caller only
+   *     needs a signed STS request without a service request to hash.
+   * @param options The SignOptions controlling custom headers and header exclusions.
+   * @return SignedAuthRequest
+   */
+  public SignedAuthRequest cloudNativeAuthSignedRequest(
+      HttpRequest request, SignOptions options) {
+    return newCloudNativeAuthSignedRequest(request, options);
+  }
+
   public abstract static class Builder<T extends AbstractStsUtilities<T>>
       implements Provider.Builder {
+    @Getter
     protected String providerId;
     protected String region;
     protected CredentialsOverrider credentialsOverrider;
@@ -61,10 +77,6 @@ public abstract class AbstractStsUtilities<T extends AbstractStsUtilities<T>> im
       return this;
     }
 
-    public String getProviderId() {
-      return this.providerId;
-    }
-
     @Override
     public Builder<T> providerId(String providerId) {
       this.providerId = providerId;
@@ -76,4 +88,19 @@ public abstract class AbstractStsUtilities<T extends AbstractStsUtilities<T>> im
 
   // Abstract methods for substrate-specific implementations
   protected abstract SignedAuthRequest newCloudNativeAuthSignedRequest(HttpRequest request);
+
+  /**
+   * Substrate-specific implementation that honors the supplied signing options. The default
+   * implementation ignores the options and delegates to {@link
+   * #newCloudNativeAuthSignedRequest(HttpRequest)}; providers that support the options override
+   * this method.
+   *
+   * @param request The HttpRequest containing the request details. May be null.
+   * @param options The SignOptions controlling custom headers and header exclusions.
+   * @return SignedAuthRequest
+   */
+  protected SignedAuthRequest newCloudNativeAuthSignedRequest(
+      HttpRequest request, SignOptions options) {
+    return newCloudNativeAuthSignedRequest(request);
+  }
 }

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/SignOptions.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/SignOptions.java
@@ -1,0 +1,115 @@
+package com.salesforce.multicloudj.sts.model;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.Getter;
+
+/**
+ * SignOptions carries optional, substrate-agnostic knobs that influence how a cloud native auth
+ * request is constructed and signed.
+ *
+ * <p>All options are optional; an instance built with no customization requests the default signing
+ * behavior. Custom headers are applied to the request that gets signed, and the exclusion flags let
+ * a caller drop headers that a downstream verifier does not expect.
+ */
+@Getter
+public class SignOptions {
+
+  /** Additional headers to set on the request that is signed. */
+  private final Map<String, String> customHeaders;
+
+  /** When true, the request payload hash header is not added to the signed request. */
+  private final boolean excludeRequestHashHeader;
+
+  /** When true, the content type header is not added to the signed request. */
+  private final boolean excludeContentTypeHeader;
+
+  /**
+   * When true, the STS action and version are signed as URL query parameters over an empty body,
+   * rather than as a form-encoded request body. This produces a request whose signature validates
+   * when a verifier replays it from the URL and headers alone, with no body.
+   */
+  private final boolean actionInQueryString;
+
+  private SignOptions(Builder builder) {
+    this.customHeaders = Collections.unmodifiableMap(new LinkedHashMap<>(builder.customHeaders));
+    this.excludeRequestHashHeader = builder.excludeRequestHashHeader;
+    this.excludeContentTypeHeader = builder.excludeContentTypeHeader;
+    this.actionInQueryString = builder.actionInQueryString;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final Map<String, String> customHeaders = new LinkedHashMap<>();
+    private boolean excludeRequestHashHeader;
+    private boolean excludeContentTypeHeader;
+    private boolean actionInQueryString;
+
+    /**
+     * Adds a single custom header to set on the signed request.
+     *
+     * @param name header name
+     * @param value header value
+     * @return this builder
+     */
+    public Builder withCustomHeader(String name, String value) {
+      this.customHeaders.put(name, value);
+      return this;
+    }
+
+    /**
+     * Adds all supplied custom headers to set on the signed request.
+     *
+     * @param customHeaders headers to add
+     * @return this builder
+     */
+    public Builder withCustomHeaders(Map<String, String> customHeaders) {
+      if (customHeaders != null) {
+        this.customHeaders.putAll(customHeaders);
+      }
+      return this;
+    }
+
+    /**
+     * Controls whether the request payload hash header is excluded from the signed request.
+     *
+     * @param excludeRequestHashHeader true to exclude the request hash header
+     * @return this builder
+     */
+    public Builder withExcludeRequestHashHeader(boolean excludeRequestHashHeader) {
+      this.excludeRequestHashHeader = excludeRequestHashHeader;
+      return this;
+    }
+
+    /**
+     * Controls whether the content type header is excluded from the signed request.
+     *
+     * @param excludeContentTypeHeader true to exclude the content type header
+     * @return this builder
+     */
+    public Builder withExcludeContentTypeHeader(boolean excludeContentTypeHeader) {
+      this.excludeContentTypeHeader = excludeContentTypeHeader;
+      return this;
+    }
+
+    /**
+     * Controls whether the STS action and version are signed as URL query parameters over an empty
+     * body instead of as a form-encoded request body.
+     *
+     * @param actionInQueryString true to sign the action and version as query parameters
+     * @return this builder
+     */
+    public Builder withActionInQueryString(boolean actionInQueryString) {
+      this.actionInQueryString = actionInQueryString;
+      return this;
+    }
+
+    public SignOptions build() {
+      return new SignOptions(this);
+    }
+  }
+}

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/SignedAuthRequest.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/SignedAuthRequest.java
@@ -1,21 +1,31 @@
 package com.salesforce.multicloudj.sts.model;
 
 import java.net.http.HttpRequest;
+import lombok.Getter;
 
+@Getter
 public class SignedAuthRequest {
   HttpRequest request;
   StsCredentials credentials;
+  String signedIdentity;
 
   public SignedAuthRequest(HttpRequest request, StsCredentials credentials) {
+    this(request, credentials, null);
+  }
+
+  /**
+   * Constructs a SignedAuthRequest with a signed identity.
+   *
+   * @param request the signed STS request
+   * @param credentials the credentials used to sign the request
+   * @param signedIdentity a self-contained, replayable representation of the signed identity, or
+   *     null when the provider does not produce one
+   */
+  public SignedAuthRequest(
+      HttpRequest request, StsCredentials credentials, String signedIdentity) {
     this.request = request;
     this.credentials = credentials;
+    this.signedIdentity = signedIdentity;
   }
 
-  public HttpRequest getRequest() {
-    return request;
-  }
-
-  public StsCredentials getCredentials() {
-    return credentials;
-  }
 }


### PR DESCRIPTION
## Summary
Adds a signed-identity output to the STS cloud-native auth signing path, so callers get a self-contained, replayable `GetCallerIdentity` request in addition to the `SignedAuthRequest`. This enables an AWS workload to federate into GCP via Workload Identity Federation (WIF), using the same portable `BucketClient` API with no static GCP keys.

## Changes
- **`SignedAuthRequest`** carries an optional `signedIdentity` (backward-compatible 2-arg constructor retained).
- **`SignOptions`** (new client model) exposes substrate-agnostic signing knobs: custom headers, `actionInQueryString`, and header exclusions.
- **`AbstractStsUtilities` / `StsUtilities`** gain a `(request, options)` overload; the default impl delegates to the no-options path so other providers stay compile-safe.
- **`AwsStsUtilities`** signs with a hand-rolled SigV4 for exact control over the minimal `SignedHeaders` set (no `x-amz-content-sha256`), which GCP's bodyless replay requires. Credentials fall back to the retained AWS default credential chain when no overrider is supplied.
- **`GcpCredentialsProvider`** handles `ASSUME_ROLE_WEB_IDENTITY` via `IdentityPoolCredentials`, inferring `AWS4` vs `JWT` subject-token type from the token shape.
- **examples**: `CrossCloudAwsToGcp` demonstrates the end-to-end AWS-to-GCS flow; `examples/pom.xml` adds `blob-gcp` + `gson` and drops a duplicate `iam` dependency block.

## API Example
```java
// Sign a GetCallerIdentity request usable as a GCP WIF subject token.
SignOptions options =
    SignOptions.builder()
        .withCustomHeader("x-goog-cloud-target-resource", audience)
        .withActionInQueryString(true)
        .build();

StsUtilities sts = StsUtilities.builder("aws").withRegion("us-west-2").build();
SignedAuthRequest signed = sts.newCloudNativeAuthSignedRequest(null, options);
String signedIdentity = signed.getSignedIdentity();
```

## Testing
- Unit tests: `mvn test -pl sts/sts-aws,sts/sts-client,multicloudj-common-gcp` — sts-aws 28/28, sts-client 34/34, common-gcp 18/18, all passing.
- Checkstyle: 0 violations across the touched modules.

## Cross-Cloud Compatibility
- **AWS**: implements the signed-identity output and all signing options.
- **GCP**: consumes the AWS subject token via WIF (`IdentityPoolCredentials`).
- **Alibaba**: the `(request, options)` overload defaults to the existing no-options path, so the provider remains compile-safe and behaviorally unchanged.