### PR TITLE
docs: expand README service and cloud provider list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,21 @@
 ----------------------
 Write once, deploy to any cloud provider...
 
-MultiCloudJ is a cloud-agnostic Java SDK providing unified and substrate-neutral interfaces for cloud services. It enables developers to write once and deploy to any cloud provider with high-level APIs for Security Token Service (STS), Blob Storage, Document Store, and more, supporting major cloud providers like AWS, GCP, and Alibaba.
+MultiCloudJ is a cloud-agnostic Java SDK providing unified and substrate-neutral interfaces for cloud services. It enables developers to write once and deploy to any cloud provider. It has high-level APIs for the following commonly-used Cloud services:
 - **Security Token Service (STS)**
 - **Blob Store**
 - **Document Store**
-- more to come...
+- **Pub Sub**
+- **Container Registry**
+- **IAM**
+- **DB Backup Restore**
+
+We are continually adding support for additional Cloud services.
+
+The following Cloud Providers are supported:
+- **AWS**
+- **GCP**
+- **Alibaba**
 
 MultiCloudJ simplifies multi-cloud compatibility, enabling consistent codebases and accelerating development for applications that needs to be deployed across different cloud platforms.
 


### PR DESCRIPTION
## What

Updates the MultiCloudJ overview in `README.md` to reflect the SDK's current surface area.

- Lists all currently supported services: **STS**, **Blob Store**, **Document Store**, **Pub Sub**, **Container Registry**, **IAM**, and **DB Backup Restore** (previously only STS/Blob/Document Store with a "more to come" note).
- Adds an explicit list of supported cloud providers: **AWS**, **GCP**, **Alibaba**.

## Why

The overview was stale — several shipped service modules (`pubsub`, `registry`, `iam`, `dbbackuprestore`) were not mentioned. This is a documentation-only change.

## Scope

- Docs only; no code, API, or build changes.
- No tests affected.