### PR TITLE
Revert "blobstore: gcp: fix generation-pinned reads and remove duplicate BlobId lookup on download (#529)"

### DIFF
--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -268,7 +268,7 @@ public class GcpBlobStore extends AbstractBlobStore {
     BlobId blobId = transformer.toBlobId(downloadRequest);
     Blob blob = getRequiredBlobForDownload(downloadRequest, blobId);
     try {
-      ReadChannel reader = storage.reader(blobId);
+      ReadChannel reader = blob.reader();
       applyRange(reader, downloadRequest, blob);
       InputStream inputStream = Channels.newInputStream(reader);
       return transformer.toDownloadResponse(blob, inputStream);

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -1801,7 +1801,7 @@ class GcpBlobStoreTest {
 
       when(mockTransformer.toBlobId(downloadRequest)).thenReturn(mockBlobId);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
-      when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
+      when(mockBlob.reader()).thenReturn(mockReadChannel);
       when(mockTransformer.toDownloadResponse(eq(mockBlob), any(InputStream.class)))
           .thenReturn(expectedResponse);
 
@@ -1810,7 +1810,7 @@ class GcpBlobStoreTest {
       assertEquals(expectedResponse, response);
       verify(mockTransformer).toBlobId(downloadRequest);
       verify(mockStorage).get(mockBlobId);
-      verify(mockStorage).reader(mockBlobId);
+      verify(mockBlob).reader();
       verify(mockTransformer, never()).computeRange(any(), any(), anyLong());
       verify(mockTransformer).toDownloadResponse(eq(mockBlob), any(InputStream.class));
     }
@@ -1849,7 +1849,7 @@ class GcpBlobStoreTest {
 
       when(mockTransformer.toBlobId(downloadRequest)).thenReturn(mockBlobId);
       when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
-      when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
+      when(mockBlob.reader()).thenReturn(mockReadChannel);
       when(mockBlob.getSize()).thenReturn(100L);
       when(mockTransformer.computeRange(10L, 20L, 100L)).thenReturn(new ImmutablePair<>(10L, 21L));
       when(mockTransformer.toDownloadResponse(eq(mockBlob), any(InputStream.class)))
@@ -1861,7 +1861,7 @@ class GcpBlobStoreTest {
       assertEquals(expectedResponse, response);
       verify(mockTransformer).toBlobId(downloadRequest);
       verify(mockStorage).get(mockBlobId);
-      verify(mockStorage).reader(mockBlobId);
+      verify(mockBlob).reader();
       verify(mockReadChannel).seek(10L);
       verify(mockReadChannel).limit(21L);
       verify(mockTransformer).computeRange(10L, 20L, 100L);
@@ -1879,7 +1879,7 @@ class GcpBlobStoreTest {
     when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
     when(mockBlob.getSize()).thenReturn(100L);
     when(mockTransformer.computeRange(0L, 0L, 100L)).thenReturn(new ImmutablePair<>(0L, 1L));
-    when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
+    when(mockBlob.reader()).thenReturn(mockReadChannel);
     when(mockTransformer.toDownloadResponse(any(Blob.class), any(InputStream.class)))
         .thenReturn(DownloadResponse.builder().key(TEST_KEY).build());
 
@@ -1899,7 +1899,7 @@ class GcpBlobStoreTest {
     when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
     when(mockBlob.getSize()).thenReturn(100L);
     when(mockTransformer.computeRange(50L, null, 100L)).thenReturn(new ImmutablePair<>(50L, null));
-    when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
+    when(mockBlob.reader()).thenReturn(mockReadChannel);
     when(mockTransformer.toDownloadResponse(any(Blob.class), any(InputStream.class)))
         .thenReturn(DownloadResponse.builder().key(TEST_KEY).build());
 
@@ -1919,7 +1919,7 @@ class GcpBlobStoreTest {
     when(mockStorage.get(mockBlobId)).thenReturn(mockBlob);
     when(mockBlob.getSize()).thenReturn(100L);
     when(mockTransformer.computeRange(null, 25L, 100L)).thenReturn(new ImmutablePair<>(75L, 101L));
-    when(mockStorage.reader(mockBlobId)).thenReturn(mockReadChannel);
+    when(mockBlob.reader()).thenReturn(mockReadChannel);
     when(mockTransformer.toDownloadResponse(any(Blob.class), any(InputStream.class)))
         .thenReturn(DownloadResponse.builder().key(TEST_KEY).build());
 


### PR DESCRIPTION
Reverts #529 (commit 759d0fb0a0c72508ed2c3319ef8e8948a799ca17).

This restores `doDownload(DownloadRequest)` to use `blob.reader()` instead of `storage.reader(blobId)` and reverts the corresponding `GcpBlobStoreTest` mock/verify changes.

## Verification
- `mvn clean install -DskipTests` — success
- `mvn test -pl blob/blob-gcp -Dtest=GcpBlobStoreTest` — 172 tests, 0 failures