### PR TITLE
docstore: preserve Integer/Float types on untyped Ali decode

### DIFF
--- a/docstore/docstore-ali/src/main/java/com/salesforce/multicloudj/docstore/ali/AliDecoder.java
+++ b/docstore/docstore-ali/src/main/java/com/salesforce/multicloudj/docstore/ali/AliDecoder.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 public class AliDecoder implements Decoder {
   private Object value = null;
+  static final double EPSILON = 1e-9;
 
   public AliDecoder(Object value) {
     this.value = value;
@@ -195,12 +196,22 @@ public class AliDecoder implements Decoder {
         return attributeValue.asBoolean();
       case INTEGER:
         try {
-          return attributeValue.asLong();
+          long l = attributeValue.asLong();
+          int i = (int) l;
+          if (i == l) {
+            return i;
+          }
+          return l;
         } catch (NumberFormatException e) {
           throw new IllegalArgumentException(attributeValue.asLong() + " is not a number");
         }
       case DOUBLE:
-        return attributeValue.asDouble();
+        double d = attributeValue.asDouble();
+        float f = (float) d;
+        if (Math.abs(f - d) < EPSILON) {
+          return f;
+        }
+        return d;
       case BINARY:
         return attributeValue.asBinary();
       case STRING:
@@ -214,7 +225,12 @@ public class AliDecoder implements Decoder {
     switch (pkValue.getType()) {
       case INTEGER:
         try {
-          return pkValue.asLong();
+          long l = pkValue.asLong();
+          int i = (int) l;
+          if (i == l) {
+            return i;
+          }
+          return l;
         } catch (NumberFormatException e) {
           throw new IllegalArgumentException(pkValue.asLong() + " is not a number");
         }

--- a/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/AliDecoderTest.java
+++ b/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/AliDecoderTest.java
@@ -1,6 +1,7 @@
 package com.salesforce.multicloudj.docstore.ali;
 
 import com.alicloud.openservices.tablestore.model.ColumnValue;
+import com.alicloud.openservices.tablestore.model.PrimaryKeyValue;
 import com.google.protobuf.Timestamp;
 import com.salesforce.multicloudj.docstore.driver.codec.Codec;
 import java.util.Arrays;
@@ -75,5 +76,91 @@ class AliDecoderTest {
     Assertions.assertNull(decoder.asBytes());
     Assertions.assertNull(decoder.asBool());
     Assertions.assertEquals(true, decoder.asNull());
+  }
+
+  @Test
+  void testAsInterfaceNarrowsIntegerColumnToInteger() {
+    Object got = new AliDecoder(ColumnValue.fromLong(5L)).asInterface();
+    Assertions.assertInstanceOf(Integer.class, got);
+    Assertions.assertEquals(5, got);
+  }
+
+  @Test
+  void testAsInterfaceKeepsOutOfIntRangeColumnAsLong() {
+    long big = 3_000_000_000L; // > Integer.MAX_VALUE
+    Object got = new AliDecoder(ColumnValue.fromLong(big)).asInterface();
+    Assertions.assertInstanceOf(Long.class, got);
+    Assertions.assertEquals(big, got);
+  }
+
+  @Test
+  void testAsInterfaceNarrowsDoubleColumnToFloat() {
+    Object got = new AliDecoder(ColumnValue.fromDouble(5.5)).asInterface();
+    Assertions.assertInstanceOf(Float.class, got);
+    Assertions.assertEquals(5.5f, got);
+  }
+
+  @Test
+  void testAsInterfaceKeepsHighPrecisionDoubleAsDouble() {
+    double precise = 0.1; // not exactly representable as a float
+    Object got = new AliDecoder(ColumnValue.fromDouble(precise)).asInterface();
+    Assertions.assertInstanceOf(Double.class, got);
+    Assertions.assertEquals(precise, got);
+  }
+
+  @Test
+  void testAsInterfaceNarrowsIntegerPrimaryKeyToInteger() {
+    Object got = new AliDecoder(PrimaryKeyValue.fromLong(7L)).asInterface();
+    Assertions.assertInstanceOf(Integer.class, got);
+    Assertions.assertEquals(7, got);
+  }
+
+  @Test
+  void testAsInterfaceKeepsOutOfIntRangePrimaryKeyAsLong() {
+    long big = 5_000_000_000L; // > Integer.MAX_VALUE
+    Object got = new AliDecoder(PrimaryKeyValue.fromLong(big)).asInterface();
+    Assertions.assertInstanceOf(Long.class, got);
+    Assertions.assertEquals(big, got);
+  }
+
+  @Test
+  void testAsInterfaceNarrowsNegativeIntegerColumnToInteger() {
+    Object got = new AliDecoder(ColumnValue.fromLong(-5L)).asInterface();
+    Assertions.assertInstanceOf(Integer.class, got);
+    Assertions.assertEquals(-5, got);
+  }
+
+  @Test
+  void testAsInterfaceNarrowsIntBoundaryColumnToInteger() {
+    // Exact int boundaries must narrow to Integer.
+    Assertions.assertInstanceOf(
+        Integer.class, new AliDecoder(ColumnValue.fromLong(Integer.MAX_VALUE)).asInterface());
+    Assertions.assertInstanceOf(
+        Integer.class, new AliDecoder(ColumnValue.fromLong(Integer.MIN_VALUE)).asInterface());
+  }
+
+  @Test
+  void testAsInterfaceKeepsJustBeyondIntBoundaryColumnAsLong() {
+    // One past each int boundary must stay Long (narrowing would wrap).
+    Assertions.assertInstanceOf(
+        Long.class, new AliDecoder(ColumnValue.fromLong(Integer.MAX_VALUE + 1L)).asInterface());
+    Assertions.assertInstanceOf(
+        Long.class, new AliDecoder(ColumnValue.fromLong(Integer.MIN_VALUE - 1L)).asInterface());
+  }
+
+  @Test
+  void testAsInterfaceNarrowsIntBoundaryPrimaryKeyToInteger() {
+    Assertions.assertInstanceOf(
+        Integer.class, new AliDecoder(PrimaryKeyValue.fromLong(Integer.MAX_VALUE)).asInterface());
+    Assertions.assertInstanceOf(
+        Integer.class, new AliDecoder(PrimaryKeyValue.fromLong(Integer.MIN_VALUE)).asInterface());
+  }
+
+  @Test
+  void testAsInterfaceKeepsJustBeyondIntBoundaryPrimaryKeyAsLong() {
+    Assertions.assertInstanceOf(
+        Long.class, new AliDecoder(PrimaryKeyValue.fromLong(Integer.MAX_VALUE + 1L)).asInterface());
+    Assertions.assertInstanceOf(
+        Long.class, new AliDecoder(PrimaryKeyValue.fromLong(Integer.MIN_VALUE - 1L)).asInterface());
   }
 }


### PR DESCRIPTION
## Summary
`AliDecoder`'s untyped decode path (`asInterface()` → `toValue`) returned `Long` for every `INTEGER` column/primary-key and `Double` for every `DOUBLE` column. Values read into `Object` / `Map<String,Object>` / `List<Object>` fields therefore came back type-widened — a caller who wrote an `Integer` or `Float` and read it back untyped got a `Long` or `Double`, causing `ClassCastException` / equality mismatches even though the numeric value was identical.

Tablestore's `ColumnType` has only 64-bit `INTEGER` and `DOUBLE`, so the width is lost on the wire and must be reconstructed on read.

## Changes
- **INTEGER**: narrow to `Integer` when the value fits in an `int` (`(int) l == l`), else keep `Long`. Applied to both the `ColumnValue` and `PrimaryKeyValue` `toValue` paths.
- **DOUBLE**: narrow to `Float` when it round-trips within `EPSILON` (`Math.abs((float) d - d) < EPSILON`), else keep `Double`.
- Only the **untyped** path changes; typed reads (`asInt`/`asFloat`/…) are unchanged.

## Testing
- Unit tests over the untyped `asInterface` path assert the returned runtime type (not just value) for: in-range / out-of-range / negative / exact-int-boundary (`Integer.MAX_VALUE`/`MIN_VALUE` and one past each) integers, and float-representable vs high-precision doubles — for both column and primary-key values.
- `mvn test -pl docstore/docstore-ali`: 84 tests, green; 0 checkstyle violations.

## Cross-cloud consistency
This brings the Ali decoder in line with the AWS (DynamoDB) and GCP (Firestore) decoders, which already apply the same narrowing for the equivalent untyped decode operation — including the identical `EPSILON = 1e-9` tolerance for the double→float round-trip check. With this change, all three providers return the same Java types for the same stored values on the untyped path, so cross-cloud behavior is unified rather than Ali-specific.