### PR TITLE
sts: support renewable session credentials for long-lived clients

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/OssCredentialsProvider.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/OssCredentialsProvider.java
@@ -3,6 +3,7 @@ package com.salesforce.multicloudj.blob.ali;
 import com.aliyun.sdk.service.oss2.credentials.Credentials;
 import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
 import com.aliyun.sdk.service.oss2.credentials.StaticCredentialsProvider;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.sts.client.StsClient;
 import com.salesforce.multicloudj.sts.model.AssumedRoleRequest;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
@@ -21,6 +22,12 @@ public class OssCredentialsProvider {
 
     switch (overrider.getType()) {
       case SESSION:
+        if (overrider.getSessionCredentialsSupplier() != null) {
+          throw new InvalidArgumentException(
+              "Session credentials supplied through withSessionCredentialsSupplier are not"
+                  + " supported by this provider. Supply them by value with"
+                  + " withSessionCredentials instead, and rebuild the client before they expire.");
+        }
         StsCredentials stsCredentials = overrider.getSessionCredentials();
         return new StaticCredentialsProvider(
             stsCredentials.getAccessKeyId(),

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/OssCredentialsProviderTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/OssCredentialsProviderTest.java
@@ -2,6 +2,7 @@ package com.salesforce.multicloudj.blob.ali;
 
 import com.aliyun.sdk.service.oss2.credentials.CredentialsProvider;
 import com.aliyun.sdk.service.oss2.credentials.StaticCredentialsProvider;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.CredentialsType;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
@@ -39,6 +40,23 @@ public class OssCredentialsProviderTest {
     Assertions.assertNotNull(provider);
     Assertions.assertInstanceOf(
         OssCredentialsProvider.AssumeRoleCredentialsProvider.class, provider);
+  }
+
+  @Test
+  public void testSessionCredentialsSupplierIsRejected() {
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentialsSupplier(() -> new StsCredentials("key", "secret", "token"))
+            .build();
+
+    InvalidArgumentException failure =
+        Assertions.assertThrows(
+            InvalidArgumentException.class,
+            () ->
+                OssCredentialsProvider.getCredentialsProvider(credentialsOverrider, "cn-shanghai"));
+    Assertions.assertTrue(
+        failure.getMessage().contains("withSessionCredentialsSupplier"),
+        "unexpected message: " + failure.getMessage());
   }
 
   @Test

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobClient.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobClient.java
@@ -5,6 +5,7 @@ import com.salesforce.multicloudj.blob.driver.BucketInfo;
 import com.salesforce.multicloudj.blob.driver.ListBucketsResponse;
 import com.salesforce.multicloudj.common.aws.AwsConstants;
 import com.salesforce.multicloudj.common.aws.CredentialsProvider;
+import com.salesforce.multicloudj.common.aws.ExpiredCredentialsInterceptor;
 import java.time.Duration;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -126,6 +127,7 @@ public class AwsBlobClient extends AbstractBlobClient<AwsBlobClient> implements 
             }
           });
     }
+    ExpiredCredentialsInterceptor.registerIfRefreshable(b, credentialsProvider);
 
     return b.build();
   }

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
@@ -31,6 +31,7 @@ import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.aws.AwsConstants;
 import com.salesforce.multicloudj.common.aws.CredentialsProvider;
+import com.salesforce.multicloudj.common.aws.ExpiredCredentialsInterceptor;
 import com.salesforce.multicloudj.common.exceptions.ArchiveInfo;
 import com.salesforce.multicloudj.common.exceptions.FailedPreconditionException;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
@@ -773,6 +774,7 @@ public class AwsBlobStore extends AbstractBlobStore implements AwsSdkService {
               }
             });
       }
+      ExpiredCredentialsInterceptor.registerIfRefreshable(b, credentialsProvider);
 
       return b.build();
     }

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/async/AwsAsyncBlobStore.java
@@ -34,6 +34,7 @@ import com.salesforce.multicloudj.blob.driver.UploadRequest;
 import com.salesforce.multicloudj.blob.driver.UploadResponse;
 import com.salesforce.multicloudj.common.aws.AwsConstants;
 import com.salesforce.multicloudj.common.aws.CredentialsProvider;
+import com.salesforce.multicloudj.common.aws.ExpiredCredentialsInterceptor;
 import com.salesforce.multicloudj.common.exceptions.ArchiveInfo;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
@@ -741,6 +742,8 @@ public class AwsAsyncBlobStore extends AbstractAsyncBlobStore implements AwsSdkS
                     config.getExecutorService())
                 .build());
       }
+
+      ExpiredCredentialsInterceptor.registerIfRefreshable(builder, credentialsProvider);
     }
 
     private static void applyCommonConfig(
@@ -749,6 +752,9 @@ public class AwsAsyncBlobStore extends AbstractAsyncBlobStore implements AwsSdkS
       builder.region(regionObj);
 
       // Configure credentials
+      // S3CrtAsyncClientBuilder exposes no execution-interceptor hook, so a rejected-credentials
+      // failure cannot invalidate the cached credentials here; renewal is driven purely by the
+      // expiration the credentials source reports.
       AwsCredentialsProvider credentialsProvider =
           CredentialsProvider.getCredentialsProvider(config.getCredentialsOverrider(), regionObj);
       if (credentialsProvider != null) {

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreCredentialsRefreshTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreCredentialsRefreshTest.java
@@ -1,0 +1,100 @@
+package com.salesforce.multicloudj.blob.aws;
+
+import com.salesforce.multicloudj.common.aws.ExpiredCredentialsInterceptor;
+import com.salesforce.multicloudj.common.aws.RefreshingSessionCredentialsProvider;
+import com.salesforce.multicloudj.common.retries.RetryConfig;
+import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * Verifies that the S3 client {@link AwsBlobStore} builds carries the pieces needed to keep working
+ * past the lifetime of the session credentials it was built with.
+ */
+public class AwsBlobStoreCredentialsRefreshTest {
+
+  @Test
+  public void testSupplierBackedSessionCredentialsAttachTheExpiredCredentialsInterceptor() {
+    AwsBlobStore.Builder builder = newBuilder(supplierBackedOverrider());
+
+    try (AwsBlobStore store = builder.build()) {
+      Assertions.assertInstanceOf(
+          RefreshingSessionCredentialsProvider.class,
+          builder.getS3Client().serviceClientConfiguration().credentialsProvider());
+      Assertions.assertTrue(
+          hasExpiredCredentialsInterceptor(builder.getS3Client()),
+          "a refreshing credentials provider must come with the invalidating interceptor");
+      Assertions.assertNotNull(store);
+    }
+  }
+
+  @Test
+  public void testValueBackedSessionCredentialsDoNotAttachTheExpiredCredentialsInterceptor() {
+    CredentialsOverrider overrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(new StsCredentials("key", "secret", "token"))
+            .build();
+    AwsBlobStore.Builder builder = newBuilder(overrider);
+
+    try (AwsBlobStore store = builder.build()) {
+      Assertions.assertFalse(hasExpiredCredentialsInterceptor(builder.getS3Client()));
+      Assertions.assertNotNull(store);
+    }
+  }
+
+  @Test
+  public void testRetryConfigurationSurvivesAlongsideTheExpiredCredentialsInterceptor() {
+    AwsBlobStore.Builder builder = newBuilder(supplierBackedOverrider());
+    builder.withRetryConfig(
+        RetryConfig.builder()
+            .mode(RetryConfig.Mode.FIXED)
+            .maxAttempts(4)
+            .fixedDelayMillis(10L)
+            .attemptTimeout(1_500L)
+            .totalTimeout(9_000L)
+            .build());
+
+    try (AwsBlobStore store = builder.build()) {
+      ClientOverrideConfiguration overrideConfiguration =
+          builder.getS3Client().serviceClientConfiguration().overrideConfiguration();
+      Assertions.assertTrue(hasExpiredCredentialsInterceptor(builder.getS3Client()));
+      Assertions.assertEquals(
+          Duration.ofMillis(1_500L), overrideConfiguration.apiCallAttemptTimeout().orElse(null));
+      Assertions.assertEquals(
+          Duration.ofMillis(9_000L), overrideConfiguration.apiCallTimeout().orElse(null));
+      Assertions.assertTrue(overrideConfiguration.retryStrategy().isPresent());
+      Assertions.assertNotNull(store);
+    }
+  }
+
+  private static AwsBlobStore.Builder newBuilder(CredentialsOverrider overrider) {
+    AwsBlobStore.Builder builder = new AwsBlobStore.Builder();
+    builder.withCredentialsOverrider(overrider);
+    builder.withBucket("bucket-1");
+    builder.withRegion("us-east-2");
+    return builder;
+  }
+
+  private static CredentialsOverrider supplierBackedOverrider() {
+    return new CredentialsOverrider.Builder(CredentialsType.SESSION)
+        .withSessionCredentialsSupplier(
+            () ->
+                new StsCredentials(
+                    "key", "secret", "token", Instant.now().plus(Duration.ofHours(1))))
+        .build();
+  }
+
+  private static boolean hasExpiredCredentialsInterceptor(S3Client s3Client) {
+    List<ExecutionInterceptor> interceptors =
+        s3Client.serviceClientConfiguration().overrideConfiguration().executionInterceptors();
+    return interceptors.stream().anyMatch(i -> i instanceof ExpiredCredentialsInterceptor);
+  }
+}

--- a/docstore/docstore-ali/src/main/java/com/salesforce/multicloudj/docstore/ali/TableStoreCredentialsProvider.java
+++ b/docstore/docstore-ali/src/main/java/com/salesforce/multicloudj/docstore/ali/TableStoreCredentialsProvider.java
@@ -2,6 +2,7 @@ package com.salesforce.multicloudj.docstore.ali;
 
 import com.alicloud.openservices.tablestore.core.auth.CredentialsProvider;
 import com.alicloud.openservices.tablestore.core.auth.CredentialsProviderFactory;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
 
@@ -14,6 +15,12 @@ public class TableStoreCredentialsProvider {
 
     switch (overrider.getType()) {
       case SESSION:
+        if (overrider.getSessionCredentialsSupplier() != null) {
+          throw new InvalidArgumentException(
+              "Session credentials supplied through withSessionCredentialsSupplier are not"
+                  + " supported by this provider. Supply them by value with"
+                  + " withSessionCredentials instead, and rebuild the client before they expire.");
+        }
         StsCredentials stsCredentials = overrider.getSessionCredentials();
         return CredentialsProviderFactory.newDefaultCredentialProvider(
             stsCredentials.getAccessKeyId(),

--- a/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/TableStoreCredentialsProviderTest.java
+++ b/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/TableStoreCredentialsProviderTest.java
@@ -1,0 +1,60 @@
+package com.salesforce.multicloudj.docstore.ali;
+
+import com.alicloud.openservices.tablestore.core.auth.CredentialsProvider;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TableStoreCredentialsProviderTest {
+
+  @Test
+  public void testSessionCredentialsProvider() {
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(new StsCredentials("key", "secret", "token"))
+            .build();
+
+    CredentialsProvider provider =
+        TableStoreCredentialsProvider.getCredentialsProvider(credentialsOverrider, "cn-shanghai");
+
+    Assertions.assertNotNull(provider);
+    Assertions.assertEquals("key", provider.getCredentials().getAccessKeyId());
+    Assertions.assertEquals("secret", provider.getCredentials().getAccessKeySecret());
+    Assertions.assertEquals("token", provider.getCredentials().getSecurityToken());
+  }
+
+  @Test
+  public void testSessionCredentialsSupplierIsRejected() {
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentialsSupplier(() -> new StsCredentials("key", "secret", "token"))
+            .build();
+
+    InvalidArgumentException failure =
+        Assertions.assertThrows(
+            InvalidArgumentException.class,
+            () ->
+                TableStoreCredentialsProvider.getCredentialsProvider(
+                    credentialsOverrider, "cn-shanghai"));
+    Assertions.assertTrue(
+        failure.getMessage().contains("withSessionCredentialsSupplier"),
+        "unexpected message: " + failure.getMessage());
+  }
+
+  @Test
+  public void testNullOverrider() {
+    Assertions.assertNull(
+        TableStoreCredentialsProvider.getCredentialsProvider(null, "cn-shanghai"));
+  }
+
+  @Test
+  public void testNullType() {
+    CredentialsOverrider credentialsOverrider = new CredentialsOverrider.Builder(null).build();
+
+    Assertions.assertNull(
+        TableStoreCredentialsProvider.getCredentialsProvider(credentialsOverrider, "cn-shanghai"));
+  }
+}

--- a/documentation/design/layers.md
+++ b/documentation/design/layers.md
@@ -49,6 +49,11 @@ String region = "us-east-1"
 // these are optional and ideally in prod, this is not required
 // since the k8s pods are set with default credentials and Substrate SDK
 // uses the default credentials in that case.
+//
+// A client holds one connection for its whole lifetime, so credentials passed by value
+// here are fixed for that lifetime and calls start failing once they expire. A client
+// that outlives its credentials should pass a callback via
+// withSessionCredentialsSupplier(...) instead, which the SDK re-invokes to renew them.
 StsCredentials credentials = new StsCredentials(
         "accessKeyId",
         "accessKeySecret",
@@ -71,6 +76,8 @@ UploadResponse response = client.upload(uploadRequest, "dummy-content");
 ```
 
 The above example demonstrates that the end user wants to open the client for the blob storage in the AWS substrate to the bucket "chameleon-java" in the region "us-east-1". The client is used to upload/write the blob in the bucket. 
+
+The credentials in this snippet are supplied by value purely to keep the example short. For the trade-off between passing credentials by value and passing a callback that the SDK re-invokes to renew them, see [Credentials and Long-Lived Clients](../guides/blobstore-guide.md#credentials-and-long-lived-clients).
 
 In this example, the portable fulfills all the requirements as discussed above:
 

--- a/documentation/guides/blobstore-guide.md
+++ b/documentation/guides/blobstore-guide.md
@@ -55,7 +55,7 @@ This client enables uploading, downloading, deleting, listing, copying, and mana
 | **Regional Support** | ⏱️ End of June'26 | ✅ Supported | ✅ Supported | Region-specific bucket operations |
 | **Endpoint Override** | ✅ Supported       | ✅ Supported | ✅ Supported | Custom endpoint configuration |
 | **Proxy Support** | ✅ Supported       | ✅ Supported | ✅ Supported | HTTP proxy configuration |
-| **Credentials Override** | ✅ Supported       | ✅ Supported | ✅ Supported | Custom credential providers via STS |
+| **Credentials Override** | ✅ Supported       | ✅ Supported | ✅ Supported | Custom credential providers via STS. See [Credentials and Long-Lived Clients](#credentials-and-long-lived-clients) |
 
 ### Provider-Specific Notes
 
@@ -84,6 +84,69 @@ bucketClient = BucketClient.builder("aws")
     .withProxyEndpoint(proxy)
     .build();
 ```
+
+---
+
+## Credentials and Long-Lived Clients
+
+A `BucketClient` holds a single underlying cloud connection for its whole lifetime. How you supply credentials therefore decides whether a client that outlives its credentials keeps working.
+
+### Prefer the default credential chain
+
+When the process already has an identity attached, such as a Kubernetes pod or a VM instance, supply no `CredentialsOverrider` at all. The cloud SDK's default credential chain then resolves and renews credentials on its own, and this remains the recommendation for those environments.
+
+```java
+BucketClient bucketClient = BucketClient.builder("aws")
+    .withRegion("us-west-2")
+    .withBucket("my-bucket")
+    .build();
+```
+
+### Session credentials supplied by value are fixed
+
+`withSessionCredentials(...)` freezes one set of credentials for the client's entire lifetime. That is fine for a client you build, use and discard. A client cached for the lifetime of the JVM, however, starts failing every call once the session token's TTL elapses, and only a restart recovers it.
+
+```java
+// Suitable only for a client that will not outlive these credentials.
+StsCredentials credentials = new StsCredentials(accessKeyId, accessKeySecret, sessionToken);
+CredentialsOverrider credsOverrider = new CredentialsOverrider.Builder(CredentialsType.SESSION)
+    .withSessionCredentials(credentials)
+    .build();
+```
+
+### Session credentials supplied by callback are renewed
+
+`withSessionCredentialsSupplier(...)` hands the SDK a `Supplier<StsCredentials>` instead of a value. The SDK invokes it again whenever the credentials it holds need renewing, so the client keeps working past the lifetime of any single set of credentials. When both forms are set on the same builder, the callback takes precedence.
+
+```java
+// secretBroker is your own component that holds currently valid session credentials.
+CredentialsOverrider credsOverrider = new CredentialsOverrider.Builder(CredentialsType.SESSION)
+    .withSessionCredentialsSupplier(() -> new StsCredentials(
+        secretBroker.accessKeyId(),
+        secretBroker.accessKeySecret(),
+        secretBroker.sessionToken(),
+        secretBroker.expiresAt()))
+    .build();
+
+BucketClient bucketClient = BucketClient.builder("aws")
+    .withRegion("us-west-2")
+    .withBucket("my-bucket")
+    .withCredentialsOverrider(credsOverrider)
+    .build();
+```
+
+Two things to get right in the callback:
+
+- **Populate the expiration.** The fourth `StsCredentials` constructor argument is a `java.time.Instant`, and supplying it lets renewal be scheduled ahead of expiry. Without it the SDK has nothing to schedule against: it treats the credentials as living for a fixed 15 minutes and renews on that cadence, so credentials that expire sooner will lapse before a renewal is due. The three-argument constructor leaves the expiration unset and remains supported.
+- **Be thread-safe and quick.** The callback runs on request threads. It is invoked once per renewal rather than once per request, but other threads can block on that invocation, so it should return promptly rather than performing a slow synchronous fetch.
+
+### Provider support for session credentials
+
+| Provider | By value | By callback |
+|----------|----------|-------------|
+| AWS | Supported | Supported |
+| GCP | Supported | Supported |
+| ALI | Supported | Not supported |
 
 ---
 

--- a/examples/src/main/java/com/salesforce/multicloudj/blob/Main.java
+++ b/examples/src/main/java/com/salesforce/multicloudj/blob/Main.java
@@ -1048,6 +1048,65 @@ public class Main {
     return builder.build();
   }
 
+  /**
+   * Builds a {@link BucketClient} whose session credentials are supplied through a callback instead
+   * of by value, which is what a client that is built once and kept for the lifetime of the process
+   * needs.
+   *
+   * <p>{@code withSessionCredentials(...)}, as used by {@link #getBucketClient(String)} above,
+   * freezes one set of credentials for the client's whole lifetime, so every call starts failing
+   * once the session token's TTL elapses. {@code withSessionCredentialsSupplier(...)} hands the SDK
+   * a callback that it invokes again whenever the credentials need renewing. When both are set on
+   * the same builder, the callback takes precedence.
+   *
+   * <p>Populate the expiration on {@link StsCredentials} so that renewal can be scheduled ahead of
+   * expiry; without it, renewal falls back to a fixed 15 minute interval.
+   */
+  public static BucketClient getBucketClientWithRenewableSessionCredentials(String provider) {
+    String bucketName = System.getProperty("bucket.name", System.getenv("BUCKET_NAME"));
+    String region = System.getProperty("bucket.region", System.getenv("BUCKET_REGION"));
+
+    if (bucketName == null || bucketName.trim().isEmpty()) {
+      throw new IllegalArgumentException(
+          "Bucket name must be provided via 'bucket.name' system property or 'BUCKET_NAME'"
+              + " environment variable");
+    }
+
+    CredentialsOverrider credsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentialsSupplier(Main::currentSessionCredentials)
+            .build();
+
+    BucketClient.BlobBuilder builder =
+        BucketClient.builder(provider)
+            .withBucket(bucketName)
+            .withCredentialsOverrider(credsOverrider);
+
+    if (region != null && !region.trim().isEmpty()) {
+      builder.withRegion(region);
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * The callback handed to {@code withSessionCredentialsSupplier(...)}. It runs on request threads,
+   * so it must be thread-safe and return promptly. The SDK invokes it once per renewal rather than
+   * once per request, but other threads can block on that invocation, so it should read from
+   * something already in memory rather than performing a slow synchronous fetch.
+   *
+   * <p>Reading the environment stands in for the caller's own credential source here. Replace it
+   * with whatever issues your session credentials, and return the expiration that source reports
+   * rather than a fabricated one.
+   */
+  private static StsCredentials currentSessionCredentials() {
+    return new StsCredentials(
+        System.getenv("AWS_ACCESS_KEY_ID"),
+        System.getenv("AWS_SECRET_ACCESS_KEY"),
+        System.getenv("AWS_SESSION_TOKEN"),
+        Instant.now().plus(Duration.ofHours(1)));
+  }
+
   private static AsyncBucketClient getAsyncBucketClient(String provider) {
     // Get configuration from environment variables or system properties
     String bucketName = System.getProperty("bucket.name", System.getenv("BUCKET_NAME"));

--- a/multicloudj-common-aws/pom.xml
+++ b/multicloudj-common-aws/pom.xml
@@ -25,6 +25,11 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/url-connection-client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/multicloudj-common-aws/src/main/java/com/salesforce/multicloudj/common/aws/CredentialsProvider.java
+++ b/multicloudj-common-aws/src/main/java/com/salesforce/multicloudj/common/aws/CredentialsProvider.java
@@ -1,8 +1,11 @@
 package com.salesforce.multicloudj.common.aws;
 
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -15,14 +18,38 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleWithWebIdentityCred
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 public class CredentialsProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(CredentialsProvider.class);
+
   public static AwsCredentialsProvider getCredentialsProvider(
       CredentialsOverrider overrider, Region region) {
     if (overrider == null || overrider.getType() == null) {
       return null;
     }
+    AwsCredentialsProvider provider = resolveCredentialsProvider(overrider, region);
+    String message =
+        "MultiCloudJ AWS credentials provider selected: credentialsType={}, providerClass={}";
+    String providerClass = provider == null ? "none" : provider.getClass().getName();
+    // Session credentials are the only type whose provider class tells an operator something they
+    // cannot infer, namely whether an expired-credentials report came from a client that renews
+    // credentials or one that holds them for its whole lifetime. The rest is debug-level noise.
+    if (overrider.getType() == CredentialsType.SESSION) {
+      log.info(message, overrider.getType(), providerClass);
+    } else {
+      log.debug(message, overrider.getType(), providerClass);
+    }
+    return provider;
+  }
+
+  private static AwsCredentialsProvider resolveCredentialsProvider(
+      CredentialsOverrider overrider, Region region) {
     switch (overrider.getType()) {
       case SESSION:
         {
+          if (overrider.getSessionCredentialsSupplier() != null) {
+            return new RefreshingSessionCredentialsProvider(
+                overrider.getSessionCredentialsSupplier());
+          }
           StsCredentials stsCredentials = overrider.getSessionCredentials();
           if (StringUtils.isBlank(stsCredentials.getSecurityToken())) {
             return StaticCredentialsProvider.create(

--- a/multicloudj-common-aws/src/main/java/com/salesforce/multicloudj/common/aws/ExpiredCredentialsInterceptor.java
+++ b/multicloudj-common-aws/src/main/java/com/salesforce/multicloudj/common/aws/ExpiredCredentialsInterceptor.java
@@ -1,0 +1,99 @@
+package com.salesforce.multicloudj.common.aws;
+
+import java.util.Objects;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+
+/**
+ * Invalidates a {@link RefreshingSessionCredentialsProvider} when a call fails because the
+ * credentials it signed with were rejected as expired, so that subsequent calls renew instead of
+ * signing with the same rejected credentials.
+ *
+ * <p>The call that failed is not recovered. Under the AWS SDK's SRA authentication flow an identity
+ * is resolved once per API call, by an interceptor that runs outside the retry loop, so every retry
+ * within a single API call re-signs with the identity resolved before the first attempt. Only the
+ * next API call picks up renewed credentials.
+ */
+public class ExpiredCredentialsInterceptor implements ExecutionInterceptor {
+
+  private static final Logger log = LoggerFactory.getLogger(ExpiredCredentialsInterceptor.class);
+
+  private static final Set<String> EXPIRED_CREDENTIALS_ERROR_CODES =
+      Set.of("ExpiredToken", "ExpiredTokenException", "InvalidToken", "TokenRefreshRequired");
+
+  /** Bounds the cause walk in case an exception chain is cyclic. */
+  private static final int MAX_CAUSE_DEPTH = 10;
+
+  private final RefreshingSessionCredentialsProvider credentialsProvider;
+
+  public ExpiredCredentialsInterceptor(RefreshingSessionCredentialsProvider credentialsProvider) {
+    this.credentialsProvider =
+        Objects.requireNonNull(credentialsProvider, "credentialsProvider must not be null");
+  }
+
+  /**
+   * Registers an interceptor on {@code clientBuilder} when {@code credentialsProvider} supports
+   * invalidation, and does nothing otherwise.
+   *
+   * <p>Call this after every other override-configuration change on the same builder: {@link
+   * SdkClientBuilder#overrideConfiguration(java.util.function.Consumer)} builds a fresh
+   * configuration and replaces whatever the builder already held, so a later call of that form
+   * would drop this interceptor.
+   *
+   * @param clientBuilder the client builder to register on
+   * @param credentialsProvider the provider the client is being built with, may be {@code null}
+   */
+  public static void registerIfRefreshable(
+      SdkClientBuilder<?, ?> clientBuilder, AwsCredentialsProvider credentialsProvider) {
+    if (!(credentialsProvider instanceof RefreshingSessionCredentialsProvider)) {
+      return;
+    }
+    ExpiredCredentialsInterceptor interceptor =
+        new ExpiredCredentialsInterceptor(
+            (RefreshingSessionCredentialsProvider) credentialsProvider);
+    ClientOverrideConfiguration existing = clientBuilder.overrideConfiguration();
+    ClientOverrideConfiguration.Builder configuration =
+        existing == null ? ClientOverrideConfiguration.builder() : existing.toBuilder();
+    clientBuilder.overrideConfiguration(
+        configuration.addExecutionInterceptor(interceptor).build());
+  }
+
+  @Override
+  public void onExecutionFailure(
+      Context.FailedExecution context, ExecutionAttributes executionAttributes) {
+    String errorCode = expiredCredentialsErrorCode(context.exception());
+    if (errorCode == null) {
+      return;
+    }
+    log.info(
+        "MultiCloudJ AWS call was rejected with errorCode={}; discarding the cached session"
+            + " credentials so the next call renews them. The failed call is not retried with"
+            + " renewed credentials.",
+        errorCode);
+    credentialsProvider.invalidate();
+  }
+
+  private static String expiredCredentialsErrorCode(Throwable failure) {
+    Throwable cause = failure;
+    for (int depth = 0; cause != null && depth < MAX_CAUSE_DEPTH; depth++) {
+      if (cause instanceof AwsServiceException) {
+        AwsServiceException serviceException = (AwsServiceException) cause;
+        if (serviceException.awsErrorDetails() != null
+            && EXPIRED_CREDENTIALS_ERROR_CODES.contains(
+                serviceException.awsErrorDetails().errorCode())) {
+          return serviceException.awsErrorDetails().errorCode();
+        }
+      }
+      cause = cause.getCause();
+    }
+    return null;
+  }
+}

--- a/multicloudj-common-aws/src/main/java/com/salesforce/multicloudj/common/aws/RefreshingSessionCredentialsProvider.java
+++ b/multicloudj-common-aws/src/main/java/com/salesforce/multicloudj/common/aws/RefreshingSessionCredentialsProvider.java
@@ -1,0 +1,247 @@
+package com.salesforce.multicloudj.common.aws;
+
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+import software.amazon.awssdk.utils.cache.CachedSupplier;
+import software.amazon.awssdk.utils.cache.RefreshResult;
+
+/**
+ * An {@link AwsCredentialsProvider} that renews caller-supplied session credentials in place, so
+ * that a client kept for the lifetime of a JVM keeps working after the credentials it was built
+ * with expire.
+ *
+ * <p>Credentials are held in a {@link CachedSupplier}, the same primitive the AWS SDK's own
+ * refreshable credentials providers are built on. It gives two renewal tiers: at the prefetch time
+ * a single caller renews while every other caller keeps using the credentials already cached, and
+ * at the stale time all callers block on one renewal. Renewal is serialised on a lock that callers
+ * wait five seconds for and then proceed without, so a supplier that can take longer than five
+ * seconds may be invoked concurrently. Suppliers should return well inside that window.
+ *
+ * <p>Renewal is scheduled from {@link StsCredentials#getExpiration()}. When the supplier declares
+ * no expiration there is nothing to schedule against, so credentials are renewed every {@link
+ * #DEFAULT_REFRESH_INTERVAL} instead. Callers that can declare an expiration should do so, because
+ * interval-based renewal cannot guarantee that a renewal happens before the credentials lapse.
+ *
+ * <p>Suppliers are invoked no more often than {@link #DEFAULT_MINIMUM_REFRESH_INTERVAL}, which
+ * bounds the load placed on a supplier that keeps returning credentials that have already expired
+ * or that expire sooner than the renewal windows above.
+ *
+ * <p>{@link #invalidate()} covers credentials the service rejects before the expiration the
+ * supplier reported. Nothing invokes it on its own; it is driven by {@link
+ * ExpiredCredentialsInterceptor}, which only the blob clients register. Every other service built
+ * on this provider gets expiration-driven renewal but no failure-driven invalidation.
+ *
+ * <p>This class is thread-safe.
+ */
+public class RefreshingSessionCredentialsProvider
+    implements AwsCredentialsProvider, SdkAutoCloseable {
+
+  /** How long before expiry all callers block on a renewal. */
+  public static final Duration DEFAULT_STALE_TIME = Duration.ofMinutes(1);
+
+  /** How long before expiry a single caller renews on behalf of the others. */
+  public static final Duration DEFAULT_PREFETCH_TIME = Duration.ofMinutes(5);
+
+  /** How often credentials are renewed when the supplier declares no expiration. */
+  public static final Duration DEFAULT_REFRESH_INTERVAL = Duration.ofMinutes(15);
+
+  /** The shortest interval permitted between two supplier invocations. */
+  public static final Duration DEFAULT_MINIMUM_REFRESH_INTERVAL = Duration.ofSeconds(1);
+
+  private static final String CACHED_VALUE_NAME = "multicloudj-session-credentials";
+
+  private final Supplier<StsCredentials> credentialsSupplier;
+  private final Duration staleTime;
+  private final Duration prefetchTime;
+  private final Duration refreshInterval;
+  private final Duration minimumRefreshInterval;
+  private final AtomicReference<CachedSupplier<AwsSessionCredentials>> cache;
+  private final AtomicReference<Instant> lastInvalidation = new AtomicReference<>(Instant.MIN);
+
+  /**
+   * Creates a provider over {@code credentialsSupplier} using the default renewal windows.
+   *
+   * @param credentialsSupplier callback returning currently valid session credentials
+   */
+  public RefreshingSessionCredentialsProvider(Supplier<StsCredentials> credentialsSupplier) {
+    this(builder().credentialsSupplier(credentialsSupplier));
+  }
+
+  private RefreshingSessionCredentialsProvider(Builder builder) {
+    this.credentialsSupplier =
+        Objects.requireNonNull(builder.credentialsSupplier, "credentialsSupplier must not be null");
+    this.staleTime = builder.staleTime;
+    this.prefetchTime = builder.prefetchTime;
+    this.refreshInterval = builder.refreshInterval;
+    this.minimumRefreshInterval = builder.minimumRefreshInterval;
+    this.cache = new AtomicReference<>(newCache());
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public AwsCredentials resolveCredentials() {
+    return cache.get().get();
+  }
+
+  /**
+   * Discards the cached credentials so that the next {@link #resolveCredentials()} invokes the
+   * supplier again.
+   *
+   * <p>Renewal windows are derived from what the supplier reports, so credentials that the service
+   * rejects can still look fresh to this provider. This is the escape hatch for that case.
+   *
+   * <p>Discarded credentials are unconditionally stale, which bypasses the renewal windows
+   * entirely. Invalidation is therefore honoured at most once per {@code minimumRefreshInterval};
+   * without that bound, a credential source that keeps handing back credentials the service
+   * rejects would be invoked once per failed request.
+   */
+  public void invalidate() {
+    Instant now = Instant.now();
+    Instant previous = lastInvalidation.get();
+    if (Duration.between(previous, now).compareTo(minimumRefreshInterval) < 0
+        || !lastInvalidation.compareAndSet(previous, now)) {
+      return;
+    }
+    CachedSupplier<AwsSessionCredentials> discarded = cache.get();
+    CachedSupplier<AwsSessionCredentials> replacement = newCache();
+    if (cache.compareAndSet(discarded, replacement)) {
+      discarded.close();
+    } else {
+      replacement.close();
+    }
+  }
+
+  /**
+   * Releases the resources held by the cached credentials. With the default configuration renewal
+   * happens on the calling thread and there is nothing to release, so this neither stops renewal
+   * nor makes the provider unusable: a later {@link #resolveCredentials()} invokes the supplier
+   * again.
+   */
+  @Override
+  public void close() {
+    cache.get().close();
+  }
+
+  @Override
+  public String toString() {
+    return "RefreshingSessionCredentialsProvider";
+  }
+
+  private CachedSupplier<AwsSessionCredentials> newCache() {
+    return CachedSupplier.builder(this::refresh).cachedValueName(CACHED_VALUE_NAME).build();
+  }
+
+  private RefreshResult<AwsSessionCredentials> refresh() {
+    StsCredentials credentials = credentialsSupplier.get();
+    if (credentials == null) {
+      throw new IllegalStateException(
+          "Session credentials supplier returned null; it must return valid session credentials.");
+    }
+
+    AwsSessionCredentials.Builder resolved =
+        AwsSessionCredentials.builder()
+            .accessKeyId(credentials.getAccessKeyId())
+            .secretAccessKey(credentials.getAccessKeySecret())
+            .sessionToken(credentials.getSecurityToken());
+
+    Instant expiration = credentials.getExpiration();
+    if (expiration != null) {
+      resolved.expirationTime(expiration);
+    }
+
+    Instant now = Instant.now();
+    Instant earliestRenewal = now.plus(minimumRefreshInterval);
+    Instant staleAt;
+    Instant prefetchAt;
+    if (expiration == null) {
+      staleAt = now.plus(refreshInterval);
+      prefetchAt = staleAt;
+    } else {
+      staleAt = expiration.minus(staleTime);
+      prefetchAt = expiration.minus(prefetchTime);
+      if (staleAt.isBefore(earliestRenewal)) {
+        staleAt = earliestRenewal;
+      }
+      if (prefetchAt.isBefore(earliestRenewal)) {
+        // Renewal windows that fall in the past would make every caller renew; deferring the
+        // prefetch to the stale boundary keeps the supplier invocation rate bounded.
+        prefetchAt = staleAt;
+      }
+    }
+
+    return RefreshResult.builder(resolved.build())
+        .staleTime(staleAt)
+        .prefetchTime(prefetchAt)
+        .build();
+  }
+
+  public static class Builder {
+    private Supplier<StsCredentials> credentialsSupplier;
+    private Duration staleTime = DEFAULT_STALE_TIME;
+    private Duration prefetchTime = DEFAULT_PREFETCH_TIME;
+    private Duration refreshInterval = DEFAULT_REFRESH_INTERVAL;
+    private Duration minimumRefreshInterval = DEFAULT_MINIMUM_REFRESH_INTERVAL;
+
+    public Builder credentialsSupplier(Supplier<StsCredentials> credentialsSupplier) {
+      this.credentialsSupplier = credentialsSupplier;
+      return this;
+    }
+
+    public Builder staleTime(Duration staleTime) {
+      this.staleTime = staleTime;
+      return this;
+    }
+
+    public Builder prefetchTime(Duration prefetchTime) {
+      this.prefetchTime = prefetchTime;
+      return this;
+    }
+
+    public Builder refreshInterval(Duration refreshInterval) {
+      this.refreshInterval = refreshInterval;
+      return this;
+    }
+
+    public Builder minimumRefreshInterval(Duration minimumRefreshInterval) {
+      this.minimumRefreshInterval = minimumRefreshInterval;
+      return this;
+    }
+
+    public RefreshingSessionCredentialsProvider build() {
+      requireNonNegative(staleTime, "staleTime");
+      requireNonNegative(prefetchTime, "prefetchTime");
+      requireNonNegative(refreshInterval, "refreshInterval");
+      requireNonNegative(minimumRefreshInterval, "minimumRefreshInterval");
+      // A prefetch window inside the stale window puts the prefetch instant after the stale
+      // instant, which retires the single-caller renewal tier without saying so.
+      if (prefetchTime.compareTo(staleTime) < 0) {
+        throw new IllegalArgumentException(
+            "prefetchTime must not be shorter than staleTime, but prefetchTime="
+                + prefetchTime
+                + " and staleTime="
+                + staleTime);
+      }
+      return new RefreshingSessionCredentialsProvider(this);
+    }
+
+    private static void requireNonNegative(Duration value, String name) {
+      if (value == null) {
+        throw new IllegalArgumentException(name + " must not be null");
+      }
+      if (value.isNegative()) {
+        throw new IllegalArgumentException(name + " must not be negative, but was " + value);
+      }
+    }
+  }
+}

--- a/multicloudj-common-aws/src/test/java/com/salesforce/multicloudj/common/aws/CredentialsProviderTest.java
+++ b/multicloudj-common-aws/src/test/java/com/salesforce/multicloudj/common/aws/CredentialsProviderTest.java
@@ -3,10 +3,14 @@ package com.salesforce.multicloudj.common.aws;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.CredentialsType;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.time.Duration;
+import java.time.Instant;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
@@ -115,5 +119,73 @@ public class CredentialsProviderTest {
         CredentialsProvider.getCredentialsProvider(credentialsOverrider, Region.AF_SOUTH_1);
     Assertions.assertNotNull(awsCredsProvider);
     Assertions.assertInstanceOf(StaticCredentialsProvider.class, awsCredsProvider);
+  }
+
+  /**
+   * Pins the behaviour of session credentials supplied by value: the provider hands out one
+   * immutable set of credentials with no expiry for the whole life of the client, and never
+   * consults the caller again. Callers that need renewal opt in with a supplier.
+   */
+  @Test
+  public void testSessionCredentialsByValueYieldANonRefreshingProvider() {
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(new StsCredentials("key", "secret", "token"))
+            .build();
+
+    AwsCredentialsProvider awsCredsProvider =
+        CredentialsProvider.getCredentialsProvider(credentialsOverrider, Region.AF_SOUTH_1);
+
+    Assertions.assertInstanceOf(StaticCredentialsProvider.class, awsCredsProvider);
+    Assertions.assertFalse(awsCredsProvider instanceof RefreshingSessionCredentialsProvider);
+
+    AwsCredentials first = awsCredsProvider.resolveCredentials();
+    AwsCredentials second = awsCredsProvider.resolveCredentials();
+    Assertions.assertSame(first, second);
+    Assertions.assertEquals("key", first.accessKeyId());
+    Assertions.assertEquals("token", ((AwsSessionCredentials) first).sessionToken());
+    Assertions.assertTrue(first.expirationTime().isEmpty());
+  }
+
+  @Test
+  public void testSessionCredentialsSupplierYieldsARefreshingProvider() {
+    Instant expiration = Instant.now().plus(Duration.ofHours(1));
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentialsSupplier(
+                () -> new StsCredentials("key", "secret", "token", expiration))
+            .build();
+
+    AwsCredentialsProvider awsCredsProvider =
+        CredentialsProvider.getCredentialsProvider(credentialsOverrider, Region.AF_SOUTH_1);
+
+    Assertions.assertInstanceOf(RefreshingSessionCredentialsProvider.class, awsCredsProvider);
+    AwsSessionCredentials resolved =
+        (AwsSessionCredentials) awsCredsProvider.resolveCredentials();
+    Assertions.assertEquals("key", resolved.accessKeyId());
+    Assertions.assertEquals("secret", resolved.secretAccessKey());
+    Assertions.assertEquals("token", resolved.sessionToken());
+    Assertions.assertEquals(expiration, resolved.expirationTime().orElse(null));
+  }
+
+  @Test
+  public void testSessionCredentialsSupplierTakesPrecedenceOverSessionCredentialsByValue() {
+    CredentialsOverrider credentialsOverrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(new StsCredentials("staleKey", "staleSecret", "staleToken"))
+            .withSessionCredentialsSupplier(
+                () ->
+                    new StsCredentials(
+                        "freshKey",
+                        "freshSecret",
+                        "freshToken",
+                        Instant.now().plus(Duration.ofHours(1))))
+            .build();
+
+    AwsCredentialsProvider awsCredsProvider =
+        CredentialsProvider.getCredentialsProvider(credentialsOverrider, Region.AF_SOUTH_1);
+
+    Assertions.assertInstanceOf(RefreshingSessionCredentialsProvider.class, awsCredsProvider);
+    Assertions.assertEquals("freshKey", awsCredsProvider.resolveCredentials().accessKeyId());
   }
 }

--- a/multicloudj-common-aws/src/test/java/com/salesforce/multicloudj/common/aws/ExpiredCredentialsInterceptorTest.java
+++ b/multicloudj-common-aws/src/test/java/com/salesforce/multicloudj/common/aws/ExpiredCredentialsInterceptorTest.java
@@ -1,0 +1,201 @@
+package com.salesforce.multicloudj.common.aws;
+
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+public class ExpiredCredentialsInterceptorTest {
+
+  private static final List<String> EXPIRED_CREDENTIALS_ERROR_CODES =
+      List.of("ExpiredToken", "ExpiredTokenException", "InvalidToken", "TokenRefreshRequired");
+
+  @Test
+  public void testInvalidatesForEveryExpiredCredentialsErrorCode() {
+    for (String errorCode : EXPIRED_CREDENTIALS_ERROR_CODES) {
+      AtomicInteger invocations = new AtomicInteger();
+      RefreshingSessionCredentialsProvider provider = refreshingProvider(invocations);
+      ExpiredCredentialsInterceptor interceptor = new ExpiredCredentialsInterceptor(provider);
+
+      Assertions.assertEquals(
+          "securityToken-1", sessionToken(provider.resolveCredentials()), errorCode);
+
+      interceptor.onExecutionFailure(
+          failedExecution(serviceException(errorCode)), new ExecutionAttributes());
+
+      Assertions.assertEquals(
+          "securityToken-2", sessionToken(provider.resolveCredentials()), errorCode);
+      Assertions.assertEquals(2, invocations.get(), errorCode);
+    }
+  }
+
+  @Test
+  public void testInvalidatesWhenTheExpiredCredentialsFailureIsWrapped() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider = refreshingProvider(invocations);
+    ExpiredCredentialsInterceptor interceptor = new ExpiredCredentialsInterceptor(provider);
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+
+    interceptor.onExecutionFailure(
+        failedExecution(new CompletionException(serviceException("ExpiredToken"))),
+        new ExecutionAttributes());
+
+    Assertions.assertEquals("securityToken-2", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(2, invocations.get());
+  }
+
+  @Test
+  public void testDoesNotInvalidateForAnUnrelatedErrorCode() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider = refreshingProvider(invocations);
+    ExpiredCredentialsInterceptor interceptor = new ExpiredCredentialsInterceptor(provider);
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+
+    interceptor.onExecutionFailure(
+        failedExecution(serviceException("NoSuchKey")), new ExecutionAttributes());
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(1, invocations.get());
+  }
+
+  @Test
+  public void testDoesNotInvalidateForAFailureThatIsNotAServiceException() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider = refreshingProvider(invocations);
+    ExpiredCredentialsInterceptor interceptor = new ExpiredCredentialsInterceptor(provider);
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+
+    interceptor.onExecutionFailure(
+        failedExecution(new IOException("connection reset")), new ExecutionAttributes());
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(1, invocations.get());
+  }
+
+  @Test
+  public void testDoesNotInvalidateForASuccessfulExecution() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider = refreshingProvider(invocations);
+    ExpiredCredentialsInterceptor interceptor = new ExpiredCredentialsInterceptor(provider);
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+
+    interceptor.afterExecution(
+        Mockito.mock(Context.AfterExecution.class), new ExecutionAttributes());
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(1, invocations.get());
+  }
+
+  @Test
+  public void testNullProviderIsRejected() {
+    Assertions.assertThrows(
+        NullPointerException.class, () -> new ExpiredCredentialsInterceptor(null));
+  }
+
+  @Test
+  public void testRegisterIfRefreshableSkipsANonRefreshingProvider() {
+    S3ClientBuilder clientBuilder = S3Client.builder();
+
+    ExpiredCredentialsInterceptor.registerIfRefreshable(
+        clientBuilder, StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "sec")));
+
+    Assertions.assertTrue(clientBuilder.overrideConfiguration().executionInterceptors().isEmpty());
+  }
+
+  @Test
+  public void testRegisterIfRefreshableSkipsANullProvider() {
+    S3ClientBuilder clientBuilder = S3Client.builder();
+
+    ExpiredCredentialsInterceptor.registerIfRefreshable(clientBuilder, null);
+
+    Assertions.assertTrue(clientBuilder.overrideConfiguration().executionInterceptors().isEmpty());
+  }
+
+  @Test
+  public void testRegisterIfRefreshablePreservesExistingOverrideConfiguration() {
+    S3ClientBuilder clientBuilder = S3Client.builder();
+    clientBuilder.overrideConfiguration(config -> config.apiCallTimeout(Duration.ofSeconds(7)));
+
+    ExpiredCredentialsInterceptor.registerIfRefreshable(
+        clientBuilder, refreshingProvider(new AtomicInteger()));
+
+    ClientOverrideConfiguration overrideConfiguration = clientBuilder.overrideConfiguration();
+    List<ExecutionInterceptor> interceptors = overrideConfiguration.executionInterceptors();
+    Assertions.assertEquals(1, interceptors.size());
+    Assertions.assertInstanceOf(ExpiredCredentialsInterceptor.class, interceptors.get(0));
+    Assertions.assertEquals(
+        Duration.ofSeconds(7), overrideConfiguration.apiCallTimeout().orElse(null));
+  }
+
+  /**
+   * Builders mocked in the provider modules' unit tests answer {@code null} from the
+   * override-configuration getter, which must not turn into a failure inside production code.
+   */
+  @Test
+  public void testRegisterIfRefreshableToleratesABuilderWithoutOverrideConfiguration() {
+    SdkClientBuilder<?, ?> clientBuilder = Mockito.mock(SdkClientBuilder.class);
+    ArgumentCaptor<ClientOverrideConfiguration> registered =
+        ArgumentCaptor.forClass(ClientOverrideConfiguration.class);
+
+    ExpiredCredentialsInterceptor.registerIfRefreshable(
+        clientBuilder, refreshingProvider(new AtomicInteger()));
+
+    Mockito.verify(clientBuilder).overrideConfiguration(registered.capture());
+    List<ExecutionInterceptor> interceptors = registered.getValue().executionInterceptors();
+    Assertions.assertEquals(1, interceptors.size());
+    Assertions.assertInstanceOf(ExpiredCredentialsInterceptor.class, interceptors.get(0));
+  }
+
+  private static RefreshingSessionCredentialsProvider refreshingProvider(
+      AtomicInteger invocations) {
+    return new RefreshingSessionCredentialsProvider(
+        () -> {
+          int invocation = invocations.incrementAndGet();
+          return new StsCredentials(
+              "accessKeyId-" + invocation,
+              "accessKeySecret-" + invocation,
+              "securityToken-" + invocation,
+              Instant.now().plus(Duration.ofHours(1)));
+        });
+  }
+
+  private static AwsServiceException serviceException(String errorCode) {
+    return AwsServiceException.builder()
+        .awsErrorDetails(AwsErrorDetails.builder().errorCode(errorCode).build())
+        .build();
+  }
+
+  private static Context.FailedExecution failedExecution(Throwable exception) {
+    Context.FailedExecution context = Mockito.mock(Context.FailedExecution.class);
+    Mockito.when(context.exception()).thenReturn(exception);
+    return context;
+  }
+
+  private static String sessionToken(AwsCredentials credentials) {
+    return ((AwsSessionCredentials) credentials).sessionToken();
+  }
+}

--- a/multicloudj-common-aws/src/test/java/com/salesforce/multicloudj/common/aws/RefreshingSessionCredentialsProviderTest.java
+++ b/multicloudj-common-aws/src/test/java/com/salesforce/multicloudj/common/aws/RefreshingSessionCredentialsProviderTest.java
@@ -1,0 +1,445 @@
+package com.salesforce.multicloudj.common.aws;
+
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+
+public class RefreshingSessionCredentialsProviderTest {
+
+  @Test
+  public void testResolvedCredentialsCarryTheSuppliedValues() {
+    Instant expiration = Instant.now().plus(Duration.ofHours(1));
+    RefreshingSessionCredentialsProvider provider =
+        new RefreshingSessionCredentialsProvider(
+            () -> new StsCredentials("key", "secret", "token", expiration));
+
+    AwsCredentials credentials = provider.resolveCredentials();
+
+    Assertions.assertInstanceOf(AwsSessionCredentials.class, credentials);
+    AwsSessionCredentials sessionCredentials = (AwsSessionCredentials) credentials;
+    Assertions.assertEquals("key", sessionCredentials.accessKeyId());
+    Assertions.assertEquals("secret", sessionCredentials.secretAccessKey());
+    Assertions.assertEquals("token", sessionCredentials.sessionToken());
+    Assertions.assertEquals(expiration, sessionCredentials.expirationTime().orElse(null));
+  }
+
+  @Test
+  public void testSupplierIsNotInvokedUntilCredentialsAreResolved() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        new RefreshingSessionCredentialsProvider(
+            countingSupplier(invocations, Duration.ofHours(1)));
+
+    Assertions.assertEquals(0, invocations.get());
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(1, invocations.get());
+  }
+
+  @Test
+  public void testRepeatedResolvesWithinFreshnessWindowInvokeSupplierOnce() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        new RefreshingSessionCredentialsProvider(
+            countingSupplier(invocations, Duration.ofHours(1)));
+
+    for (int i = 0; i < 10; i++) {
+      Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    }
+
+    Assertions.assertEquals(1, invocations.get());
+  }
+
+  @Test
+  public void testStaleCredentialsAreRenewedAndTheNewTokenIsReturned() throws Exception {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        RefreshingSessionCredentialsProvider.builder()
+            .credentialsSupplier(countingSupplier(invocations, Duration.ofMillis(300)))
+            .staleTime(Duration.ZERO)
+            .prefetchTime(Duration.ZERO)
+            .minimumRefreshInterval(Duration.ofMillis(1))
+            .build();
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(1, invocations.get());
+
+    Thread.sleep(400);
+
+    Assertions.assertEquals("securityToken-2", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(2, invocations.get());
+  }
+
+  @Test
+  public void testConcurrentResolvesOnAStaleCacheInvokeSupplierOnce() throws Exception {
+    int threads = 16;
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        new RefreshingSessionCredentialsProvider(
+            () -> {
+              int invocation = invocations.incrementAndGet();
+              try {
+                Thread.sleep(100);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+              }
+              return new StsCredentials(
+                  "accessKeyId-" + invocation,
+                  "accessKeySecret-" + invocation,
+                  "securityToken-" + invocation,
+                  Instant.now().plus(Duration.ofHours(1)));
+            });
+
+    CountDownLatch startGate = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    try {
+      List<Future<String>> resolved = new ArrayList<>();
+      for (int i = 0; i < threads; i++) {
+        resolved.add(
+            pool.submit(
+                () -> {
+                  startGate.await();
+                  return sessionToken(provider.resolveCredentials());
+                }));
+      }
+      startGate.countDown();
+
+      for (Future<String> token : resolved) {
+        Assertions.assertEquals("securityToken-1", token.get(30, TimeUnit.SECONDS));
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+
+    Assertions.assertEquals(1, invocations.get());
+  }
+
+  @Test
+  public void testInvalidateForcesTheNextResolveToReinvokeTheSupplier() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        new RefreshingSessionCredentialsProvider(
+            countingSupplier(invocations, Duration.ofHours(1)));
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(1, invocations.get());
+
+    provider.invalidate();
+
+    Assertions.assertEquals("securityToken-2", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(2, invocations.get());
+  }
+
+  @Test
+  public void testRepeatedInvalidationWithinTheMinimumRefreshIntervalIsHonouredOnce() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        RefreshingSessionCredentialsProvider.builder()
+            .credentialsSupplier(countingSupplier(invocations, Duration.ofHours(1)))
+            .minimumRefreshInterval(Duration.ofHours(1))
+            .build();
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+
+    provider.invalidate();
+    Assertions.assertEquals("securityToken-2", sessionToken(provider.resolveCredentials()));
+
+    for (int i = 0; i < 100; i++) {
+      provider.invalidate();
+      Assertions.assertEquals("securityToken-2", sessionToken(provider.resolveCredentials()));
+    }
+    Assertions.assertEquals(
+        2,
+        invocations.get(),
+        "a credential source the service keeps rejecting must not be invoked once per failure");
+  }
+
+  @Test
+  public void testInvalidationIsHonouredAgainOnceTheMinimumRefreshIntervalElapses()
+      throws Exception {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        RefreshingSessionCredentialsProvider.builder()
+            .credentialsSupplier(countingSupplier(invocations, Duration.ofHours(1)))
+            .minimumRefreshInterval(Duration.ofMillis(1))
+            .build();
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+
+    provider.invalidate();
+    Assertions.assertEquals("securityToken-2", sessionToken(provider.resolveCredentials()));
+
+    Thread.sleep(50);
+
+    provider.invalidate();
+    Assertions.assertEquals("securityToken-3", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(3, invocations.get());
+  }
+
+  @Test
+  public void testConcurrentInvalidationIsHonouredOnce() throws Exception {
+    int threads = 16;
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        RefreshingSessionCredentialsProvider.builder()
+            .credentialsSupplier(countingSupplier(invocations, Duration.ofHours(1)))
+            .minimumRefreshInterval(Duration.ofHours(1))
+            .build();
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+
+    CountDownLatch startGate = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    try {
+      List<Future<?>> invalidations = new ArrayList<>();
+      for (int i = 0; i < threads; i++) {
+        invalidations.add(
+            pool.submit(
+                () -> {
+                  startGate.await();
+                  provider.invalidate();
+                  return null;
+                }));
+      }
+      startGate.countDown();
+      for (Future<?> invalidation : invalidations) {
+        invalidation.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+
+    Assertions.assertEquals("securityToken-2", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(2, invocations.get());
+  }
+
+  @Test
+  public void testNullExpirationCachesForTheRefreshInterval() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        new RefreshingSessionCredentialsProvider(countingSupplier(invocations, null));
+
+    AwsSessionCredentials credentials = (AwsSessionCredentials) provider.resolveCredentials();
+    Assertions.assertEquals("securityToken-1", credentials.sessionToken());
+    Assertions.assertTrue(credentials.expirationTime().isEmpty());
+
+    for (int i = 0; i < 10; i++) {
+      Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    }
+    Assertions.assertEquals(1, invocations.get());
+  }
+
+  @Test
+  public void testNullExpirationIsRenewedOnceTheRefreshIntervalElapses() throws Exception {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        RefreshingSessionCredentialsProvider.builder()
+            .credentialsSupplier(countingSupplier(invocations, null))
+            .refreshInterval(Duration.ofMillis(200))
+            .build();
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(1, invocations.get());
+
+    Thread.sleep(300);
+
+    Assertions.assertEquals("securityToken-2", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(2, invocations.get());
+  }
+
+  @Test
+  public void testAlreadyExpiredCredentialsMakeProgressWithoutReinvokingTheSupplierPerResolve()
+      throws Exception {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        RefreshingSessionCredentialsProvider.builder()
+            .credentialsSupplier(countingSupplier(invocations, Duration.ofMinutes(-1)))
+            .minimumRefreshInterval(Duration.ofSeconds(2))
+            .build();
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+
+    for (int i = 0; i < 100; i++) {
+      Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    }
+    Assertions.assertEquals(
+        1,
+        invocations.get(),
+        "renewal windows derived from a past expiration must not make every resolve renew");
+
+    Thread.sleep(2_300);
+
+    Assertions.assertEquals("securityToken-2", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(2, invocations.get());
+  }
+
+  @Test
+  public void testExpirationNearerThanTheStaleWindowStillCaches() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        RefreshingSessionCredentialsProvider.builder()
+            .credentialsSupplier(countingSupplier(invocations, Duration.ofSeconds(5)))
+            .minimumRefreshInterval(Duration.ofSeconds(2))
+            .build();
+
+    for (int i = 0; i < 100; i++) {
+      Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    }
+    Assertions.assertEquals(1, invocations.get());
+  }
+
+  @Test
+  public void testSupplierReturningNullThrowsAndLeavesTheProviderUsable() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        new RefreshingSessionCredentialsProvider(
+            () -> {
+              if (invocations.incrementAndGet() == 1) {
+                return null;
+              }
+              return new StsCredentials(
+                  "key", "secret", "token", Instant.now().plus(Duration.ofHours(1)));
+            });
+
+    IllegalStateException failure =
+        Assertions.assertThrows(IllegalStateException.class, provider::resolveCredentials);
+    Assertions.assertTrue(
+        failure.getMessage().contains("returned null"),
+        "unexpected message: " + failure.getMessage());
+
+    Assertions.assertEquals("token", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(2, invocations.get());
+  }
+
+  @Test
+  public void testSupplierThrowingPropagatesAndLeavesTheProviderUsable() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        new RefreshingSessionCredentialsProvider(
+            () -> {
+              if (invocations.incrementAndGet() == 1) {
+                throw new IllegalArgumentException("no credentials available");
+              }
+              return new StsCredentials(
+                  "key", "secret", "token", Instant.now().plus(Duration.ofHours(1)));
+            });
+
+    IllegalArgumentException failure =
+        Assertions.assertThrows(IllegalArgumentException.class, provider::resolveCredentials);
+    Assertions.assertEquals("no credentials available", failure.getMessage());
+
+    Assertions.assertEquals("token", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(2, invocations.get());
+  }
+
+  @Test
+  public void testCloseLeavesTheProviderUsable() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        new RefreshingSessionCredentialsProvider(
+            countingSupplier(invocations, Duration.ofHours(1)));
+
+    provider.close();
+    provider.close();
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+    Assertions.assertEquals(1, invocations.get());
+  }
+
+  @Test
+  public void testNullSupplierIsRejected() {
+    Assertions.assertThrows(
+        NullPointerException.class, () -> new RefreshingSessionCredentialsProvider(null));
+  }
+
+  @Test
+  public void testNullDurationsAreRejected() {
+    assertBuildRejects(builder -> builder.staleTime(null), "staleTime must not be null");
+    assertBuildRejects(builder -> builder.prefetchTime(null), "prefetchTime must not be null");
+    assertBuildRejects(
+        builder -> builder.refreshInterval(null), "refreshInterval must not be null");
+    assertBuildRejects(
+        builder -> builder.minimumRefreshInterval(null), "minimumRefreshInterval must not be null");
+  }
+
+  @Test
+  public void testNegativeDurationsAreRejected() {
+    Duration negative = Duration.ofSeconds(-1);
+    assertBuildRejects(builder -> builder.staleTime(negative), "staleTime must not be negative");
+    assertBuildRejects(
+        builder -> builder.prefetchTime(negative), "prefetchTime must not be negative");
+    assertBuildRejects(
+        builder -> builder.refreshInterval(negative), "refreshInterval must not be negative");
+    assertBuildRejects(
+        builder -> builder.minimumRefreshInterval(negative),
+        "minimumRefreshInterval must not be negative");
+  }
+
+  @Test
+  public void testPrefetchTimeShorterThanStaleTimeIsRejected() {
+    assertBuildRejects(
+        builder -> builder.staleTime(Duration.ofMinutes(5)).prefetchTime(Duration.ofMinutes(1)),
+        "prefetchTime must not be shorter than staleTime");
+  }
+
+  @Test
+  public void testPrefetchTimeEqualToStaleTimeIsAccepted() {
+    AtomicInteger invocations = new AtomicInteger();
+    RefreshingSessionCredentialsProvider provider =
+        RefreshingSessionCredentialsProvider.builder()
+            .credentialsSupplier(countingSupplier(invocations, Duration.ofHours(1)))
+            .staleTime(Duration.ofMinutes(5))
+            .prefetchTime(Duration.ofMinutes(5))
+            .build();
+
+    Assertions.assertEquals("securityToken-1", sessionToken(provider.resolveCredentials()));
+  }
+
+  private static void assertBuildRejects(
+      UnaryOperator<RefreshingSessionCredentialsProvider.Builder> configuration,
+      String expectedMessage) {
+    RefreshingSessionCredentialsProvider.Builder builder =
+        configuration.apply(
+            RefreshingSessionCredentialsProvider.builder()
+                .credentialsSupplier(() -> new StsCredentials("key", "secret", "token")));
+
+    IllegalArgumentException failure =
+        Assertions.assertThrows(IllegalArgumentException.class, builder::build);
+    Assertions.assertTrue(
+        failure.getMessage().startsWith(expectedMessage),
+        "unexpected message: " + failure.getMessage());
+  }
+
+  private static Supplier<StsCredentials> countingSupplier(
+      AtomicInteger invocations, Duration validity) {
+    return () -> {
+      int invocation = invocations.incrementAndGet();
+      return new StsCredentials(
+          "accessKeyId-" + invocation,
+          "accessKeySecret-" + invocation,
+          "securityToken-" + invocation,
+          validity == null ? null : Instant.now().plus(validity));
+    };
+  }
+
+  private static String sessionToken(AwsCredentials credentials) {
+    return ((AwsSessionCredentials) credentials).sessionToken();
+  }
+}

--- a/multicloudj-common-gcp/src/main/java/com/salesforce/multicloudj/common/gcp/GcpCredentialsProvider.java
+++ b/multicloudj-common-gcp/src/main/java/com/salesforce/multicloudj/common/gcp/GcpCredentialsProvider.java
@@ -8,12 +8,17 @@ import com.google.auth.oauth2.IdentityPoolCredentials;
 import com.google.auth.oauth2.ImpersonatedCredentials;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GcpCredentialsProvider {
+
+  private static final Logger logger = LoggerFactory.getLogger(GcpCredentialsProvider.class);
 
   // Google Security Token Service endpoint used to exchange a federated subject token
   // for a short-lived GCP access token under Workload Identity Federation.
@@ -26,13 +31,27 @@ public class GcpCredentialsProvider {
     if (overrider == null || overrider.getType() == null) {
       return null;
     }
+    Credentials credentials = resolveCredentials(overrider);
+    if (credentials != null) {
+      String message = "Resolved GCP credentials. credentialsType={}, credentialsClass={}";
+      String credentialsClass = credentials.getClass().getName();
+      // Session credentials are the only type whose credentials class tells an operator something
+      // they cannot infer, namely whether an expired-credentials report came from credentials that
+      // renew themselves or ones fixed for the client's whole lifetime. The rest is debug-level
+      // noise.
+      if (overrider.getType() == CredentialsType.SESSION) {
+        logger.info(message, overrider.getType(), credentialsClass);
+      } else {
+        logger.debug(message, overrider.getType(), credentialsClass);
+      }
+    }
+    return credentials;
+  }
+
+  private static Credentials resolveCredentials(CredentialsOverrider overrider) {
     switch (overrider.getType()) {
       case SESSION:
-        StsCredentials stsCredentials = overrider.getSessionCredentials();
-        return GoogleCredentials.newBuilder()
-            .setAccessToken(
-                AccessToken.newBuilder().setTokenValue(stsCredentials.getSecurityToken()).build())
-            .build();
+        return buildSessionCredentials(overrider);
       case ASSUME_ROLE:
         GoogleCredentials sourceCredentials = null;
         try {
@@ -71,6 +90,31 @@ public class GcpCredentialsProvider {
       default:
         return null;
     }
+  }
+
+  /**
+   * Builds session credentials from the overrider.
+   *
+   * <p>When a session credentials supplier is present the credentials renew themselves by calling
+   * back into it, which keeps a client working past the lifetime of any single set of credentials.
+   *
+   * <p>Otherwise the caller's credentials are held as a single fixed access token that cannot be
+   * renewed, and the client stops working once they lapse. The declared expiration is deliberately
+   * not carried onto that token: the auth library treats a token inside its refresh margin as
+   * expired and reaches for a renewal that a fixed token cannot provide, so honouring the
+   * expiration would fail calls minutes before the credentials actually lapse, and would fail them
+   * with an auth-library error that call sites neither expect nor map. An expiration is only
+   * actionable when there is a callback to renew from.
+   */
+  private static GoogleCredentials buildSessionCredentials(CredentialsOverrider overrider) {
+    Supplier<StsCredentials> sessionCredentialsSupplier = overrider.getSessionCredentialsSupplier();
+    if (sessionCredentialsSupplier != null) {
+      return new RefreshableSessionCredentials(sessionCredentialsSupplier);
+    }
+    StsCredentials stsCredentials = overrider.getSessionCredentials();
+    AccessToken accessToken =
+        AccessToken.newBuilder().setTokenValue(stsCredentials.getSecurityToken()).build();
+    return GoogleCredentials.newBuilder().setAccessToken(accessToken).build();
   }
 
   /**

--- a/multicloudj-common-gcp/src/main/java/com/salesforce/multicloudj/common/gcp/RefreshableSessionCredentials.java
+++ b/multicloudj-common-gcp/src/main/java/com/salesforce/multicloudj/common/gcp/RefreshableSessionCredentials.java
@@ -1,0 +1,97 @@
+package com.salesforce.multicloudj.common.gcp;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.function.Supplier;
+
+/**
+ * Session credentials that renew themselves through a caller-supplied callback rather than holding
+ * a single access token for the lifetime of the client.
+ *
+ * <p>Google's auth library only renews a token once that token reports itself as expired, and it
+ * treats a token carrying no expiration time as permanently fresh. Every token produced here
+ * therefore carries an expiration: the one declared by {@link StsCredentials#getExpiration()} when
+ * the callback supplies it, and {@link #DEFAULT_TOKEN_LIFETIME} measured from the moment the token
+ * is produced when it does not. The library renews a few minutes ahead of the expiration it is
+ * given, so the effective renewal cadence is slightly shorter than the declared lifetime.
+ *
+ * <p>That same margin means a callback returning credentials which are already expired, or which
+ * expire within the margin, would be asked for a renewal on every request. The token from the last
+ * callback invocation is therefore reused for {@link #MINIMUM_REFRESH_INTERVAL} before the callback
+ * is invoked again. The reused token keeps its original expiration, so the auth library still sees
+ * the credentials as expired; the bound limits how hard the callback is driven, it does not
+ * disguise credentials that have lapsed.
+ *
+ * <p>{@code OAuth2Credentials} serialises refreshes on its own lock and publishes the outcome to
+ * every waiting caller, so this class adds no locking of its own and the callback is invoked once
+ * per renewal however many threads are in flight. The callback runs on request threads and must
+ * itself be thread-safe.
+ */
+final class RefreshableSessionCredentials extends GoogleCredentials {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Lifetime applied to credentials that declare no expiration of their own. It stays comfortably
+   * above the auth library's refresh margin so that renewal happens on a predictable cadence rather
+   * than on every request.
+   */
+  static final Duration DEFAULT_TOKEN_LIFETIME = Duration.ofMinutes(15);
+
+  /** The shortest interval permitted between two callback invocations. */
+  static final Duration MINIMUM_REFRESH_INTERVAL = Duration.ofSeconds(1);
+
+  private final Supplier<StsCredentials> sessionCredentialsSupplier;
+
+  private volatile LastRefresh lastRefresh;
+
+  RefreshableSessionCredentials(Supplier<StsCredentials> sessionCredentialsSupplier) {
+    this.sessionCredentialsSupplier = sessionCredentialsSupplier;
+  }
+
+  @Override
+  public AccessToken refreshAccessToken() throws IOException {
+    Instant now = Instant.now();
+    LastRefresh previous = lastRefresh;
+    if (previous != null
+        && Duration.between(previous.suppliedAt, now).compareTo(MINIMUM_REFRESH_INTERVAL) < 0) {
+      return previous.token;
+    }
+
+    StsCredentials credentials = sessionCredentialsSupplier.get();
+    if (credentials == null) {
+      throw new IOException("Session credentials supplier returned no credentials");
+    }
+    String securityToken = credentials.getSecurityToken();
+    if (securityToken == null || securityToken.isBlank()) {
+      throw new IOException("Session credentials supplier returned no security token");
+    }
+    Instant expiration = credentials.getExpiration();
+    if (expiration == null) {
+      expiration = now.plus(DEFAULT_TOKEN_LIFETIME);
+    }
+    AccessToken token =
+        AccessToken.newBuilder()
+            .setTokenValue(securityToken)
+            .setExpirationTime(Date.from(expiration))
+            .build();
+    lastRefresh = new LastRefresh(token, now);
+    return token;
+  }
+
+  /** What the last callback invocation produced, and when it was invoked. */
+  private static final class LastRefresh {
+    private final AccessToken token;
+    private final Instant suppliedAt;
+
+    LastRefresh(AccessToken token, Instant suppliedAt) {
+      this.token = token;
+      this.suppliedAt = suppliedAt;
+    }
+  }
+}

--- a/multicloudj-common-gcp/src/test/java/com/salesforce/multicloudj/common/gcp/GcpCredentialsProviderTest.java
+++ b/multicloudj-common-gcp/src/test/java/com/salesforce/multicloudj/common/gcp/GcpCredentialsProviderTest.java
@@ -1,18 +1,29 @@
 package com.salesforce.multicloudj.common.gcp;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.auth.Credentials;
+import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.IdentityPoolCredentials;
 import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
 import com.salesforce.multicloudj.sts.model.CredentialsType;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
 public class GcpCredentialsProviderTest {
@@ -63,6 +74,289 @@ public class GcpCredentialsProviderTest {
           GcpCredentialsProvider.getCredentials(overrider);
         },
         "NullPointerException expected when sessionCredentials is null");
+  }
+
+  @Test
+  void testSessionCredentialsByValueWithoutExpirationKeepExistingType() {
+    // Arrange
+    CredentialsOverrider overrider =
+        sessionOverrider(new StsCredentials("key-id", "key-secret", "test-token"));
+
+    // Act
+    Credentials credentials = GcpCredentialsProvider.getCredentials(overrider);
+
+    // Assert - callers that pass no expiration must keep the credentials they have always had.
+    assertEquals(
+        GoogleCredentials.class,
+        credentials.getClass(),
+        "Session credentials supplied by value should stay plain GoogleCredentials");
+    AccessToken accessToken = ((GoogleCredentials) credentials).getAccessToken();
+    assertEquals("test-token", accessToken.getTokenValue());
+    assertNull(accessToken.getExpirationTime(), "No expiration was declared, so none is invented");
+    assertDoesNotThrow(
+        ((GoogleCredentials) credentials)::refreshIfExpired,
+        "A token with no expiration is treated as fresh and is never renewed");
+  }
+
+  @Test
+  void testSessionCredentialsByValueIgnoreTheDeclaredExpiration() throws Exception {
+    // Arrange
+    Instant expiration = Instant.now().plus(Duration.ofHours(1));
+    CredentialsOverrider overrider =
+        sessionOverrider(new StsCredentials("key-id", "key-secret", "test-token", expiration));
+
+    // Act
+    Credentials credentials = GcpCredentialsProvider.getCredentials(overrider);
+
+    // Assert - the expiration only schedules renewal, and credentials supplied by value have no
+    // renewal path, so declaring one must leave this path exactly as it is without one.
+    assertEquals(GoogleCredentials.class, credentials.getClass());
+    AccessToken accessToken = ((GoogleCredentials) credentials).getAccessToken();
+    assertEquals("test-token", accessToken.getTokenValue());
+    assertNull(accessToken.getExpirationTime());
+    assertDoesNotThrow(
+        ((GoogleCredentials) credentials)::refreshIfExpired,
+        "Declaring an expiration must not put the credentials on a renewal path they lack");
+    assertEquals(
+        List.of("Bearer test-token"),
+        credentials
+            .getRequestMetadata(URI.create("https://storage.googleapis.com"))
+            .get("Authorization"));
+  }
+
+  @Test
+  void testSessionCredentialsByValueWithAPastExpirationStillWork() {
+    // Arrange
+    Instant expiration = Instant.now().minus(Duration.ofHours(1));
+    CredentialsOverrider overrider =
+        sessionOverrider(new StsCredentials("key-id", "key-secret", "test-token", expiration));
+
+    // Act
+    GoogleCredentials credentials =
+        (GoogleCredentials) GcpCredentialsProvider.getCredentials(overrider);
+
+    // Assert - the service is the authority on whether a token still works, so a stale declared
+    // expiration must not fail the call before the service has been asked.
+    assertNull(credentials.getAccessToken().getExpirationTime());
+    assertDoesNotThrow(credentials::refreshIfExpired);
+    assertEquals("test-token", credentials.getAccessToken().getTokenValue());
+  }
+
+  @Test
+  void testSessionCredentialsSupplierProducesRefreshableCredentials() {
+    // Arrange
+    CredentialsOverrider overrider =
+        sessionSupplierOverrider(() -> sessionCredentials("test-token", Duration.ofHours(1)));
+
+    // Act
+    Credentials credentials = GcpCredentialsProvider.getCredentials(overrider);
+
+    // Assert - the call sites hand the result to StorageOptions and some cast it to
+    // GoogleCredentials, so the refreshable form has to remain a GoogleCredentials.
+    assertInstanceOf(RefreshableSessionCredentials.class, credentials);
+    assertInstanceOf(GoogleCredentials.class, credentials);
+  }
+
+  @Test
+  void testScopingRefreshableSessionCredentialsKeepsThemRefreshable() {
+    // Arrange - callers scope the credentials before handing them to a client, which must not
+    // trade the refreshable credentials for a fixed set.
+    CredentialsOverrider overrider =
+        sessionSupplierOverrider(() -> sessionCredentials("test-token", Duration.ofHours(1)));
+    GoogleCredentials credentials =
+        (GoogleCredentials) GcpCredentialsProvider.getCredentials(overrider);
+
+    // Act
+    GoogleCredentials scoped =
+        credentials.createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));
+
+    // Assert
+    assertInstanceOf(RefreshableSessionCredentials.class, scoped);
+  }
+
+  @Test
+  void testSessionCredentialsSupplierIsInvokedLazily() throws Exception {
+    // Arrange
+    AtomicInteger invocations = new AtomicInteger(0);
+    CredentialsOverrider overrider =
+        sessionSupplierOverrider(
+            () -> {
+              invocations.incrementAndGet();
+              return sessionCredentials("test-token", Duration.ofHours(1));
+            });
+
+    // Act
+    GoogleCredentials credentials =
+        (GoogleCredentials) GcpCredentialsProvider.getCredentials(overrider);
+
+    // Assert - building a client must not reach out for credentials.
+    assertEquals(0, invocations.get(), "Supplier should not run while building the credentials");
+    assertNull(credentials.getAccessToken(), "No token should exist before one is needed");
+
+    // Act - the first time a token is needed the supplier drives it.
+    credentials.refreshIfExpired();
+
+    // Assert
+    assertEquals(1, invocations.get(), "Supplier should run when a token is first needed");
+    assertEquals("test-token", credentials.getAccessToken().getTokenValue());
+  }
+
+  @Test
+  void testExpiredTokenIsRenewedFromSessionCredentialsSupplier() throws Exception {
+    // Arrange - the first credentials handed out have already lapsed, the next ones are valid.
+    AtomicInteger invocations = new AtomicInteger(0);
+    CredentialsOverrider overrider =
+        sessionSupplierOverrider(
+            () ->
+                invocations.incrementAndGet() == 1
+                    ? sessionCredentials("lapsed-token", Duration.ofMinutes(-5))
+                    : sessionCredentials("renewed-token", Duration.ofHours(1)));
+    GoogleCredentials credentials =
+        (GoogleCredentials) GcpCredentialsProvider.getCredentials(overrider);
+
+    credentials.refreshIfExpired();
+    assertEquals(1, invocations.get());
+    assertEquals("lapsed-token", credentials.getAccessToken().getTokenValue());
+
+    // Act - the held token has lapsed, so asking for a usable token goes back to the supplier once
+    // the minimum interval between supplier invocations has passed.
+    Thread.sleep(RefreshableSessionCredentials.MINIMUM_REFRESH_INTERVAL.toMillis() + 100);
+    credentials.refreshIfExpired();
+
+    // Assert - the renewed token is the one now presented to the service.
+    assertEquals(2, invocations.get(), "A lapsed token should send the provider to the supplier");
+    assertEquals("renewed-token", credentials.getAccessToken().getTokenValue());
+    Map<String, List<String>> metadata =
+        credentials.getRequestMetadata(URI.create("https://storage.googleapis.com"));
+    assertEquals(List.of("Bearer renewed-token"), metadata.get("Authorization"));
+
+    // Act & Assert - a token that is still valid is reused rather than renewed.
+    credentials.refreshIfExpired();
+    assertEquals(2, invocations.get(), "A valid token should be reused");
+  }
+
+  @Test
+  void testAlreadyExpiredSuppliedCredentialsDoNotInvokeTheSupplierOnEveryRefresh()
+      throws Exception {
+    // Arrange - the supplier only ever hands back credentials that have already lapsed, which the
+    // auth library asks to renew on every single request.
+    AtomicInteger invocations = new AtomicInteger(0);
+    CredentialsOverrider overrider =
+        sessionSupplierOverrider(
+            () -> {
+              invocations.incrementAndGet();
+              return sessionCredentials("lapsed-token", Duration.ofMinutes(-5));
+            });
+    GoogleCredentials credentials =
+        (GoogleCredentials) GcpCredentialsProvider.getCredentials(overrider);
+
+    // Act
+    for (int i = 0; i < 20; i++) {
+      credentials.refreshIfExpired();
+    }
+
+    // Assert - the supplier is driven at a bounded rate rather than once per attempt, and the
+    // token handed back keeps the expiration it really has.
+    assertEquals(
+        1,
+        invocations.get(),
+        "A supplier returning lapsed credentials must not be invoked once per refresh attempt");
+    AccessToken accessToken = credentials.getAccessToken();
+    assertEquals("lapsed-token", accessToken.getTokenValue());
+    assertTrue(
+        accessToken.getExpirationTime().toInstant().isBefore(Instant.now()),
+        "The reused token must keep its real expiration rather than a fabricated one");
+  }
+
+  @Test
+  void testSessionCredentialsSupplierWithoutExpirationStillProducesExpiringToken()
+      throws Exception {
+    // Arrange
+    Instant before = Instant.now();
+    CredentialsOverrider overrider =
+        sessionSupplierOverrider(
+            () -> new StsCredentials("key-id", "key-secret", "test-token", null));
+    GoogleCredentials credentials =
+        (GoogleCredentials) GcpCredentialsProvider.getCredentials(overrider);
+
+    // Act
+    credentials.refreshIfExpired();
+
+    // Assert - a token with no expiration would never be renewed, so one is synthesized.
+    AccessToken accessToken = credentials.getAccessToken();
+    assertEquals("test-token", accessToken.getTokenValue());
+    assertNotNull(accessToken.getExpirationTime(), "A synthesized expiration should be applied");
+    Instant expiration = accessToken.getExpirationTime().toInstant();
+    Duration lifetime = RefreshableSessionCredentials.DEFAULT_TOKEN_LIFETIME;
+    assertTrue(expiration.isAfter(Instant.now()), "The credentials should be usable");
+    assertFalse(
+        expiration.isBefore(before.plus(lifetime).minusSeconds(1)),
+        "The synthesized expiration should be roughly one default token lifetime away");
+    assertFalse(
+        expiration.isAfter(Instant.now().plus(lifetime)),
+        "The synthesized expiration should not exceed the default token lifetime");
+  }
+
+  @Test
+  void testSessionCredentialsSupplierReturningNullFails() {
+    // Arrange
+    CredentialsOverrider overrider = sessionSupplierOverrider(() -> null);
+    GoogleCredentials credentials =
+        (GoogleCredentials) GcpCredentialsProvider.getCredentials(overrider);
+
+    // Act & Assert
+    IOException ex = assertThrows(IOException.class, credentials::refreshIfExpired);
+    assertTrue(ex.getMessage().contains("no credentials"), ex.getMessage());
+  }
+
+  @Test
+  void testSessionCredentialsSupplierReturningNoTokenFails() {
+    // Arrange
+    CredentialsOverrider overrider =
+        sessionSupplierOverrider(() -> new StsCredentials("key-id", "key-secret", "  "));
+    GoogleCredentials credentials =
+        (GoogleCredentials) GcpCredentialsProvider.getCredentials(overrider);
+
+    // Act & Assert
+    IOException ex = assertThrows(IOException.class, credentials::refreshIfExpired);
+    assertTrue(ex.getMessage().contains("no security token"), ex.getMessage());
+  }
+
+  @Test
+  void testSessionCredentialsSupplierFailureIsSurfaced() {
+    // Arrange
+    CredentialsOverrider overrider =
+        sessionSupplierOverrider(
+            () -> {
+              throw new IllegalStateException("session credentials unavailable");
+            });
+    GoogleCredentials credentials =
+        (GoogleCredentials) GcpCredentialsProvider.getCredentials(overrider);
+
+    // Act & Assert
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, credentials::refreshIfExpired);
+    assertEquals("session credentials unavailable", ex.getMessage());
+  }
+
+  @Test
+  void testSessionCredentialsSupplierTakesPrecedenceOverFixedCredentials() throws Exception {
+    // Arrange
+    CredentialsOverrider overrider =
+        new CredentialsOverrider.Builder(CredentialsType.SESSION)
+            .withSessionCredentials(new StsCredentials("key-id", "key-secret", "fixed-token"))
+            .withSessionCredentialsSupplier(
+                () -> sessionCredentials("supplied-token", Duration.ofHours(1)))
+            .build();
+
+    // Act
+    GoogleCredentials credentials =
+        (GoogleCredentials) GcpCredentialsProvider.getCredentials(overrider);
+    credentials.refreshIfExpired();
+
+    // Assert
+    assertInstanceOf(RefreshableSessionCredentials.class, credentials);
+    assertEquals("supplied-token", credentials.getAccessToken().getTokenValue());
   }
 
   @Test
@@ -207,5 +501,22 @@ public class GcpCredentialsProviderTest {
             () -> GcpCredentialsProvider.getCredentials(overrider),
             "IllegalArgumentException expected when webIdentityTokenSupplier is null");
     assertTrue(ex.getMessage().contains("webIdentityTokenSupplier"));
+  }
+
+  private static CredentialsOverrider sessionOverrider(StsCredentials sessionCredentials) {
+    return new CredentialsOverrider.Builder(CredentialsType.SESSION)
+        .withSessionCredentials(sessionCredentials)
+        .build();
+  }
+
+  private static CredentialsOverrider sessionSupplierOverrider(
+      Supplier<StsCredentials> sessionCredentialsSupplier) {
+    return new CredentialsOverrider.Builder(CredentialsType.SESSION)
+        .withSessionCredentialsSupplier(sessionCredentialsSupplier)
+        .build();
+  }
+
+  private static StsCredentials sessionCredentials(String securityToken, Duration validFor) {
+    return new StsCredentials("key-id", "key-secret", securityToken, Instant.now().plus(validFor));
   }
 }

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/CredentialsOverrider.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/CredentialsOverrider.java
@@ -12,6 +12,13 @@ import lombok.Getter;
  * we cover the two listed above. If the service supplies both, the session credentialsOverrider and
  * the details for assume role, the session credentialsOverrider takes precedence over the assume
  * role.
+ *
+ * <p>Session credentials can be supplied either by value through {@link
+ * Builder#withSessionCredentials} or by callback through {@link
+ * Builder#withSessionCredentialsSupplier}. Clients hold a single underlying cloud connection for
+ * their entire lifetime, so credentials supplied by value are fixed for that lifetime and any
+ * service call made after they expire fails. Long-lived clients should supply a callback instead so
+ * that expiring credentials can be renewed in place. When both are set, the callback wins.
  */
 @Getter
 public class CredentialsOverrider {
@@ -21,6 +28,7 @@ public class CredentialsOverrider {
   protected Integer durationSeconds;
   protected String sessionName;
   protected Supplier<String> webIdentityTokenSupplier;
+  protected Supplier<StsCredentials> sessionCredentialsSupplier;
 
   public CredentialsOverrider(Builder builder) {
     this.type = builder.type;
@@ -29,6 +37,7 @@ public class CredentialsOverrider {
     this.durationSeconds = builder.durationSeconds;
     this.webIdentityTokenSupplier = builder.webIdentityTokenSupplier;
     this.sessionName = builder.sessionName;
+    this.sessionCredentialsSupplier = builder.sessionCredentialsSupplier;
   }
 
   public static class Builder {
@@ -38,6 +47,7 @@ public class CredentialsOverrider {
     private Integer durationSeconds;
     protected String sessionName;
     protected Supplier<String> webIdentityTokenSupplier;
+    protected Supplier<StsCredentials> sessionCredentialsSupplier;
 
     public Builder(CredentialsType type) {
       this.type = type;
@@ -45,6 +55,23 @@ public class CredentialsOverrider {
 
     public Builder withSessionCredentials(StsCredentials sessionCredentials) {
       this.sessionCredentials = sessionCredentials;
+      return this;
+    }
+
+    /**
+     * Supplies session credentials through a callback that is invoked again whenever the current
+     * credentials need renewing, which keeps a long-lived client working past the lifetime of any
+     * single set of credentials. Populate {@link StsCredentials#getExpiration()} so renewal can be
+     * scheduled ahead of expiry; otherwise renewal falls back to a fixed interval.
+     *
+     * <p>The supplier is called from request threads and must be thread-safe and reasonably fast.
+     *
+     * @param sessionCredentialsSupplier callback returning currently valid session credentials
+     * @return this builder
+     */
+    public Builder withSessionCredentialsSupplier(
+        Supplier<StsCredentials> sessionCredentialsSupplier) {
+      this.sessionCredentialsSupplier = sessionCredentialsSupplier;
       return this;
     }
 

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/StsCredentials.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/StsCredentials.java
@@ -1,14 +1,23 @@
 package com.salesforce.multicloudj.sts.model;
 
+import java.time.Instant;
+
 public class StsCredentials {
   String accessKeyId;
   String accessKeySecret;
   String securityToken;
+  Instant expiration;
 
   public StsCredentials(String accessKeyId, String accessKeySecret, String securityToken) {
+    this(accessKeyId, accessKeySecret, securityToken, null);
+  }
+
+  public StsCredentials(
+      String accessKeyId, String accessKeySecret, String securityToken, Instant expiration) {
     this.accessKeyId = accessKeyId;
     this.accessKeySecret = accessKeySecret;
     this.securityToken = securityToken;
+    this.expiration = expiration;
   }
 
   public String getAccessKeyId() {
@@ -21,5 +30,24 @@ public class StsCredentials {
 
   public String getAccessKeySecret() {
     return accessKeySecret;
+  }
+
+  /**
+   * The instant at which these credentials stop being valid, or {@code null} if the caller did not
+   * declare one.
+   *
+   * <p>This is only consulted for credentials supplied through {@link
+   * CredentialsOverrider.Builder#withSessionCredentialsSupplier}, where it schedules the renewal
+   * that invokes the supplier again; declaring it lets renewal happen before the credentials
+   * lapse, and omitting it leaves renewal to a fixed interval that cannot make that guarantee.
+   * Credentials supplied by value through {@link
+   * CredentialsOverrider.Builder#withSessionCredentials} cannot be renewed at all, so the
+   * expiration is ignored on that path and the credentials are used until the service rejects
+   * them.
+   *
+   * @return the expiration instant, or {@code null} if unknown
+   */
+  public Instant getExpiration() {
+    return expiration;
   }
 }


### PR DESCRIPTION
## Summary

Fixes `W-23561298`. A client holds one underlying cloud connection for its whole lifetime, but `CredentialsOverrider` only accepted session credentials **by value**, so those credentials were frozen for that lifetime. A `BucketClient` cached for the life of the JVM therefore failed every call once the session token's TTL elapsed:

```
com.salesforce.multicloudj.common.exceptions.UnknownException:
  software.amazon.awssdk.services.s3.model.S3Exception: The provided token has expired.
  (Service: S3, Status Code: 400)
```

The expired-credentials error is not in the AWS SDK's retryable set, so only a process restart recovered it.

`CredentialsOverrider` now also accepts a `Supplier<StsCredentials>` that the SDK re-invokes to renew credentials in place, and `StsCredentials` carries an optional expiration so renewal can be scheduled ahead of expiry rather than on a fixed interval. Supplying credentials by value is unchanged, so this is fully backward compatible.

## Changes

- `CredentialsOverrider.Builder.withSessionCredentialsSupplier(Supplier<StsCredentials>)` — the callback form; takes precedence when both forms are set. Mirrors the existing `withWebIdentityTokenSupplier` pattern.
- `StsCredentials` — optional 4th constructor argument `java.time.Instant expiration` plus `getExpiration()`. The 3-argument constructor is retained and behaves as before.
- AWS `RefreshingSessionCredentialsProvider` — renews through the SDK's own `CachedSupplier`, giving prefetch and stale tiers plus single-flight renewal under contention, and bounds how often the callback is invoked.
- GCP `RefreshableSessionCredentials` — a `GoogleCredentials` subclass that renews through the callback and always stamps an expiration, since a token carrying none is treated as permanently fresh and can never be renewed.
- AWS `ExpiredCredentialsInterceptor` — the blob clients invalidate the cached credentials when a call is rejected as expired, so the next call renews instead of re-signing with the same credentials. The rejected call itself is not recovered: an identity is resolved once per API call by an interceptor outside the retry loop, so retries within one call always re-sign with the identity resolved before the first attempt.
- The resolved credentials provider is logged at client construction, so an expired-credentials report can be traced back to whether the client was built on a renewing or a frozen provider.
- Alibaba rejects a session-credentials callback with a clear `InvalidArgumentException` rather than dereferencing null, as it does not implement renewal.

## API Example

```java
CredentialsOverrider credsOverrider =
    new CredentialsOverrider.Builder(CredentialsType.SESSION)
        .withSessionCredentialsSupplier(() -> new StsCredentials(
            secretBroker.accessKeyId(),
            secretBroker.accessKeySecret(),
            secretBroker.sessionToken(),
            secretBroker.expiresAt()))
        .build();

BucketClient bucketClient = BucketClient.builder("aws")
    .withRegion("us-west-2")
    .withBucket("my-bucket")
    .withCredentialsOverrider(credsOverrider)
    .build();
```

## Testing

Full reactor build green. New unit coverage for: callback laziness, caching within the freshness window, renewal once stale, single-flight renewal under contention, invalidation and its rate bound, absent and already-past expirations, builder validation, and callback failure modes. A characterization test pins the by-value path as still non-renewing so the backward-compatible behaviour cannot regress silently.

No conformance tests were added: credential renewal is driven by wall-clock expiry and credentials are stripped from WireMock recordings, so the behaviour is not observable in record/replay. It is covered by unit tests against the real cloud SDK credential machinery instead.

## Cross-Cloud Compatibility

- **AWS**: renewal implemented, plus failure-driven invalidation on the blob clients.
- **GCP**: renewal implemented.
- **Alibaba**: not implemented; the callback is rejected with a clear error at client-build time instead of failing obscurely. Tracked as a follow-up.