### PR TITLE
docstore: apply DELETE inside atomic writes on Alibaba Tablestore

### DIFF
--- a/docstore/docstore-ali/src/main/java/com/salesforce/multicloudj/docstore/ali/AliDocStore.java
+++ b/docstore/docstore-ali/src/main/java/com/salesforce/multicloudj/docstore/ali/AliDocStore.java
@@ -27,6 +27,7 @@ import com.alicloud.openservices.tablestore.model.PrimaryKeyColumn;
 import com.alicloud.openservices.tablestore.model.PrimaryKeySchema;
 import com.alicloud.openservices.tablestore.model.PrimaryKeyValue;
 import com.alicloud.openservices.tablestore.model.PutRowRequest;
+import com.alicloud.openservices.tablestore.model.RowChange;
 import com.alicloud.openservices.tablestore.model.RowDeleteChange;
 import com.alicloud.openservices.tablestore.model.RowExistenceExpectation;
 import com.alicloud.openservices.tablestore.model.RowPutChange;
@@ -284,7 +285,7 @@ public class AliDocStore extends AbstractDocStore {
     PrimaryKey primaryKey = pkBuilder.build();
     RowDeleteChange rowChange = new RowDeleteChange(collectionOptions.getTableName(), primaryKey);
     return new WriteOperation(
-        action, new PutRowRequest(), null, null, () -> runDelete(rowChange, action, beforeDo));
+        action, rowChange, null, null, () -> runDelete(rowChange, action, beforeDo));
   }
 
   protected WriteOperation newPut(Action action, Consumer<Predicate<Object>> beforeDo) {
@@ -335,7 +336,7 @@ public class AliDocStore extends AbstractDocStore {
 
     return new WriteOperation(
         action,
-        new PutRowRequest(rowChange),
+        rowChange,
         newPartitionKey,
         rev,
         () -> runPut(rowChange, action, beforeDo));
@@ -572,9 +573,18 @@ public class AliDocStore extends AbstractDocStore {
 
     try {
       for (WriteOperation op : operations) {
-        PutRowRequest putRowRequest = op.getPutRowRequest();
-        putRowRequest.setTransactionId(transactionId);
-        tableStoreClient.putRow(putRowRequest);
+        // Tablestore has no single generic "apply this RowChange" call, so dispatch each op to the
+        // request type its change requires: deletes go through deleteRow, puts through putRow.
+        RowChange change = op.getRowChange();
+        if (change instanceof RowDeleteChange) {
+          DeleteRowRequest deleteRowRequest = new DeleteRowRequest((RowDeleteChange) change);
+          deleteRowRequest.setTransactionId(transactionId);
+          tableStoreClient.deleteRow(deleteRowRequest);
+        } else {
+          PutRowRequest putRowRequest = new PutRowRequest((RowPutChange) change);
+          putRowRequest.setTransactionId(transactionId);
+          tableStoreClient.putRow(putRowRequest);
+        }
       }
       tableStoreClient.commitTransaction(new CommitTransactionRequest(transactionId));
     } catch (RuntimeException e) {

--- a/docstore/docstore-ali/src/main/java/com/salesforce/multicloudj/docstore/ali/AliDocStore.java
+++ b/docstore/docstore-ali/src/main/java/com/salesforce/multicloudj/docstore/ali/AliDocStore.java
@@ -43,6 +43,7 @@ import com.salesforce.multicloudj.common.exceptions.ResourceAlreadyExistsExcepti
 import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.common.exceptions.TransactionFailedException;
+import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.common.util.UUID;
 import com.salesforce.multicloudj.docstore.client.Query;
@@ -575,15 +576,21 @@ public class AliDocStore extends AbstractDocStore {
       for (WriteOperation op : operations) {
         // Tablestore has no single generic "apply this RowChange" call, so dispatch each op to the
         // request type its change requires: deletes go through deleteRow, puts through putRow.
+        // Reject any other unsupported RowChange subtype with a clear error rather than blindly
+        // casting it to a put and failing with an opaque ClassCastException mid-transaction.
         RowChange change = op.getRowChange();
         if (change instanceof RowDeleteChange) {
           DeleteRowRequest deleteRowRequest = new DeleteRowRequest((RowDeleteChange) change);
           deleteRowRequest.setTransactionId(transactionId);
           tableStoreClient.deleteRow(deleteRowRequest);
-        } else {
+        } else if (change instanceof RowPutChange) {
           PutRowRequest putRowRequest = new PutRowRequest((RowPutChange) change);
           putRowRequest.setTransactionId(transactionId);
           tableStoreClient.putRow(putRowRequest);
+        } else {
+          throw new UnSupportedOperationException(
+              "Unsupported RowChange type in atomic write: "
+                  + (change == null ? "null" : change.getClass().getName()));
         }
       }
       tableStoreClient.commitTransaction(new CommitTransactionRequest(transactionId));

--- a/docstore/docstore-ali/src/main/java/com/salesforce/multicloudj/docstore/ali/WriteOperation.java
+++ b/docstore/docstore-ali/src/main/java/com/salesforce/multicloudj/docstore/ali/WriteOperation.java
@@ -1,6 +1,6 @@
 package com.salesforce.multicloudj.docstore.ali;
 
-import com.alicloud.openservices.tablestore.model.PutRowRequest;
+import com.alicloud.openservices.tablestore.model.RowChange;
 import com.salesforce.multicloudj.docstore.driver.Action;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,7 +9,10 @@ import lombok.Getter;
 @Getter
 public class WriteOperation {
   private Action action;
-  private PutRowRequest putRowRequest;
+  // The native Tablestore change (RowPutChange or RowDeleteChange). The transactional path
+  // (runTxWrites) branches on its concrete type to issue the correct putRow/deleteRow call; the
+  // non-atomic path executes via the run runnable instead.
+  private RowChange rowChange;
   private String newPartitionKey;
   private String newRevision;
   private Runnable run;

--- a/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/AliDocStoreTest.java
+++ b/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/AliDocStoreTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import com.alicloud.openservices.tablestore.ClientException;
 import com.alicloud.openservices.tablestore.SyncClient;
 import com.alicloud.openservices.tablestore.TableStoreException;
+import com.alicloud.openservices.tablestore.model.AbortTransactionRequest;
 import com.alicloud.openservices.tablestore.model.BatchGetRowResponse;
 import com.alicloud.openservices.tablestore.model.CapacityUnit;
 import com.alicloud.openservices.tablestore.model.Column;
@@ -23,6 +24,7 @@ import com.alicloud.openservices.tablestore.model.GetRangeRequest;
 import com.alicloud.openservices.tablestore.model.GetRangeResponse;
 import com.alicloud.openservices.tablestore.model.IndexMeta;
 import com.alicloud.openservices.tablestore.model.IndexType;
+import com.alicloud.openservices.tablestore.model.PrimaryKey;
 import com.alicloud.openservices.tablestore.model.PrimaryKeyBuilder;
 import com.alicloud.openservices.tablestore.model.PrimaryKeyValue;
 import com.alicloud.openservices.tablestore.model.PutRowRequest;
@@ -30,6 +32,7 @@ import com.alicloud.openservices.tablestore.model.PutRowResponse;
 import com.alicloud.openservices.tablestore.model.RangeRowQueryCriteria;
 import com.alicloud.openservices.tablestore.model.Response;
 import com.alicloud.openservices.tablestore.model.Row;
+import com.alicloud.openservices.tablestore.model.RowChange;
 import com.alicloud.openservices.tablestore.model.RowDeleteChange;
 import com.alicloud.openservices.tablestore.model.RowPutChange;
 import com.alicloud.openservices.tablestore.model.StartLocalTransactionResponse;
@@ -38,7 +41,9 @@ import com.google.protobuf.Timestamp;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.ResourceAlreadyExistsException;
 import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
+import com.salesforce.multicloudj.common.exceptions.TransactionFailedException;
 import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.docstore.client.Query;
 import com.salesforce.multicloudj.docstore.driver.Action;
@@ -61,6 +66,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.junit.jupiter.api.AfterEach;
@@ -96,6 +103,20 @@ class AliDocStoreTest {
 
     public void setIndex(int index) {
       this.index = index;
+    }
+  }
+
+  // A RowChange subtype that is neither a put nor a delete, used to exercise the transactional
+  // dispatch loop's rejection of unsupported change types. Not tied to any real SDK operation, so
+  // it stays valid regardless of which RowChange types the driver supports.
+  static class UnknownRowChange extends RowChange {
+    UnknownRowChange(String tableName) {
+      super(tableName);
+    }
+
+    @Override
+    public int getDataSize() {
+      return 0;
     }
   }
 
@@ -457,6 +478,59 @@ class AliDocStoreTest {
 
     // The transaction commits once, covering both operations atomically.
     verify(syncClient, times(1)).commitTransaction(any());
+  }
+
+  @Test
+  void testWritesTxRejectsUnsupportedRowChange() {
+    // The transactional dispatch loop must reject an unsupported RowChange subtype with a clear
+    // error instead of blindly casting it to a put and throwing an opaque ClassCastException. Feed
+    // it a synthetic unsupported RowChange (via an overridden newPut) and assert the atomic write
+    // fails cleanly and rolls back. A test-only stub keeps this valid even if new RowChange types
+    // become supported later.
+    SyncClient txClient = mock(SyncClient.class);
+    StartLocalTransactionResponse txResponse = mock(StartLocalTransactionResponse.class);
+    when(txResponse.getTransactionID()).thenReturn("tx-id");
+    when(txClient.startLocalTransaction(any())).thenReturn(txResponse);
+
+    AliDocStore.Builder builder =
+        new AliDocStore.Builder()
+            .withRegion("cn-shanghai")
+            .withEndpointType("internet")
+            .withInstanceId("something")
+            .withCollectionOptions(
+                new CollectionOptions.CollectionOptionsBuilder()
+                    .withPartitionKey("title")
+                    .withSortKey("publisher")
+                    .withTableName("my-table")
+                    .withRevisionField("docRevision")
+                    .build())
+            .withTableStoreClient(txClient);
+    AliDocStore docStoreWithUnknownChange =
+        new AliDocStore(builder) {
+          @Override
+          protected WriteOperation newPut(Action action, Consumer<Predicate<Object>> beforeDo) {
+            return new WriteOperation(
+                action, new UnknownRowChange("my-table"), null, null, () -> {});
+          }
+        };
+
+    Book book = new Book("BlueBook", null, "WA", null, 3.99f, null, null);
+    ActionList writes =
+        docStoreWithUnknownChange
+            .getActions()
+            .enableAtomicWrites()
+            .put(new Document(book));
+
+    TransactionFailedException thrown =
+        Assertions.assertThrows(TransactionFailedException.class, writes::run);
+    Assertions.assertInstanceOf(
+        UnSupportedOperationException.class,
+        thrown.getCause(),
+        "unsupported RowChange must surface as UnSupportedOperationException, not a CCE");
+
+    // The transaction must NOT commit, and must be aborted (all-or-nothing rollback).
+    verify(txClient, times(0)).commitTransaction(any());
+    verify(txClient, times(1)).abortTransaction(any(AbortTransactionRequest.class));
   }
 
   @Test

--- a/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/AliDocStoreTest.java
+++ b/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/AliDocStoreTest.java
@@ -15,6 +15,7 @@ import com.alicloud.openservices.tablestore.model.Column;
 import com.alicloud.openservices.tablestore.model.ColumnValue;
 import com.alicloud.openservices.tablestore.model.CommitTransactionRequest;
 import com.alicloud.openservices.tablestore.model.ConsumedCapacity;
+import com.alicloud.openservices.tablestore.model.DeleteRowRequest;
 import com.alicloud.openservices.tablestore.model.DeleteRowResponse;
 import com.alicloud.openservices.tablestore.model.DescribeTableRequest;
 import com.alicloud.openservices.tablestore.model.DescribeTableResponse;
@@ -416,6 +417,46 @@ class AliDocStoreTest {
         ArgumentCaptor.forClass(CommitTransactionRequest.class);
     verify(syncClient, times(1)).commitTransaction(argumentCaptorTx.capture());
     Assertions.assertEquals("tx-id", argumentCaptorTx.getValue().getTransactionID());
+  }
+
+  @Test
+  void testWritesTxMixedPutAndDelete() {
+    // An atomic write containing both a put and a delete must issue the delete via deleteRow (not
+    // putRow) so the row is actually removed. The transactional path used to send every operation
+    // through putRow, so a delete never reached deleteRow inside the transaction. Verify the delete
+    // lands on deleteRow and both operations carry the transaction id.
+    Book putBook = new Book("BlueBook", null, "WA", null, 3.99f, null, null);
+    Book deleteBook = new Book("BlueBook", null, "TX", null, 3.99f, null, null);
+    ActionList writes =
+        ali.getActions()
+            .enableAtomicWrites()
+            .put(new Document(putBook))
+            .delete(new Document(deleteBook));
+    writes.run();
+
+    // The delete must go through deleteRow (exactly once), with the transaction id attached.
+    ArgumentCaptor<DeleteRowRequest> deleteCaptor =
+        ArgumentCaptor.forClass(DeleteRowRequest.class);
+    verify(syncClient, times(1)).deleteRow(deleteCaptor.capture());
+    DeleteRowRequest deleteRequest = deleteCaptor.getValue();
+    Assertions.assertEquals("tx-id", deleteRequest.getTransactionId());
+    Assertions.assertEquals(
+        "TX",
+        deleteRequest
+            .getRowChange()
+            .getPrimaryKey()
+            .getPrimaryKeyColumn("publisher")
+            .getValue()
+            .asString(),
+        "deleteRow must target the row identified by the delete action's key");
+
+    // The put must go through putRow (exactly once), also within the transaction.
+    ArgumentCaptor<PutRowRequest> putCaptor = ArgumentCaptor.forClass(PutRowRequest.class);
+    verify(syncClient, times(1)).putRow(putCaptor.capture());
+    Assertions.assertEquals("tx-id", putCaptor.getValue().getTransactionId());
+
+    // The transaction commits once, covering both operations atomically.
+    verify(syncClient, times(1)).commitTransaction(any());
   }
 
   @Test


### PR DESCRIPTION
## Summary
A DELETE inside an atomic (transactional) write could never succeed on the Alibaba Tablestore docstore provider. In an atomic batch (`enableAtomicWrites()`) containing a delete, the operation always failed with `TransactionFailedException` and the whole transaction rolled back — the delete never happened, and neither did any sibling operation in the block. Delete-inside-atomic was effectively unusable.

## Root cause
`WriteOperation` carried a `PutRowRequest`, and `runTxWrites` unconditionally called `putRow(op.getPutRowRequest())` for every operation. `newDelete` built a real `RowDeleteChange` but wrapped it in an empty `new PutRowRequest()` (its `rowChange` field null) and stashed the actual delete inside a `Runnable` that only the non-atomic path (`runWrites` via `getRun()`) invokes. So in the transactional loop the delete op's empty request reached `putRow` and threw a `NullPointerException` inside the Tablestore SDK at request-build time (`OTSProtocolBuilder.buildPutRowRequest` calls `getRowChange()` → null, then dereferences it) — client-side, before any network call and before `commitTransaction`. That NPE was caught, the transaction aborted, and `TransactionFailedException` surfaced. The non-atomic path was unaffected (it dispatches via the runnable to `runDelete`, which works).

## Changes
- `WriteOperation` now carries the native Tablestore `RowChange` (the abstract base of `RowPutChange`/`RowDeleteChange`) instead of a `PutRowRequest`. The old field was consumed only by `runTxWrites`, so this is a replacement rather than an addition, and it removes the empty-`PutRowRequest` placeholder in `newDelete`.
- `runTxWrites` now branches on the change type: a `RowDeleteChange` builds a `DeleteRowRequest` and calls `deleteRow`; a `RowPutChange` builds a `PutRowRequest` and calls `putRow`. Both attach the transaction id. The existing all-or-nothing abort + `TransactionFailedException` wrapper is preserved.
- The non-atomic path (`runWrites` via the run runnable) and `updateRevision` are unchanged.

## Why the operation must be dispatched by type
Tablestore's transaction API has no single generic "apply this RowChange" call — it requires separately-typed `putRow`/`deleteRow` calls, so the driver must distinguish the change type when replaying operations inside the transaction.

## Testing
- New unit test `testWritesTxMixedPutAndDelete`: an atomic batch mixing a put and a delete issues a real `deleteRow` carrying the transaction id (verified via captured request), the put goes through `putRow`, and the transaction commits once.
- Mutation-verified: reverting the fix makes the new test fail, confirming it guards the behavior rather than passing vacuously.
- **End-to-end validation against a live Tablestore instance**: with the fix, an atomic put+delete applies correctly (the deleted row is physically absent on a raw `GetRow`, and the put is applied); with the fix dropped, the same scenario reproduces the pre-fix `NullPointerException` → `TransactionFailedException`. This confirms the fix works against the real SDK, not just against mocks — and note that the mock-based unit test alone masks the pre-fix NPE (a stubbed `putRow` returns cleanly), which is why the live run was done.
- Full `docstore-ali` module suite green (90 tests), checkstyle clean.

## Cross-cloud compatibility
Scoped to the Alibaba provider. AWS and GCP already dispatch deletes correctly inside their transactional writes; no client-module or cross-provider changes.
