### PR TITLE
[Benchmarks] PubSub: scope batchSize @Param to nested @State; drop redundant benchmarkLargeBatchAck

### DIFF
--- a/pubsub/pubsub-client/src/test/java/com/salesforce/multicloudj/pubsub/client/AbstractPubsubBenchmarkTest.java
+++ b/pubsub/pubsub-client/src/test/java/com/salesforce/multicloudj/pubsub/client/AbstractPubsubBenchmarkTest.java
@@ -62,15 +62,9 @@ public abstract class AbstractPubsubBenchmarkTest {
   protected static final int MEDIUM_MESSAGE = 10240; // 10KB
   protected static final int LARGE_MESSAGE = 102400; // 100KB
 
-  protected static final int BATCH_SIZE_SMALL = 10;
-
   // Pre-population constants — kept small to avoid long setup (each SNS publish ~3-5s round-trip)
   protected static final int PREPOPULATE_RECEIVE = 50;
   protected static final int MESSAGE_AVAILABILITY_DELAY_MS = 1000;
-
-  // @Param for batch ack benchmarks — drives both benchmarkBatchAck and benchmarkLargeBatchAck
-  @Param({"1", "10"})
-  protected int batchSize;
 
   protected TopicClient topicClient;
   protected SubscriptionClient subscriptionClient;
@@ -104,14 +98,6 @@ public abstract class AbstractPubsubBenchmarkTest {
       throw new IllegalStateException("Required environment variable not set: " + name);
     }
     return value;
-  }
-
-  /**
-   * Returns the maximum number of messages allowed in a single batch ack call.
-   * AWS: 10 messages per batch, GCP: 1000 messages per batch.
-   */
-  protected int getMaxBatchAckSize() {
-    return BATCH_SIZE_SMALL;
   }
 
   @Setup(Level.Trial)
@@ -376,24 +362,31 @@ public abstract class AbstractPubsubBenchmarkTest {
     }
   }
 
+  /** Scopes the batchSize {@code @Param} to the batch-ack benchmark only, not the whole class. */
+  @State(Scope.Benchmark)
+  public static class BatchParams {
+    @Param({"1", "10"})
+    public int batchSize;
+  }
+
   /**
    * Batch acknowledgment benchmark.
    *
    * <p>Publishes {@code batchSize} messages then receives and acks them in a single batch call.
-   * Parameterised via {@link #batchSize} ({@code @Param({"1","10"})}).
+   * Parameterised via {@link BatchParams#batchSize} ({@code @Param({"1","10"})}).
    *
    * <p>Note: {@code sendAcks()} enqueues the batch ack asynchronously; the underlying RPC cost is
    * NOT captured in this benchmark's latency measurement.
    */
   @Benchmark
   @Threads(4)
-  public void benchmarkBatchAck(Blackhole bh) {
+  public void benchmarkBatchAck(BatchParams params, Blackhole bh) {
     try {
-      for (int i = 0; i < batchSize; i++) {
+      for (int i = 0; i < params.batchSize; i++) {
         topicClient.send(createMessage(SMALL_MESSAGE));
       }
       List<AckID> ackIds = new ArrayList<>();
-      for (int i = 0; i < batchSize; i++) {
+      for (int i = 0; i < params.batchSize; i++) {
         Message msg = subscriptionClient.receive();
         ackIds.add(msg.getAckID());
         bh.consume(msg);
@@ -403,38 +396,6 @@ public abstract class AbstractPubsubBenchmarkTest {
     } catch (Exception e) {
       logger.error(">>> Benchmark batch ack FAILED: {}", e.getMessage());
       throw new RuntimeException("Benchmark batch ack failed", e);
-    }
-  }
-
-  /**
-   * Large batch acknowledgment benchmark — shows provider scaling advantage.
-   *
-   * <p>Publishes then receives {@code Math.min(batchSize, getMaxBatchAckSize())} messages in one
-   * batch ack (AWS: 10, GCP: 1000). Parameterised via {@link #batchSize}
-   * ({@code @Param({"1","10"})}).
-   *
-   * <p>Note: {@code sendAcks()} enqueues the batch ack asynchronously; the underlying RPC cost is
-   * NOT captured in this benchmark's latency measurement.
-   */
-  @Benchmark
-  @Threads(4)
-  public void benchmarkLargeBatchAck(Blackhole bh) {
-    int effectiveBatch = Math.min(batchSize, getMaxBatchAckSize());
-    try {
-      for (int i = 0; i < effectiveBatch; i++) {
-        topicClient.send(createMessage(SMALL_MESSAGE));
-      }
-      List<AckID> ackIds = new ArrayList<>();
-      for (int i = 0; i < effectiveBatch; i++) {
-        Message msg = subscriptionClient.receive();
-        ackIds.add(msg.getAckID());
-        bh.consume(msg);
-      }
-      subscriptionClient.sendAcks(ackIds);
-      bh.consume(ackIds.size());
-    } catch (Exception e) {
-      logger.error(">>> Benchmark large batch ack FAILED: {}", e.getMessage());
-      throw new RuntimeException("Benchmark large batch ack failed", e);
     }
   }
 

--- a/pubsub/pubsub-gcp/src/test/java/com/salesforce/multicloudj/pubsub/gcp/GcpPubsubBenchmarkTest.java
+++ b/pubsub/pubsub-gcp/src/test/java/com/salesforce/multicloudj/pubsub/gcp/GcpPubsubBenchmarkTest.java
@@ -39,12 +39,6 @@ public class GcpPubsubBenchmarkTest extends AbstractPubsubBenchmarkTest {
     return "gcp";
   }
 
-  @Override
-  protected int getMaxBatchAckSize() {
-    // GCP supports up to 1000 messages per batch ack (vs AWS limit of 10)
-    return 1000;
-  }
-
   /**
    * GCP NACK-and-redelivery benchmark.
    *


### PR DESCRIPTION
### What
Scope the batch-ack `@Param` to a nested `@State` so it fans out only the batch benchmark, and delete the redundant `benchmarkLargeBatchAck`.

### Why
A class-level `@Param batchSize` on a `@State(Scope.Benchmark)` class expands its cross-product over *every* `@Benchmark` in the class — so all 12 non-batch benchmarks were silently run twice (batchSize 1 and 10), doubling wall-clock and emitting two indistinguishable results per benchmark. Moving the param into a nested `BatchParams @State` consumed only by `benchmarkBatchAck` confines the expansion to the one benchmark that uses it.

`benchmarkLargeBatchAck` is deleted, not fixed: with `@Param({"1","10"})` and `Math.min(batchSize, cap)` it ran a byte-identical workload to `benchmarkBatchAck` at every achievable size (never reaching GCP's 1000 ceiling), so it measured nothing extra. A genuine 1000-message variant is off-mission (it tracks provider batch-API limits, not SDK performance) and unaffordable at ~3-5s SNS round-trips. The now-dead `getMaxBatchAckSize()` (+ GCP override) and `BATCH_SIZE_SMALL` go with it.

### Note
This reconciles the downstream copy already shipped in the sfdc-bazel monorepo (services/sfdc-bazel#101288). Landing it here keeps `main` from clobbering that refactor on the next mirror sync (W-21084117).

### Test plan
- `mvn -pl pubsub/pubsub-client,pubsub/pubsub-aws,pubsub/pubsub-gcp -am test-compile` — clean (checkstyle included).
- BenchmarkList shape verified via the sfdc-bazel `benchmark_runner` build of the identical refactor: `batchSize` attaches only to `benchmarkBatchAck`; `benchmarkLargeBatchAck` absent from the catalog.
