### PR TITLE
sts: add JMH benchmark suite

### DIFF
--- a/sts/sts-aws/pom.xml
+++ b/sts/sts-aws/pom.xml
@@ -69,6 +69,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.auto</groupId>
             <artifactId>auto-common</artifactId>
             <version>1.2.2</version>

--- a/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsBenchmarkTest.java
+++ b/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsBenchmarkTest.java
@@ -1,5 +1,6 @@
 package com.salesforce.multicloudj.sts.aws;
 
+import com.salesforce.multicloudj.common.aws.AwsConstants;
 import com.salesforce.multicloudj.sts.client.AbstractStsBenchmarkTest;
 import com.salesforce.multicloudj.sts.client.StsClient;
 import java.net.URI;
@@ -15,18 +16,32 @@ public class AwsStsBenchmarkTest extends AbstractStsBenchmarkTest {
 
   @Override
   protected String getProviderId() {
-    return "aws";
+    return AwsConstants.PROVIDER_ID;
+  }
+
+  @Override
+  protected boolean supportsGetAccessToken() {
+    // GetSessionToken rejects temporary/session credentials, so it cannot run under the
+    // assumed-role creds the pipeline uses.
+    return false;
   }
 
   public static class HarnessImpl implements Harness {
 
     private final String region = requireEnv("STS_BENCHMARK_AWS_REGION");
     private final String roleArn = requireEnv("STS_BENCHMARK_AWS_ROLE_ARN");
-    private final String endpoint = requireEnv("STS_BENCHMARK_AWS_ENDPOINT");
+    // Optional: the SDK derives the default regional STS endpoint from the region. Set only for
+    // non-default endpoints (FIPS, VPC/PrivateLink, custom partitions).
+    private final String endpoint = optionalEnv("STS_BENCHMARK_AWS_ENDPOINT");
+    private final String webIdentityToken = optionalEnv("STS_BENCHMARK_AWS_WEB_IDENTITY_TOKEN");
 
     @Override
     public StsClient createStsClient() {
-      return StsClient.builder("aws").withRegion(region).withEndpoint(URI.create(endpoint)).build();
+      StsClient.StsBuilder builder = StsClient.builder(AwsConstants.PROVIDER_ID).withRegion(region);
+      if (endpoint != null) {
+        builder.withEndpoint(URI.create(endpoint));
+      }
+      return builder.build();
     }
 
     @Override
@@ -36,8 +51,8 @@ public class AwsStsBenchmarkTest extends AbstractStsBenchmarkTest {
 
     @Override
     public String getWebIdentityToken() {
-      // AWS web identity federation requires an external OIDC token; not benchmarkable here.
-      return null;
+      // External OIDC token minted by a trusted IdP; supplied via env when available.
+      return webIdentityToken;
     }
 
     @Override

--- a/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsBenchmarkTest.java
+++ b/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsBenchmarkTest.java
@@ -1,0 +1,48 @@
+package com.salesforce.multicloudj.sts.aws;
+
+import com.salesforce.multicloudj.sts.client.AbstractStsBenchmarkTest;
+import com.salesforce.multicloudj.sts.client.StsClient;
+import java.net.URI;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AwsStsBenchmarkTest extends AbstractStsBenchmarkTest {
+
+  @Override
+  protected Harness createHarness() {
+    return new HarnessImpl();
+  }
+
+  @Override
+  protected String getProviderId() {
+    return "aws";
+  }
+
+  public static class HarnessImpl implements Harness {
+
+    private final String region = requireEnv("STS_BENCHMARK_AWS_REGION");
+    private final String roleArn = requireEnv("STS_BENCHMARK_AWS_ROLE_ARN");
+    private final String endpoint = requireEnv("STS_BENCHMARK_AWS_ENDPOINT");
+
+    @Override
+    public StsClient createStsClient() {
+      return StsClient.builder("aws").withRegion(region).withEndpoint(URI.create(endpoint)).build();
+    }
+
+    @Override
+    public String getRoleName() {
+      return roleArn;
+    }
+
+    @Override
+    public String getWebIdentityToken() {
+      // AWS web identity federation requires an external OIDC token; not benchmarkable here.
+      return null;
+    }
+
+    @Override
+    public void close() {
+      // StsClient has no explicit resource to release.
+    }
+  }
+}

--- a/sts/sts-client/pom.xml
+++ b/sts/sts-client/pom.xml
@@ -65,6 +65,18 @@
             </exclusions>
         </dependency>
 
+        <!-- JMH Dependencies for Benchmarking -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- The transitives of the dependencies above -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/AbstractStsBenchmarkTest.java
+++ b/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/AbstractStsBenchmarkTest.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
@@ -66,19 +66,44 @@ public abstract class AbstractStsBenchmarkTest {
   protected abstract String getProviderId();
 
   /**
+   * Whether this provider can issue a short-lived token under the credentials the run uses. When
+   * false, the token-issuance benchmark is dropped from the sweep (see runBenchmarks) rather than
+   * timing a call the provider will reject.
+   */
+  protected abstract boolean supportsGetAccessToken();
+
+  /**
+   * Whether a web-identity (OIDC) token is available for the federation benchmark. Requires an
+   * external token minted by a trusted identity provider; when absent the benchmark is dropped
+   * from the sweep rather than timing an empty method.
+   */
+  protected boolean supportsWebIdentity(Harness probe) {
+    return StringUtils.isNotBlank(probe.getWebIdentityToken());
+  }
+
+  /**
    * Reads a required config value from OS environment first, then from -D system properties.
    * Fails fast with a clear error if neither is set — avoids silent misconfiguration producing
    * garbage benchmark results.
    */
   protected static String requireEnv(String name) {
-    String value = System.getenv(name);
-    if (StringUtils.isBlank(value)) {
-      value = System.getProperty(name);
-    }
+    String value = optionalEnv(name);
     if (StringUtils.isBlank(value)) {
       throw new IllegalStateException("Required environment variable not set: " + name);
     }
     return value;
+  }
+
+  /**
+   * Reads an optional config value from OS environment first, then from -D system properties.
+   * Returns null if neither is set — callers decide whether the absence disables a code path.
+   */
+  protected static String optionalEnv(String name) {
+    String value = System.getenv(name);
+    if (StringUtils.isBlank(value)) {
+      value = System.getProperty(name);
+    }
+    return StringUtils.isBlank(value) ? null : value;
   }
 
   @Setup(Level.Trial)
@@ -115,23 +140,16 @@ public abstract class AbstractStsBenchmarkTest {
   }
 
   /**
-   * Assume role via web identity federation. No-ops when the harness doesn't provide a web
-   * identity token, since not every provider supports this flow in a benchmarkable way. JMH's
-   * Runner doesn't understand JUnit assumptions, so we skip manually instead of using
-   * Assumptions.assumeTrue.
+   * Assume role via web identity federation. Requires an external OIDC token supplied by the
+   * harness; when none is available the benchmark is dropped from the sweep (see runBenchmarks)
+   * rather than timed as an empty method.
    */
   @Benchmark
   public void benchmarkGetAssumeRoleWithWebIdentity(Blackhole bh) {
-    String webIdentityToken = harness.getWebIdentityToken();
-    if (webIdentityToken == null) {
-      bh.consume(webIdentityToken);
-      return;
-    }
-
     AssumeRoleWebIdentityRequest request =
         AssumeRoleWebIdentityRequest.builder()
             .role(harness.getRoleName())
-            .webIdentityToken(webIdentityToken)
+            .webIdentityToken(harness.getWebIdentityToken())
             .sessionName("mcj-benchmark-web-identity-session")
             .expiration(3600)
             .build();
@@ -140,10 +158,8 @@ public abstract class AbstractStsBenchmarkTest {
   }
 
   /**
-   * Short-lived access/session token issuance. Excluded from the default sweep (see
-   * runBenchmarks): AWS GetSessionToken rejects temporary/session credentials, so it cannot run
-   * under the assumed-role creds the pipeline uses. Kept for anyone running with long-term
-   * IAM-user creds. (Mirrors multicloud-py's supports_get_access_token capability gate.)
+   * Short-lived token issuance. Dropped from the default sweep on providers that report they
+   * cannot issue one under the run's credentials (see runBenchmarks and supportsGetAccessToken).
    */
   @Benchmark
   public void benchmarkGetAccessToken(Blackhole bh) {
@@ -167,6 +183,21 @@ public abstract class AbstractStsBenchmarkTest {
     bh.consume(credentials);
   }
 
+  /**
+   * Benchmark-name regexes to exclude from the sweep for this provider, derived from its declared
+   * capabilities. Pulled out of the JMH wiring so the gating is unit-testable without a live run.
+   */
+  List<String> computeExcludes(Harness probe) {
+    List<String> excludes = new ArrayList<>();
+    if (!supportsGetAccessToken()) {
+      excludes.add(".*benchmarkGetAccessToken.*");
+    }
+    if (!supportsWebIdentity(probe)) {
+      excludes.add(".*benchmarkGetAssumeRoleWithWebIdentity.*");
+    }
+    return excludes;
+  }
+
   @Test
   @EnabledIfSystemProperty(named = "runBenchmarks", matches = "true")
   public void runBenchmarks() throws RunnerException {
@@ -177,17 +208,25 @@ public abstract class AbstractStsBenchmarkTest {
       }
     }
 
-    Options opt =
+    ChainedOptionsBuilder builder =
         new OptionsBuilder()
             .include(".*" + this.getClass().getName() + ".*")
-            // GetSessionToken can't be called with session creds; unexercisable in the pipeline.
-            .exclude(".*benchmarkGetAccessToken.*")
             .forks(1)
             .resultFormat(ResultFormatType.JSON)
             .result("target/jmh-sts-results-" + getProviderId() + ".json")
-            .jvmArgsAppend(forwardedArgs.toArray(new String[0]))
-            .build();
+            .jvmArgsAppend(forwardedArgs.toArray(new String[0]));
 
-    new Runner(opt).run();
+    // JMH has no per-method skip and ignores JUnit assumptions under Runner, so unexercisable
+    // benchmarks are excluded here. A throwaway probe harness answers the capability questions;
+    // the live harness is created inside the fork by @Setup.
+    try (Harness probe = createHarness()) {
+      for (String pattern : computeExcludes(probe)) {
+        builder.exclude(pattern);
+      }
+    } catch (Exception e) {
+      throw new RunnerException("Failed to probe harness capabilities", e);
+    }
+
+    new Runner(builder.build()).run();
   }
 }

--- a/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/AbstractStsBenchmarkTest.java
+++ b/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/AbstractStsBenchmarkTest.java
@@ -1,0 +1,193 @@
+package com.salesforce.multicloudj.sts.client;
+
+import com.salesforce.multicloudj.sts.model.AssumeRoleWebIdentityRequest;
+import com.salesforce.multicloudj.sts.model.AssumedRoleRequest;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.GetAccessTokenRequest;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * JMH benchmarks for STS control-plane operations via {@link StsClient}.
+ *
+ * <p>Control-plane auth is latency-primary: STS throttles aggressively, so throughput mostly
+ * measures the provider's rate limiter, not the SDK. The {@code SampleTime} percentiles are the
+ * signal that matters here; {@code Throughput} is retained only for trend comparison.
+ */
+@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class AbstractStsBenchmarkTest {
+
+  // Harness interface
+  public interface Harness extends AutoCloseable {
+    StsClient createStsClient();
+
+    String getRoleName();
+
+    // May return null if the provider doesn't support web-identity federation.
+    String getWebIdentityToken();
+  }
+
+  protected Harness harness;
+  protected StsClient stsClient;
+
+  protected abstract Harness createHarness();
+
+  protected abstract String getProviderId();
+
+  /**
+   * Reads a required config value from OS environment first, then from -D system properties.
+   * Fails fast with a clear error if neither is set — avoids silent misconfiguration producing
+   * garbage benchmark results.
+   */
+  protected static String requireEnv(String name) {
+    String value = System.getenv(name);
+    if (StringUtils.isBlank(value)) {
+      value = System.getProperty(name);
+    }
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalStateException("Required environment variable not set: " + name);
+    }
+    return value;
+  }
+
+  @Setup(Level.Trial)
+  public void setupBenchmark() throws Exception {
+    harness = createHarness();
+    stsClient = harness.createStsClient();
+  }
+
+  @TearDown(Level.Trial)
+  public void teardownBenchmark() throws Exception {
+    if (harness != null) {
+      harness.close();
+    }
+  }
+
+  /** Caller identity lookup - the most common control-plane read. */
+  @Benchmark
+  public void benchmarkGetCallerIdentity(Blackhole bh) {
+    CallerIdentity identity = stsClient.getCallerIdentity();
+    bh.consume(identity);
+  }
+
+  /** Assume role and consume the resulting temporary credentials. */
+  @Benchmark
+  public void benchmarkGetAssumeRoleCredentials(Blackhole bh) {
+    AssumedRoleRequest request =
+        AssumedRoleRequest.newBuilder()
+            .withRole(harness.getRoleName())
+            .withSessionName("mcj-benchmark-session")
+            .withExpiration(3600)
+            .build();
+    StsCredentials credentials = stsClient.getAssumeRoleCredentials(request);
+    bh.consume(credentials);
+  }
+
+  /**
+   * Assume role via web identity federation. No-ops when the harness doesn't provide a web
+   * identity token, since not every provider supports this flow in a benchmarkable way. JMH's
+   * Runner doesn't understand JUnit assumptions, so we skip manually instead of using
+   * Assumptions.assumeTrue.
+   */
+  @Benchmark
+  public void benchmarkGetAssumeRoleWithWebIdentity(Blackhole bh) {
+    String webIdentityToken = harness.getWebIdentityToken();
+    if (webIdentityToken == null) {
+      bh.consume(webIdentityToken);
+      return;
+    }
+
+    AssumeRoleWebIdentityRequest request =
+        AssumeRoleWebIdentityRequest.builder()
+            .role(harness.getRoleName())
+            .webIdentityToken(webIdentityToken)
+            .sessionName("mcj-benchmark-web-identity-session")
+            .expiration(3600)
+            .build();
+    StsCredentials credentials = stsClient.getAssumeRoleWithWebIdentityCredentials(request);
+    bh.consume(credentials);
+  }
+
+  /**
+   * Short-lived access/session token issuance. Excluded from the default sweep (see
+   * runBenchmarks): AWS GetSessionToken rejects temporary/session credentials, so it cannot run
+   * under the assumed-role creds the pipeline uses. Kept for anyone running with long-term
+   * IAM-user creds. (Mirrors multicloud-py's supports_get_access_token capability gate.)
+   */
+  @Benchmark
+  public void benchmarkGetAccessToken(Blackhole bh) {
+    GetAccessTokenRequest request =
+        GetAccessTokenRequest.newBuilder().withDurationSeconds(3600).build();
+    StsCredentials credentials = stsClient.getAccessToken(request);
+    bh.consume(credentials);
+  }
+
+  /** Concurrent assume-role calls to surface refresh-storm/throttling behavior. */
+  @Benchmark
+  @Threads(8)
+  public void benchmarkConcurrentAssumeRole(Blackhole bh) {
+    AssumedRoleRequest request =
+        AssumedRoleRequest.newBuilder()
+            .withRole(harness.getRoleName())
+            .withSessionName("mcj-benchmark-concurrent-session")
+            .withExpiration(3600)
+            .build();
+    StsCredentials credentials = stsClient.getAssumeRoleCredentials(request);
+    bh.consume(credentials);
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "runBenchmarks", matches = "true")
+  public void runBenchmarks() throws RunnerException {
+    List<String> forwardedArgs = new ArrayList<>();
+    for (String key : System.getProperties().stringPropertyNames()) {
+      if (key.startsWith("STS_BENCHMARK_")) {
+        forwardedArgs.add("-D" + key + "=" + System.getProperty(key));
+      }
+    }
+
+    Options opt =
+        new OptionsBuilder()
+            .include(".*" + this.getClass().getName() + ".*")
+            // GetSessionToken can't be called with session creds; unexercisable in the pipeline.
+            .exclude(".*benchmarkGetAccessToken.*")
+            .forks(1)
+            .resultFormat(ResultFormatType.JSON)
+            .result("target/jmh-sts-results-" + getProviderId() + ".json")
+            .jvmArgsAppend(forwardedArgs.toArray(new String[0]))
+            .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/AbstractStsBenchmarkTestGatingTest.java
+++ b/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/AbstractStsBenchmarkTestGatingTest.java
@@ -1,0 +1,97 @@
+package com.salesforce.multicloudj.sts.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the capability-driven benchmark gating in {@link AbstractStsBenchmarkTest}. These
+ * verify that {@code computeExcludes} drops exactly the unexercisable benchmarks for each
+ * provider/token combination, without needing a live JMH run.
+ */
+class AbstractStsBenchmarkTestGatingTest {
+
+  private static final String ACCESS_TOKEN = ".*benchmarkGetAccessToken.*";
+  private static final String WEB_IDENTITY = ".*benchmarkGetAssumeRoleWithWebIdentity.*";
+
+  /** Minimal benchmark instance with capabilities supplied by the test. */
+  private static AbstractStsBenchmarkTest instance(boolean supportsAccessToken) {
+    return new AbstractStsBenchmarkTest() {
+      @Override
+      protected Harness createHarness() {
+        return null;
+      }
+
+      @Override
+      protected String getProviderId() {
+        return "test";
+      }
+
+      @Override
+      protected boolean supportsGetAccessToken() {
+        return supportsAccessToken;
+      }
+    };
+  }
+
+  private static AbstractStsBenchmarkTest.Harness harnessWithToken(String token) {
+    return new AbstractStsBenchmarkTest.Harness() {
+      @Override
+      public StsClient createStsClient() {
+        return null;
+      }
+
+      @Override
+      public String getRoleName() {
+        return "role";
+      }
+
+      @Override
+      public String getWebIdentityToken() {
+        return token;
+      }
+
+      @Override
+      public void close() {}
+    };
+  }
+
+  @Test
+  void noAccessToken_noWebIdentityToken_excludesBoth() {
+    List<String> excludes = instance(false).computeExcludes(harnessWithToken(null));
+    assertTrue(excludes.contains(ACCESS_TOKEN), "no access-token capability drops getAccessToken");
+    assertTrue(excludes.contains(WEB_IDENTITY), "no token must drop web-identity");
+    assertEquals(2, excludes.size());
+  }
+
+  @Test
+  void supportsAccessToken_noWebIdentityToken_excludesOnlyWebIdentity() {
+    List<String> excludes = instance(true).computeExcludes(harnessWithToken(null));
+    assertFalse(excludes.contains(ACCESS_TOKEN), "access-token capable; must not drop it");
+    assertTrue(excludes.contains(WEB_IDENTITY), "no token must drop web-identity");
+    assertEquals(1, excludes.size());
+  }
+
+  @Test
+  void supportsAccessToken_withWebIdentityToken_excludesNothing() {
+    List<String> excludes = instance(true).computeExcludes(harnessWithToken("oidc-jwt"));
+    assertTrue(excludes.isEmpty(), "full-capability run must sweep every benchmark");
+  }
+
+  @Test
+  void noAccessToken_withWebIdentityToken_excludesOnlyAccessToken() {
+    List<String> excludes = instance(false).computeExcludes(harnessWithToken("oidc-jwt"));
+    assertTrue(excludes.contains(ACCESS_TOKEN));
+    assertFalse(excludes.contains(WEB_IDENTITY), "token present; web-identity must be swept");
+    assertEquals(1, excludes.size());
+  }
+
+  @Test
+  void blankWebIdentityToken_isTreatedAsAbsent() {
+    List<String> excludes = instance(true).computeExcludes(harnessWithToken("   "));
+    assertTrue(excludes.contains(WEB_IDENTITY), "blank token must drop web-identity");
+  }
+}

--- a/sts/sts-gcp/pom.xml
+++ b/sts/sts-gcp/pom.xml
@@ -56,6 +56,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-iamcredentials</artifactId>
             <version>2.63.0</version>

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsBenchmarkTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsBenchmarkTest.java
@@ -1,0 +1,46 @@
+package com.salesforce.multicloudj.sts.gcp;
+
+import com.salesforce.multicloudj.common.gcp.GcpConstants;
+import com.salesforce.multicloudj.sts.client.AbstractStsBenchmarkTest;
+import com.salesforce.multicloudj.sts.client.StsClient;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class GcpStsBenchmarkTest extends AbstractStsBenchmarkTest {
+
+  @Override
+  protected Harness createHarness() {
+    return new HarnessImpl();
+  }
+
+  @Override
+  protected String getProviderId() {
+    return GcpConstants.PROVIDER_ID;
+  }
+
+  public static class HarnessImpl implements Harness {
+
+    private final String serviceAccount = requireEnv("STS_BENCHMARK_GCP_SERVICE_ACCOUNT");
+
+    @Override
+    public StsClient createStsClient() {
+      return StsClient.builder(GcpConstants.PROVIDER_ID).build();
+    }
+
+    @Override
+    public String getRoleName() {
+      return serviceAccount;
+    }
+
+    @Override
+    public String getWebIdentityToken() {
+      // GCP token exchange requires an external OIDC token; not benchmarkable here.
+      return null;
+    }
+
+    @Override
+    public void close() {
+      // No client resource to release.
+    }
+  }
+}

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsBenchmarkTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsBenchmarkTest.java
@@ -18,9 +18,15 @@ public class GcpStsBenchmarkTest extends AbstractStsBenchmarkTest {
     return GcpConstants.PROVIDER_ID;
   }
 
+  @Override
+  protected boolean supportsGetAccessToken() {
+    return true;
+  }
+
   public static class HarnessImpl implements Harness {
 
     private final String serviceAccount = requireEnv("STS_BENCHMARK_GCP_SERVICE_ACCOUNT");
+    private final String webIdentityToken = optionalEnv("STS_BENCHMARK_GCP_WEB_IDENTITY_TOKEN");
 
     @Override
     public StsClient createStsClient() {
@@ -34,8 +40,8 @@ public class GcpStsBenchmarkTest extends AbstractStsBenchmarkTest {
 
     @Override
     public String getWebIdentityToken() {
-      // GCP token exchange requires an external OIDC token; not benchmarkable here.
-      return null;
+      // External OIDC token exchanged for a GCP access token; supplied via env when available.
+      return webIdentityToken;
     }
 
     @Override


### PR DESCRIPTION
## Summary
Adds a JMH benchmark suite for STS: `AbstractStsBenchmarkTest` (sts-client) plus thin AWS/GCP concretes. Gated by `@EnabledIfSystemProperty(named="runBenchmarks", matches="true")` — inert in CI (green without fixtures); the chameleon-example-service pipeline opts in explicitly.

**Swept per provider — AWS 3, GCP 4:** `getCallerIdentity`, `getAssumeRoleCredentials`, `concurrentAssumeRole` on both, plus `getAccessToken` on GCP. `getAccessToken` and `getAssumeRoleWithWebIdentity` are kept as `@Benchmark`s but gated out of the sweep when the provider/run can't exercise them (see **Capability gating** below); they re-enter automatically once runnable.

## Testing proof
Run locally against **live AWS + GCP**, both JMH modes (Throughput + SampleTime), producing populated results with zero errors on both clouds. Per-provider swept counts and the capability gating are detailed under **Capability gating** below.

Invocation (creds via OS env only, never `-D`):
```
mvn test -pl sts/sts-aws -Dtest=AwsStsBenchmarkTest -DrunBenchmarks=true \
  -DSTS_BENCHMARK_AWS_REGION=us-west-2 \
  -DSTS_BENCHMARK_AWS_ROLE_ARN=<assumable-role-arn>
  # optional: -DSTS_BENCHMARK_AWS_ENDPOINT=<custom-endpoint>
mvn test -pl sts/sts-gcp -Dtest=GcpStsBenchmarkTest -DrunBenchmarks=true \
  -DSTS_BENCHMARK_GCP_SERVICE_ACCOUNT=<sa-email>
```
Rendered AWS-vs-GCP comparison pages are being published to the benchmark-visualizer (git.soma Pages) alongside the other suites.

## Capability gating (`getAccessToken`, `getAssumeRoleWithWebIdentity`)
JMH has no per-method skip and ignores JUnit assumptions under `Runner`, so unexercisable benchmarks are excluded in `runBenchmarks()` based on per-provider capabilities rather than one blanket `.exclude()`:
- `supportsGetAccessToken()` — AWS `false`, GCP `true`
- `supportsWebIdentity(probe)` — true iff `STS_BENCHMARK_<CLOUD>_WEB_IDENTITY_TOKEN` is set

This replaces the previous unconditional `.exclude(getAccessToken)`, which also stripped GCP even though GCP implements the operation. It also removes the old in-method `if (token == null) return` no-op in `getAssumeRoleWithWebIdentity` — that shipped an empty method to JMH, which timed it as a ~1.5×10⁹ ops/s row indistinguishable from real data.

**Verified live on 2026-08-13 — both clouds, both token states:**
- **AWS `getAccessToken` still unrunnable:** a direct `GetSessionToken` under the assumed-role creds returns `AccessDenied: Cannot call GetSessionToken with session credentials` (AWS maps `getAccessToken` → `GetSessionToken`). `supportsGetAccessToken()=false` excludes it; the gate keeps this AWS-only so GCP is no longer stripped.
- **AWS, no token:** swept 3 (`getCallerIdentity`, `getAssumeRoleCredentials`, `concurrentAssumeRole`); `getAccessToken` and web-identity excluded. Run omitted `STS_BENCHMARK_AWS_ENDPOINT`, confirming the client derives the default regional endpoint.
- **AWS, token set:** web-identity entered the sweep and made a live `AssumeRoleWithWebIdentity` call; AWS rejected the placeholder token server-side (`InvalidIdentityTokenException`, 400) — proof the call is live, not a no-op.
- **GCP, no token:** swept 4 (adds `getAccessToken`); web-identity excluded. `getAccessToken` produced a real datapoint — coverage the old blanket exclude was denying GCP.
- **GCP, token set:** web-identity entered the sweep and made a live STS token-exchange call; GCP rejected the placeholder token (`400 invalid_request`).

Gating is covered by a deterministic unit test (`AbstractStsBenchmarkTestGatingTest`, 5 cases, no creds) that runs in CI.

## Run contract
- sts-aws: `STS_BENCHMARK_AWS_{REGION,ROLE_ARN}` required; `STS_BENCHMARK_AWS_ENDPOINT` optional (default regional endpoint derived from region); `STS_BENCHMARK_AWS_WEB_IDENTITY_TOKEN` optional (enables the web-identity benchmark)
- sts-gcp: `STS_BENCHMARK_GCP_SERVICE_ACCOUNT` required; `STS_BENCHMARK_GCP_WEB_IDENTITY_TOKEN` optional (enables the web-identity benchmark)

## JMH config note
The class-level `@Warmup`/`@Measurement`/`@Fork` are the local-run baseline. The chameleon pipeline vendors these files and drives JMH via its own `BenchmarkRunner`, overriding warmup/measurement/forks via env vars — so those annotations are not the pipeline's config.

## Downstream
Running this in the pipeline needs a separate vendor-sync PR into sfdc-bazel (new Bazel target + `runtime_deps` wiring + any infra/cron); it does not propagate automatically.

## Merge order
Independent of the other suite PRs. Recommend the root-pom JMH fix (`build: add jmh-generator-annprocess…`) merges first so this is runnable on JDK 21+.
