### PR TITLE
sts: resolve ambient credentials for the Ali STS public builder

### DIFF
--- a/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliSts.java
+++ b/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliSts.java
@@ -2,6 +2,7 @@ package com.salesforce.multicloudj.sts.ali;
 
 import com.aliyuncs.DefaultAcsClient;
 import com.aliyuncs.IAcsClient;
+import com.aliyuncs.auth.AlibabaCloudCredentialsProvider;
 import com.aliyuncs.auth.BasicSessionCredentials;
 import com.aliyuncs.auth.DefaultCredentialsProvider;
 import com.aliyuncs.exceptions.ClientException;
@@ -70,7 +71,12 @@ public class AliSts extends AbstractSts {
       EnvironmentUtils.setNoProxy("");
     }
 
-    this.stsClient = new DefaultAcsClient(clientProfile);
+    // Attach the SDK's default credential chain so the client can authenticate from the ambient
+    // environment: a bare DefaultProfile has no credentials, so a client built without this fails
+    // every request with MissingAccessKeyId. DefaultCredentialsProvider resolves — and refreshes —
+    // per request across system properties, env vars (long-term AK/SK), OIDC/RRSA (re-reads the
+    // token file), profile file, and ECS instance RAM role.
+    this.stsClient = new DefaultAcsClient(clientProfile, buildCredentialsProvider());
   }
 
   public AliSts(Builder builder, IAcsClient stsClient) {
@@ -80,6 +86,32 @@ public class AliSts extends AbstractSts {
 
   public AliSts() {
     super(new Builder());
+  }
+
+  /**
+   * Builds the SDK default credential chain for the public-builder client path. Resolution is lazy:
+   * the returned provider is invoked per request by the client, so credentials are resolved — and
+   * refreshed — per request rather than snapshotted at build time. The chain covers system
+   * properties, env vars (long-term AK/SK), OIDC/RRSA (re-reading the token file on expiry), the
+   * profile file, and the ECS instance RAM role. If nothing resolves, it throws
+   * {@code ClientException("not found credentials")} at request time, surfaced via
+   * {@link #mapException(Throwable)}.
+   *
+   * @return the SDK default credentials provider
+   */
+  static AlibabaCloudCredentialsProvider buildCredentialsProvider() {
+    try {
+      // The DefaultCredentialsProvider ctor (aliyun-java-sdk-core 4.7.2) does no credential I/O —
+      // it only assembles the sub-provider list; resolution (incl. the ECS RAM-role IMDS fetch and
+      // the OIDC token-file read) happens lazily in getCredentials(). Its only constructor throw is
+      // for an empty ALIBABA_CLOUD_ECS_METADATA; surface that as an actionable argument error.
+      return new DefaultCredentialsProvider();
+    } catch (ClientException e) {
+      throw new InvalidArgumentException(
+          "Invalid Alibaba credentials configuration in the environment "
+              + "(check ALIBABA_CLOUD_ECS_METADATA)",
+          e);
+    }
   }
 
   // Alibaba STS client doesn't directly support the endpoints override but
@@ -411,7 +443,11 @@ public class AliSts extends AbstractSts {
     // ali-yun has a wierd chain where ServerException extends the ClientException
     if (t instanceof ClientException) {
       String errorCode = ((ClientException) t).getErrCode();
-      exceptionClass = ERROR_MAPPING.getOrDefault(errorCode, UnknownException.class);
+      // A ClientException can carry a null error code (e.g. the SDK's own "not found credentials").
+      // Only look up when a code is present; otherwise keep the UnknownException default.
+      if (errorCode != null) {
+        exceptionClass = ERROR_MAPPING.getOrDefault(errorCode, UnknownException.class);
+      }
     }
     // aliyuncs ClientException has no status/retry signal; rely on type-default retryability.
     return ExceptionHandler.build(exceptionClass, t, null);

--- a/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsTest.java
+++ b/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.aliyuncs.DefaultAcsClient;
+import com.aliyuncs.auth.AlibabaCloudCredentialsProvider;
 import com.aliyuncs.exceptions.ClientException;
 import com.aliyuncs.http.HttpClientConfig;
 import com.aliyuncs.profile.IClientProfile;
@@ -14,14 +15,17 @@ import com.aliyuncs.sts.model.v20150401.AssumeRoleWithOIDCRequest;
 import com.aliyuncs.sts.model.v20150401.AssumeRoleWithOIDCResponse;
 import com.aliyuncs.sts.model.v20150401.GetCallerIdentityRequest;
 import com.aliyuncs.sts.model.v20150401.GetCallerIdentityResponse;
+import com.aliyuncs.utils.AuthUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.model.AssumeRoleWebIdentityRequest;
 import com.salesforce.multicloudj.sts.model.AssumedRoleRequest;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.CredentialScope;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.lang.reflect.Field;
 import java.net.URI;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -183,6 +187,22 @@ public class AliStsTest {
   public void testRuntimeExceptionType() {
     AliSts sts = new AliSts().builder().build(mockStsClient);
     Assertions.assertInstanceOf(UnknownException.class, sts.mapException(new RuntimeException()));
+  }
+
+  @Test
+  public void testMapExceptionWithNullErrorCode() {
+    // A ClientException can carry a null error code (e.g. the SDK's own "not found credentials"
+    // raised by the credentials fallback when nothing resolves). ERROR_MAPPING is a Map.of(...),
+    // which throws on a null key -- mapException must not NPE, and must preserve the cause.
+    AliSts sts = new AliSts().builder().build(mockStsClient);
+    ClientException noCreds = new ClientException("not found credentials");
+    Assertions.assertNull(
+        noCreds.getErrCode(), "precondition: single-arg ClientException has no code");
+
+    SubstrateSdkException mapped = sts.mapException(noCreds);
+
+    Assertions.assertInstanceOf(UnknownException.class, mapped);
+    Assertions.assertSame(noCreds, mapped.getCause(), "original ClientException must be preserved");
   }
 
   @Test
@@ -393,6 +413,49 @@ public class AliStsTest {
 
     AliSts sts = new AliSts().builder().build(mockStsClient);
     assertThrows(InvalidArgumentException.class, () -> sts.assumeRole(request));
+  }
+
+  @Test
+  public void testPublicBuilderAttachesDefaultCredentialsProvider() throws Exception {
+    // Guards the headline fix: the public builder must attach the SDK default credential chain to
+    // the underlying client. Building via the real builder is offline (the SDK client ctor does no
+    // credential network I/O); inspecting the attached provider catches a regression where the
+    // provider-carrying DefaultAcsClient ctor is dropped for the bare single-arg one (which would
+    // reattach the StaticCredentialsProvider snapshot and reintroduce the MissingAccessKeyId
+    // failure this fix addresses).
+    AliSts sts = new AliSts().builder().withRegion("cn-hangzhou").build();
+
+    Field stsClientField = AliSts.class.getDeclaredField("stsClient");
+    stsClientField.setAccessible(true);
+    Object client = stsClientField.get(sts);
+    Assertions.assertInstanceOf(DefaultAcsClient.class, client);
+
+    // DefaultAcsClient.getCredentialsProvider() returns the provider passed to its constructor
+    // verbatim. Assert positively that it is the same type buildCredentialsProvider() produces
+    // (the SDK DefaultCredentialsProvider), which pins the wiring rather than the absence of one
+    // wrong type.
+    AlibabaCloudCredentialsProvider provider =
+        ((DefaultAcsClient) client).getCredentialsProvider();
+    Assertions.assertNotNull(provider, "public builder must attach a credentials provider");
+    Assertions.assertEquals(
+        AliSts.buildCredentialsProvider().getClass(),
+        provider.getClass(),
+        "public builder must attach the SDK default credentials provider");
+  }
+
+  @Test
+  public void testBuildCredentialsProviderWrapsCtorFailure() {
+    // The DefaultCredentialsProvider ctor throws ClientException for an empty
+    // ALIBABA_CLOUD_ECS_METADATA; the no-arg buildCredentialsProvider() must wrap that as
+    // InvalidArgumentException. Force the condition via the SDK's test seam (AuthUtils overrides
+    // System.getenv for this variable), and reset it in finally so the JVM-wide static does not
+    // leak to other tests.
+    AuthUtils.setEnvironmentECSMetaData("");
+    try {
+      assertThrows(InvalidArgumentException.class, AliSts::buildCredentialsProvider);
+    } finally {
+      AuthUtils.setEnvironmentECSMetaData(null);
+    }
   }
 
   // Compares two JSON strings for structural equality, ignoring object key ordering.


### PR DESCRIPTION
## Summary
`StsClient.builder("ali")...build()` constructed the underlying `DefaultAcsClient` on a bare profile with no credentials provider attached, so every request failed with `MissingAccessKeyId` — the Ali STS provider was unusable through the cloud-agnostic public builder.

This attaches the Aliyun SDK's own `DefaultCredentialsProvider` chain via the provider-carrying `DefaultAcsClient` constructor, so credentials are resolved (and refreshed) per request from the ambient environment.

## Changes
- `AliSts(Builder)` now builds `new DefaultAcsClient(clientProfile, buildCredentialsProvider())`.
- `buildCredentialsProvider()` returns the SDK `DefaultCredentialsProvider`, which resolves per request across: system properties, environment variables (long-term AK/SK), OIDC/RRSA (re-reading the token file on expiry, so it renews), the profile file, and the ECS instance RAM role.
- The constructor-time `ClientException` for a malformed `ALIBABA_CLOUD_ECS_METADATA` is surfaced as `InvalidArgumentException`.
- `mapException` no longer throws on a `ClientException` with a null error code (the "no credentials found" case now reaches it at request time).

## Note on approach (updated)
An earlier revision of this PR added a custom `AliCredentialsProvider` to also read a security token from `ALIBABA_CLOUD_SECURITY_TOKEN`. That was dropped in favor of leaning on the SDK's `DefaultCredentialsProvider`, because: (1) the SDK default chain already covers the durable ambient modes — long-term AK/SK, profile, ECS RAM role, and **auto-renewing OIDC/RRSA**; (2) the only capability the custom provider added — a static env-var session token — cannot self-renew (the process environment is fixed at JVM start and the resulting credential carries no refresh signal), so it goes stale after its lifetime with no in-process recovery; and (3) no in-repo consumer resolves a session token from the environment via this builder. Leaning on the SDK default chain keeps the durable modes (including renewing OIDC) and drops only the non-renewing static-env-token path. A custom provider can be reintroduced additively if a concrete need arises.

## Testing
- `testPublicBuilderAttachesDefaultCredentialsProvider`: builds via the public builder (offline) and asserts the attached provider is the SDK default chain, not the bare-constructor `StaticCredentialsProvider` snapshot.
- `testBuildCredentialsProviderWrapsCtorFailure`: a malformed `ALIBABA_CLOUD_ECS_METADATA` maps to `InvalidArgumentException`.
- A null-error-code `ClientException` maps to `UnknownException` without NPE.
- `mvn test -pl sts/sts-ali`: 23 tests, green; 0 checkstyle violations.