### PR TITLE
build: add jmh-generator-annprocess to annotationProcessorPaths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -569,6 +569,11 @@
                             <artifactId>auto-service</artifactId>
                             <version>${auto-service.version}</version>
                         </path>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Summary
Adds `jmh-generator-annprocess` to the root pom's `<annotationProcessorPaths>`.

This repo already configures `<annotationProcessorPaths>` (lombok, auto-service),
which puts javac on `--processor-path` and stops it from discovering processors on
the compile/test classpath. As a result the JMH generator is never picked up and
`META-INF/BenchmarkList` is not generated, so every JMH benchmark suite fails at
runtime with `Unable to find the resource: /META-INF/BenchmarkList`. `jmh.version`
(1.37) and `jmh-core` are already parent-managed; this only adds the missing
generator path.

## Scope
Affects local benchmark runs and reactor builds. Downstream consumers that build
through Bazel (not this root pom) are unaffected, so this does not change their
build behavior.

## Merge order
Hard runtime dependency for the benchmark suites: they compile without this change
but cannot run (the BenchmarkList is missing). Recommend merging this first so the
per-module benchmark suites are runnable locally and in CI.

## Testing
- `mvn install -DskipTests` clean on the full reactor.
- `jmh-generator-annprocess:1.37` resolves from the parent-managed version.
- Verified with a one-method `@Benchmark` class: with `annotationProcessorPaths`
  configured, `BenchmarkList` is generated only when the JMH generator is on the
  processor path — confirmed on JDK 11 and JDK 25.
