### PR TITLE
chore: check unprotected paths for directory creations

### DIFF
--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/driver/AbstractAsyncBlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/async/driver/AbstractAsyncBlobStore.java
@@ -25,6 +25,7 @@ import com.salesforce.multicloudj.blob.driver.PresignedUrlResponse;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import java.io.File;
@@ -349,7 +350,12 @@ public abstract class AbstractAsyncBlobStore implements AsyncBlobStore {
     if (!request.isCreateParentPath()) {
       return destination;
     }
-    Path resolved = destination.resolve(request.getKey()).normalize();
+    Path base = destination.normalize();
+    Path resolved = base.resolve(request.getKey()).normalize();
+    if (!resolved.startsWith(base)) {
+      throw new InvalidArgumentException(
+          "Object key resolves outside the download destination directory: " + request.getKey());
+    }
     Path parent = resolved.getParent();
     if (parent != null) {
       try {

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStore.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStore.java
@@ -1,5 +1,6 @@
 package com.salesforce.multicloudj.blob.driver;
 
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.common.provider.Provider;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
@@ -439,7 +440,12 @@ public abstract class AbstractBlobStore implements BlobStore, AutoCloseable {
     if (!request.isCreateParentPath()) {
       return destination;
     }
-    Path resolved = destination.resolve(request.getKey()).normalize();
+    Path base = destination.normalize();
+    Path resolved = base.resolve(request.getKey()).normalize();
+    if (!resolved.startsWith(base)) {
+      throw new InvalidArgumentException(
+          "Object key resolves outside the download destination directory: " + request.getKey());
+    }
     Path parent = resolved.getParent();
     if (parent != null) {
       try {

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/async/driver/AbstractAsyncBlobStoreTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/async/driver/AbstractAsyncBlobStoreTest.java
@@ -32,6 +32,7 @@ import com.salesforce.multicloudj.blob.driver.PresignedOperation;
 import com.salesforce.multicloudj.blob.driver.PresignedUrlRequest;
 import com.salesforce.multicloudj.blob.driver.UploadPartResponse;
 import com.salesforce.multicloudj.blob.driver.UploadRequest;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.CredentialsType;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
@@ -49,6 +50,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 
 public class AbstractAsyncBlobStoreTest {
@@ -722,5 +724,29 @@ public class AbstractAsyncBlobStoreTest {
         () -> {
           mockBlobStore.deleteDirectory("test-prefix");
         });
+  }
+
+  @Test
+  void testCreateDownloadDestinationPath_rejectsTraversalKey(@TempDir Path destination) {
+    DownloadRequest request =
+        new DownloadRequest.Builder()
+            .withKey("../../etc/passwd")
+            .withCreateParentPath(true)
+            .build();
+    assertThrows(
+        InvalidArgumentException.class,
+        () -> mockBlobStore.createDownloadDestinationPath(request, destination));
+  }
+
+  @Test
+  void testCreateDownloadDestinationPath_allowsNestedKey(@TempDir Path destination) {
+    DownloadRequest request =
+        new DownloadRequest.Builder()
+            .withKey("nested/dir/object.txt")
+            .withCreateParentPath(true)
+            .build();
+    Path resolved = mockBlobStore.createDownloadDestinationPath(request, destination);
+    assertTrue(resolved.startsWith(destination.normalize()));
+    assertEquals(destination.resolve("nested/dir/object.txt").normalize(), resolved);
   }
 }

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStoreTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/driver/AbstractBlobStoreTest.java
@@ -2,6 +2,8 @@ package com.salesforce.multicloudj.blob.driver;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -13,6 +15,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.CredentialsType;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
@@ -27,6 +30,7 @@ import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 
 public class AbstractBlobStoreTest {
@@ -470,5 +474,29 @@ public class AbstractBlobStoreTest {
     org.junit.jupiter.api.Assertions.assertNull(delegated.getMode());
     org.junit.jupiter.api.Assertions.assertEquals(
         Boolean.FALSE, delegated.getBypassGovernanceRetention());
+  }
+
+  @Test
+  void testCreateDownloadDestinationPath_rejectsTraversalKey(@TempDir Path destination) {
+    DownloadRequest request =
+        new DownloadRequest.Builder()
+            .withKey("../../etc/passwd")
+            .withCreateParentPath(true)
+            .build();
+    assertThrows(
+        InvalidArgumentException.class,
+        () -> mockBlobStore.createDownloadDestinationPath(request, destination));
+  }
+
+  @Test
+  void testCreateDownloadDestinationPath_allowsNestedKey(@TempDir Path destination) {
+    DownloadRequest request =
+        new DownloadRequest.Builder()
+            .withKey("nested/dir/object.txt")
+            .withCreateParentPath(true)
+            .build();
+    Path resolved = mockBlobStore.createDownloadDestinationPath(request, destination);
+    assertTrue(resolved.startsWith(destination.normalize()));
+    assertEquals(destination.resolve("nested/dir/object.txt").normalize(), resolved);
   }
 }

--- a/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
+++ b/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
@@ -351,7 +351,12 @@ public class InMemoryBlobStore extends AbstractBlobStore {
     if (!request.isCreateParentPath()) {
       return destination;
     }
-    Path resolved = destination.resolve(request.getKey()).normalize();
+    Path base = destination.normalize();
+    Path resolved = base.resolve(request.getKey()).normalize();
+    if (!resolved.startsWith(base)) {
+      throw new InvalidArgumentException(
+          "Object key resolves outside the download destination directory: " + request.getKey());
+    }
     Path parent = resolved.getParent();
     if (parent != null) {
       try {


### PR DESCRIPTION
## Summary

< Provide a brief description of the changes in this PR >

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
