### PR TITLE
iam: add JMH benchmark suite

### DIFF
--- a/iam/iam-aws/pom.xml
+++ b/iam/iam-aws/pom.xml
@@ -79,6 +79,11 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/iam/iam-aws/src/test/java/com/salesforce/multicloudj/iam/aws/AwsIamBenchmarkTest.java
+++ b/iam/iam-aws/src/test/java/com/salesforce/multicloudj/iam/aws/AwsIamBenchmarkTest.java
@@ -1,0 +1,82 @@
+package com.salesforce.multicloudj.iam.aws;
+
+import com.salesforce.multicloudj.iam.client.AbstractIamBenchmarkTest;
+import com.salesforce.multicloudj.iam.client.IamClient;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AwsIamBenchmarkTest extends AbstractIamBenchmarkTest {
+
+  @Override
+  protected Harness createHarness() {
+    return new HarnessImpl();
+  }
+
+  @Override
+  protected String getProviderId() {
+    return "aws";
+  }
+
+  public static class HarnessImpl implements Harness {
+
+    private final String region = requireEnv("IAM_BENCHMARK_AWS_REGION");
+    private final String identityName = requireEnv("IAM_BENCHMARK_AWS_IDENTITY_NAME");
+    private final String tenantId = requireEnv("IAM_BENCHMARK_AWS_TENANT_ID");
+    private final String policyName = requireEnv("IAM_BENCHMARK_AWS_POLICY_NAME");
+    private final String endpoint = requireEnv("IAM_BENCHMARK_AWS_ENDPOINT");
+    private final String policyResource = requireEnv("IAM_BENCHMARK_AWS_POLICY_RESOURCE");
+
+    @Override
+    public IamClient createIamClient() {
+      // Credentials flow via the AWS default provider chain (OS env / profile), never -D.
+      return IamClient.builder("aws").withRegion(region).withEndpoint(URI.create(endpoint)).build();
+    }
+
+    @Override
+    public String getIdentityName() {
+      return identityName;
+    }
+
+    @Override
+    public String getTenantId() {
+      return tenantId;
+    }
+
+    @Override
+    public String getRegion() {
+      return region;
+    }
+
+    @Override
+    public String getPolicyName() {
+      return policyName;
+    }
+
+    @Override
+    public String getRoleName() {
+      return identityName;
+    }
+
+    @Override
+    public List<String> getPolicyActions() {
+      return List.of("storage:GetObject", "storage:PutObject");
+    }
+
+    @Override
+    public String getPolicyResource() {
+      return policyResource;
+    }
+
+    @Override
+    public String getPolicyVersion() {
+      return "2012-10-17";
+    }
+
+    @Override
+    public void close() {
+      // IamClient owns and closes the underlying AWS SDK IamClient
+    }
+  }
+}

--- a/iam/iam-client/pom.xml
+++ b/iam/iam-client/pom.xml
@@ -59,6 +59,18 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
+        <!-- JMH Dependencies for Benchmarking -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/iam/iam-client/src/test/java/com/salesforce/multicloudj/iam/client/AbstractIamBenchmarkTest.java
+++ b/iam/iam-client/src/test/java/com/salesforce/multicloudj/iam/client/AbstractIamBenchmarkTest.java
@@ -1,0 +1,337 @@
+package com.salesforce.multicloudj.iam.client;
+
+import com.salesforce.multicloudj.iam.model.Action;
+import com.salesforce.multicloudj.iam.model.AttachInlinePolicyRequest;
+import com.salesforce.multicloudj.iam.model.Effect;
+import com.salesforce.multicloudj.iam.model.GetAttachedPoliciesRequest;
+import com.salesforce.multicloudj.iam.model.GetInlinePolicyDetailsRequest;
+import com.salesforce.multicloudj.iam.model.PolicyDocument;
+import com.salesforce.multicloudj.iam.model.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * JMH benchmarks for IAM control-plane operations via {@link IamClient}.
+ *
+ * <p>IAM is latency-primary: the SetIamPolicy/GetIamPolicy backend throttles hard, so throughput
+ * mostly reflects the provider's rate limiter. The {@code SampleTime} percentiles are the signal;
+ * {@code Throughput} is kept only for trend comparison.
+ */
+@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+// No @Threads: benchmarks read-modify-write a single shared IAM policy (project or role), so
+// concurrent invocations would race on GetIamPolicy/SetIamPolicy and corrupt each other's bindings.
+public abstract class AbstractIamBenchmarkTest {
+
+  private final AtomicInteger nextLifecycleId = new AtomicInteger(0);
+
+  // Harness interface
+  public interface Harness extends AutoCloseable {
+    IamClient createIamClient();
+
+    String getIdentityName();
+
+    String getTenantId();
+
+    String getRegion();
+
+    String getPolicyName();
+
+    String getRoleName();
+
+    List<String> getPolicyActions();
+
+    default String getPolicyResource() {
+      return null;
+    }
+
+    default String getPolicyVersion() {
+      return "";
+    }
+
+    default String getLifecycleIdentityPrefix() {
+      return "iam-benchmark-lifecycle-";
+    }
+
+    /**
+     * Converts a raw identity name/id into the form the provider's attach/remove policy calls
+     * expect as {@code identityName} (e.g. GCP needs a "serviceAccount:email" member string,
+     * not the bare account id used to create the identity).
+     */
+    default String toPolicyMember(String identityName, String identityId) {
+      return identityName;
+    }
+  }
+
+  protected Harness harness;
+  protected IamClient iamClient;
+
+  protected abstract Harness createHarness();
+
+  protected abstract String getProviderId();
+
+  /**
+   * Reads a required config value from OS environment first, then from -D system properties.
+   * Fails fast with a clear error if neither is set.
+   */
+  protected static String requireEnv(String name) {
+    String value = System.getenv(name);
+    if (StringUtils.isBlank(value)) {
+      value = System.getProperty(name);
+    }
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalStateException("Required environment variable not set: " + name);
+    }
+    return value;
+  }
+
+  @Setup(Level.Trial)
+  public void setupBenchmark() throws Exception {
+    try {
+      harness = createHarness();
+      iamClient = harness.createIamClient();
+
+      // Seed the inline policy that benchmarkGetAttachedPolicies / benchmarkGetInlinePolicyDetails
+      // read. Tolerate an already-attached policy (e.g. left over from a previously aborted trial):
+      // the read benchmarks only need it to exist, and teardown removes it. A hard failure here
+      // would wedge every benchmark method in the class.
+      try {
+        iamClient.attachInlinePolicy(
+            AttachInlinePolicyRequest.builder()
+                .policyDocument(buildPolicyDocument(harness.getPolicyName()))
+                .tenantId(harness.getTenantId())
+                .region(harness.getRegion())
+                .identityName(harness.getIdentityName())
+                .build());
+      } catch (Exception e) {
+        // Best-effort seed; the policy may already be attached. Read benchmarks tolerate this.
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to setup benchmark", e);
+    }
+  }
+
+  @TearDown(Level.Trial)
+  public void teardownBenchmark() throws Exception {
+    try {
+      if (iamClient != null) {
+        try {
+          iamClient.removePolicy(
+              harness.getIdentityName(),
+              harness.getPolicyName(),
+              harness.getTenantId(),
+              harness.getRegion());
+        } catch (Exception e) {
+          // Continue cleanup on error
+        }
+        iamClient.close();
+      }
+
+      if (harness != null) {
+        harness.close();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Error closing harness", e);
+    }
+  }
+
+  private PolicyDocument buildPolicyDocument(String policyName) {
+    Statement.StatementBuilder statementBuilder = Statement.builder().effect(Effect.ALLOW);
+    if (harness.getPolicyResource() != null) {
+      statementBuilder.resource(harness.getPolicyResource());
+    }
+    for (String action : harness.getPolicyActions()) {
+      statementBuilder.action(Action.of(action));
+    }
+    return PolicyDocument.builder()
+        .name(policyName)
+        .version(harness.getPolicyVersion())
+        .statement(statementBuilder.build())
+        .build();
+  }
+
+  /** Get Identity - read steady-state, the most common op. */
+  @Benchmark
+  public void benchmarkGetIdentity(Blackhole bh) {
+    try {
+      String identity =
+          iamClient.getIdentity(
+              harness.getIdentityName(), harness.getTenantId(), harness.getRegion());
+      bh.consume(identity);
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark get identity failed", e);
+    }
+  }
+
+  /** Get Attached Policies - list, possibly paginated. */
+  @Benchmark
+  public void benchmarkGetAttachedPolicies(Blackhole bh) {
+    try {
+      List<String> attachedPolicies =
+          iamClient.getAttachedPolicies(
+              GetAttachedPoliciesRequest.builder()
+                  .roleName(harness.getRoleName())
+                  .identityName(harness.getIdentityName())
+                  .tenantId(harness.getTenantId())
+                  .region(harness.getRegion())
+                  .build());
+      bh.consume(attachedPolicies);
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark get attached policies failed", e);
+    }
+  }
+
+  /** Get Inline Policy Details - fetch + parse. */
+  @Benchmark
+  public void benchmarkGetInlinePolicyDetails(Blackhole bh) {
+    try {
+      String policyDetails =
+          iamClient.getInlinePolicyDetails(
+              GetInlinePolicyDetailsRequest.builder()
+                  .identityName(harness.getIdentityName())
+                  .policyName(harness.getPolicyName())
+                  .roleName(harness.getRoleName())
+                  .tenantId(harness.getTenantId())
+                  .region(harness.getRegion())
+                  .build());
+      bh.consume(policyDetails);
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark get inline policy details failed", e);
+    }
+  }
+
+  /** Create/Attach/Remove/Delete identity lifecycle; bundled so mutating ops self-clean. */
+  @Benchmark
+  public void benchmarkCreateAttachDeleteIdentity(Blackhole bh) {
+    String identityName = harness.getLifecycleIdentityPrefix() + nextLifecycleId.incrementAndGet();
+    // Reuse harness.getPolicyName() rather than a per-invocation name: GCP's removePolicy matches
+    // against the role translated from policy actions (not the document name), so the name must be
+    // identical between attach and remove. Uniqueness comes from identityName instead.
+    String lifecyclePolicyName = harness.getPolicyName();
+    boolean identityCreated = false;
+
+    try {
+      String identityId =
+          iamClient.createIdentity(
+              identityName,
+              "IAM benchmark lifecycle identity",
+              harness.getTenantId(),
+              harness.getRegion(),
+              Optional.empty(),
+              Optional.empty());
+      identityCreated = true;
+      bh.consume(identityId);
+
+      String policyMember = harness.toPolicyMember(identityName, identityId);
+
+      // Some providers create identities eventually-consistently: the attach can race propagation
+      // and fail with "does not exist". Retry briefly; read-after-write providers pass first try.
+      attachWithPropagationRetry(lifecyclePolicyName, policyMember);
+
+      iamClient.removePolicy(
+          policyMember, lifecyclePolicyName, harness.getTenantId(), harness.getRegion());
+    } finally {
+      if (identityCreated) {
+        try {
+          iamClient.deleteIdentity(identityName, harness.getTenantId(), harness.getRegion());
+        } catch (Exception e) {
+          // Guard cleanup so a failure mid-sequence doesn't wedge the trial
+        }
+      }
+    }
+  }
+
+  // Bounded retry to absorb create->attach eventual-consistency lag (identity not yet propagated).
+  private static final int ATTACH_MAX_ATTEMPTS = 5;
+  private static final long ATTACH_RETRY_BASE_MILLIS = 500L;
+
+  private void attachWithPropagationRetry(String policyName, String policyMember) {
+    RuntimeException last = null;
+    for (int attempt = 1; attempt <= ATTACH_MAX_ATTEMPTS; attempt++) {
+      try {
+        iamClient.attachInlinePolicy(
+            AttachInlinePolicyRequest.builder()
+                .policyDocument(buildPolicyDocument(policyName))
+                .tenantId(harness.getTenantId())
+                .region(harness.getRegion())
+                .identityName(policyMember)
+                .build());
+        return;
+      } catch (RuntimeException e) {
+        last = e;
+        if (!isIdentityNotPropagated(e) || attempt == ATTACH_MAX_ATTEMPTS) {
+          throw e;
+        }
+        try {
+          Thread.sleep(ATTACH_RETRY_BASE_MILLIS * attempt);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw e;
+        }
+      }
+    }
+    throw last;
+  }
+
+  private static boolean isIdentityNotPropagated(Throwable t) {
+    for (Throwable cur = t; cur != null; cur = cur.getCause()) {
+      String msg = cur.getMessage();
+      if (msg != null && msg.toLowerCase().contains("does not exist")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "runBenchmarks", matches = "true")
+  public void runBenchmarks() throws RunnerException {
+    List<String> forwardedArgs = new ArrayList<>();
+    for (String key : System.getProperties().stringPropertyNames()) {
+      if (key.startsWith("IAM_BENCHMARK_")) {
+        forwardedArgs.add("-D" + key + "=" + System.getProperty(key));
+      }
+    }
+
+    Options opt =
+        new OptionsBuilder()
+            .include(".*" + this.getClass().getName() + ".*")
+            .forks(1)
+            .resultFormat(ResultFormatType.JSON)
+            .result("target/jmh-iam-results-" + getProviderId() + ".json")
+            .jvmArgsAppend(forwardedArgs.toArray(new String[0]))
+            .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/iam/iam-client/src/test/java/com/salesforce/multicloudj/iam/client/AbstractIamBenchmarkTest.java
+++ b/iam/iam-client/src/test/java/com/salesforce/multicloudj/iam/client/AbstractIamBenchmarkTest.java
@@ -163,6 +163,10 @@ public abstract class AbstractIamBenchmarkTest {
       // re-runs and forks never collide on names.
       String identityName =
           harness.getLifecycleIdentityPrefix() + (System.nanoTime() & 0xFFFFFFFFL);
+      // Track before creating: a create RPC can commit server-side and still surface an error to
+      // the client, so the name must be drainable even if createIdentity throws. Deleting a
+      // never-created name is swallowed downstream.
+      createdIdentities.add(identityName);
       String identityId =
           iamClient.createIdentity(
               identityName,
@@ -171,7 +175,6 @@ public abstract class AbstractIamBenchmarkTest {
               harness.getRegion(),
               Optional.empty(),
               Optional.empty());
-      createdIdentities.add(identityName);
       lifecycleIdentityName = identityName;
       lifecyclePolicyMember = harness.toPolicyMember(identityName, identityId);
 

--- a/iam/iam-client/src/test/java/com/salesforce/multicloudj/iam/client/AbstractIamBenchmarkTest.java
+++ b/iam/iam-client/src/test/java/com/salesforce/multicloudj/iam/client/AbstractIamBenchmarkTest.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -41,9 +42,9 @@ import org.slf4j.LoggerFactory;
 /**
  * JMH benchmarks for IAM control-plane operations via {@link IamClient}.
  *
- * <p>IAM is latency-primary: the SetIamPolicy/GetIamPolicy backend throttles hard, so throughput
- * mostly reflects the provider's rate limiter. The {@code SampleTime} percentiles are the signal;
- * {@code Throughput} is kept only for trend comparison.
+ * <p>IAM is latency-primary: the policy backend throttles hard, so throughput mostly reflects the
+ * provider's rate limiter. The {@code SampleTime} percentiles are the signal; {@code Throughput}
+ * is kept only for trend comparison.
  */
 @BenchmarkMode({Mode.Throughput, Mode.SampleTime})
 @OutputTimeUnit(TimeUnit.SECONDS)
@@ -52,23 +53,24 @@ import org.slf4j.LoggerFactory;
 @Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-// No @Threads: benchmarks read-modify-write a single shared IAM policy (project or role), so
-// concurrent invocations would race on GetIamPolicy/SetIamPolicy and corrupt each other's bindings.
+// No @Threads: benchmarks read-modify-write one shared IAM policy; concurrent invocations would
+// race and corrupt each other's bindings.
 public abstract class AbstractIamBenchmarkTest {
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractIamBenchmarkTest.class);
 
-  // Identities minted during setup; drained in @TearDown so a run never leaks real cloud
-  // principals (e.g. GCP soft-deleted service accounts count against the 100/project quota
-  // for 30 days). ConcurrentHashMap.newKeySet() mirrors AbstractDocstoreBenchmarkTest's pattern.
+  // Minted during setup, drained in cleanup() so a run never leaks real principals (a deleted
+  // identity may still count against an account quota during a retention window).
   private final Set<String> createdIdentities = ConcurrentHashMap.newKeySet();
 
-  // Lifecycle identity created once in @Setup and reused by benchmarkAttachRemovePolicy so the
-  // create RPC and its eventual-consistency wait stay OUT of the timed region.
   private String lifecycleIdentityName;
   private String lifecyclePolicyMember;
 
-  // Harness interface
+  // cleanup() runs from both @TearDown and a shutdown hook (JMH skips @TearDown on an aborted
+  // trial); this guard makes whichever loses the race a no-op.
+  private final AtomicBoolean cleaned = new AtomicBoolean(false);
+  private Thread cleanupHook;
+
   public interface Harness extends AutoCloseable {
     IamClient createIamClient();
 
@@ -92,25 +94,17 @@ public abstract class AbstractIamBenchmarkTest {
       return "";
     }
 
-    // Kept short: GCP service-account ids cap at 30 chars, and callers append a numeric suffix.
+    // Kept short: some providers cap identity ids (~30 chars); callers append a numeric suffix.
     default String getLifecycleIdentityPrefix() {
       return "iam-bench-lc-";
     }
 
-    /**
-     * Converts a raw identity name/id into the form the provider's attach/remove policy calls
-     * expect as {@code identityName} (e.g. GCP needs a "serviceAccount:email" member string,
-     * not the bare account id used to create the identity).
-     */
+    /** Identity form the attach/remove calls expect; providers needing a typed member override. */
     default String toPolicyMember(String identityName, String identityId) {
       return identityName;
     }
 
-    /**
-     * The member string for the pre-seeded read identity ({@link #getIdentityName()}) as
-     * attach/remove/get-policy expect it. GCP needs "serviceAccount:email" here, not the bare
-     * email that {@code getIdentity} consumes; AWS is role-scoped and unaffected.
-     */
+    /** Pre-seeded read identity ({@link #getIdentityName()}) as the policy calls expect it. */
     default String getPolicyMemberName() {
       return toPolicyMember(getIdentityName(), getIdentityName());
     }
@@ -140,16 +134,18 @@ public abstract class AbstractIamBenchmarkTest {
 
   @Setup(Level.Trial)
   public void setupBenchmark() throws Exception {
+    // Arm before any RPC that can throw: identities are registered as minted, so the hook drains
+    // them even if setup fails partway.
+    cleanupHook = new Thread(this::cleanup, "iam-benchmark-cleanup");
+    Runtime.getRuntime().addShutdownHook(cleanupHook);
     try {
       harness = createHarness();
       iamClient = harness.createIamClient();
 
-      // Seed the inline policy that benchmarkGetAttachedPolicies / benchmarkGetInlinePolicyDetails
-      // read. Use the member form (GCP needs "serviceAccount:email"): with the bare identity name
-      // the GCP SetIamPolicy is rejected, and both read benchmarks would then measure a
-      // silently-empty lookup instead of a populated policy. Tolerate an already-attached policy
-      // (e.g. left over from an aborted trial) but log it: on AWS a missing seed throws loudly, on
-      // GCP it is silent, so an unlogged swallow hides the failure on the provider where it bites.
+      // Seed the inline policy the read benchmarks consume, via the member form: seeding with the
+      // bare name is rejected on providers needing a typed member, leaving the reads measuring an
+      // empty lookup. Tolerate an already-attached policy (aborted trial) but log it — some
+      // providers fail the seed silently.
       try {
         iamClient.attachInlinePolicy(
             AttachInlinePolicyRequest.builder()
@@ -163,10 +159,8 @@ public abstract class AbstractIamBenchmarkTest {
             "Seed attachInlinePolicy failed (may already be attached): {}", e.getMessage());
       }
 
-      // Create the lifecycle identity ONCE here, absorbing create + eventual-consistency lag
-      // outside any timed region, so benchmarkAttachRemovePolicy times only attach/remove against
-      // an already-propagated principal. Suffix with nanoTime so re-runs (and forks, which restart
-      // JMH counters at 0) never collide on names.
+      // Create the lifecycle identity once here, outside any timed region; nanoTime suffix so
+      // re-runs and forks never collide on names.
       String identityName =
           harness.getLifecycleIdentityPrefix() + (System.nanoTime() & 0xFFFFFFFFL);
       String identityId =
@@ -181,8 +175,7 @@ public abstract class AbstractIamBenchmarkTest {
       lifecycleIdentityName = identityName;
       lifecyclePolicyMember = harness.toPolicyMember(identityName, identityId);
 
-      // Prime propagation here (not in the benchmark): attach then remove once, retrying the
-      // create->attach eventual-consistency window so the timed benchmark never pays for it.
+      // Prime propagation here, not in the benchmark, so the timed region never pays for it.
       attachWithPropagationRetry(harness.getPolicyName(), lifecyclePolicyMember);
       iamClient.removePolicy(
           lifecyclePolicyMember,
@@ -195,9 +188,27 @@ public abstract class AbstractIamBenchmarkTest {
   }
 
   @TearDown(Level.Trial)
-  public void teardownBenchmark() throws Exception {
-    try {
-      if (iamClient != null) {
+  public void teardownBenchmark() {
+    cleanup();
+    if (cleanupHook != null) {
+      try {
+        Runtime.getRuntime().removeShutdownHook(cleanupHook);
+      } catch (IllegalStateException e) {
+        // Shutdown already in progress — the hook is running/ran; nothing to remove.
+      }
+    }
+  }
+
+  /**
+   * Removes the seed policy, drains minted identities, closes client/harness. Runs once (guarded
+   * by {@link #cleaned}); swallows per-step failures so one bad delete can't strand the rest.
+   */
+  private void cleanup() {
+    if (!cleaned.compareAndSet(false, true)) {
+      return;
+    }
+    if (iamClient != null) {
+      if (harness != null) {
         try {
           iamClient.removePolicy(
               harness.getPolicyMemberName(),
@@ -205,29 +216,32 @@ public abstract class AbstractIamBenchmarkTest {
               harness.getTenantId(),
               harness.getRegion());
         } catch (Exception e) {
-          logger.warn("Failed to remove seed policy in teardown: {}", e.getMessage());
+          logger.warn("Failed to remove seed policy in cleanup: {}", e.getMessage());
         }
+      }
 
-        // Drain every identity minted this run so nothing leaks (mirrors
-        // AbstractDocstoreBenchmarkTest). GCP soft-deleted service accounts count against the
-        // 100/project quota for 30 days, so a leaked identity is not merely cosmetic.
-        for (String identityName : createdIdentities) {
-          try {
-            iamClient.deleteIdentity(identityName, harness.getTenantId(), harness.getRegion());
-          } catch (Exception e) {
-            logger.warn("Failed to delete benchmark identity {}: {}", identityName, e.getMessage());
-          }
+      for (String identityName : createdIdentities) {
+        try {
+          iamClient.deleteIdentity(identityName, harness.getTenantId(), harness.getRegion());
+        } catch (Exception e) {
+          logger.warn("Failed to delete benchmark identity {}: {}", identityName, e.getMessage());
         }
-        createdIdentities.clear();
+      }
+      createdIdentities.clear();
 
+      try {
         iamClient.close();
+      } catch (Exception e) {
+        logger.warn("Failed to close IAM client in cleanup: {}", e.getMessage());
       }
+    }
 
-      if (harness != null) {
+    if (harness != null) {
+      try {
         harness.close();
+      } catch (Exception e) {
+        logger.warn("Failed to close harness in cleanup: {}", e.getMessage());
       }
-    } catch (Exception e) {
-      throw new RuntimeException("Error closing harness", e);
     }
   }
 
@@ -297,14 +311,10 @@ public abstract class AbstractIamBenchmarkTest {
   }
 
   /**
-   * Attach then remove an inline policy on an already-propagated identity.
-   *
-   * <p>Times only the two mutating control-plane RPCs. The identity's create and its
-   * eventual-consistency wait happen once in {@link #setupBenchmark()}, and its delete in
-   * {@link #teardownBenchmark()} — none of that RPC cost bleeds into this measurement, and no
-   * {@code Thread.sleep} backoff runs inside the timed region. Reuses {@code getPolicyName()} for
-   * both calls because GCP's removePolicy matches on the role translated from the policy actions,
-   * not the document name, so attach and remove must name the same role.
+   * Attach then remove an inline policy on an already-propagated identity — times only the two
+   * mutating RPCs; create and delete happen in setup/cleanup. Reuses {@code getPolicyName()} for
+   * both calls: some providers match removePolicy on the role translated from the actions, not the
+   * document name, so attach and remove must name the same role.
    */
   @Benchmark
   public void benchmarkAttachRemovePolicy(Blackhole bh) {
@@ -321,7 +331,7 @@ public abstract class AbstractIamBenchmarkTest {
     bh.consume(lifecycleIdentityName);
   }
 
-  // Bounded retry to absorb create->attach eventual-consistency lag (identity not yet propagated).
+  // Bounded retry to absorb create->attach propagation lag on eventually-consistent providers.
   private static final int ATTACH_MAX_ATTEMPTS = 5;
   private static final long ATTACH_RETRY_BASE_MILLIS = 500L;
 

--- a/iam/iam-client/src/test/java/com/salesforce/multicloudj/iam/client/AbstractIamBenchmarkTest.java
+++ b/iam/iam-client/src/test/java/com/salesforce/multicloudj/iam/client/AbstractIamBenchmarkTest.java
@@ -10,8 +10,9 @@ import com.salesforce.multicloudj.iam.model.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -34,6 +35,8 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * JMH benchmarks for IAM control-plane operations via {@link IamClient}.
@@ -53,7 +56,17 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 // concurrent invocations would race on GetIamPolicy/SetIamPolicy and corrupt each other's bindings.
 public abstract class AbstractIamBenchmarkTest {
 
-  private final AtomicInteger nextLifecycleId = new AtomicInteger(0);
+  private static final Logger logger = LoggerFactory.getLogger(AbstractIamBenchmarkTest.class);
+
+  // Identities minted during setup; drained in @TearDown so a run never leaks real cloud
+  // principals (e.g. GCP soft-deleted service accounts count against the 100/project quota
+  // for 30 days). ConcurrentHashMap.newKeySet() mirrors AbstractDocstoreBenchmarkTest's pattern.
+  private final Set<String> createdIdentities = ConcurrentHashMap.newKeySet();
+
+  // Lifecycle identity created once in @Setup and reused by benchmarkAttachRemovePolicy so the
+  // create RPC and its eventual-consistency wait stay OUT of the timed region.
+  private String lifecycleIdentityName;
+  private String lifecyclePolicyMember;
 
   // Harness interface
   public interface Harness extends AutoCloseable {
@@ -79,8 +92,9 @@ public abstract class AbstractIamBenchmarkTest {
       return "";
     }
 
+    // Kept short: GCP service-account ids cap at 30 chars, and callers append a numeric suffix.
     default String getLifecycleIdentityPrefix() {
-      return "iam-benchmark-lifecycle-";
+      return "iam-bench-lc-";
     }
 
     /**
@@ -90,6 +104,15 @@ public abstract class AbstractIamBenchmarkTest {
      */
     default String toPolicyMember(String identityName, String identityId) {
       return identityName;
+    }
+
+    /**
+     * The member string for the pre-seeded read identity ({@link #getIdentityName()}) as
+     * attach/remove/get-policy expect it. GCP needs "serviceAccount:email" here, not the bare
+     * email that {@code getIdentity} consumes; AWS is role-scoped and unaffected.
+     */
+    default String getPolicyMemberName() {
+      return toPolicyMember(getIdentityName(), getIdentityName());
     }
   }
 
@@ -122,20 +145,50 @@ public abstract class AbstractIamBenchmarkTest {
       iamClient = harness.createIamClient();
 
       // Seed the inline policy that benchmarkGetAttachedPolicies / benchmarkGetInlinePolicyDetails
-      // read. Tolerate an already-attached policy (e.g. left over from a previously aborted trial):
-      // the read benchmarks only need it to exist, and teardown removes it. A hard failure here
-      // would wedge every benchmark method in the class.
+      // read. Use the member form (GCP needs "serviceAccount:email"): with the bare identity name
+      // the GCP SetIamPolicy is rejected, and both read benchmarks would then measure a
+      // silently-empty lookup instead of a populated policy. Tolerate an already-attached policy
+      // (e.g. left over from an aborted trial) but log it: on AWS a missing seed throws loudly, on
+      // GCP it is silent, so an unlogged swallow hides the failure on the provider where it bites.
       try {
         iamClient.attachInlinePolicy(
             AttachInlinePolicyRequest.builder()
                 .policyDocument(buildPolicyDocument(harness.getPolicyName()))
                 .tenantId(harness.getTenantId())
                 .region(harness.getRegion())
-                .identityName(harness.getIdentityName())
+                .identityName(harness.getPolicyMemberName())
                 .build());
       } catch (Exception e) {
-        // Best-effort seed; the policy may already be attached. Read benchmarks tolerate this.
+        logger.warn(
+            "Seed attachInlinePolicy failed (may already be attached): {}", e.getMessage());
       }
+
+      // Create the lifecycle identity ONCE here, absorbing create + eventual-consistency lag
+      // outside any timed region, so benchmarkAttachRemovePolicy times only attach/remove against
+      // an already-propagated principal. Suffix with nanoTime so re-runs (and forks, which restart
+      // JMH counters at 0) never collide on names.
+      String identityName =
+          harness.getLifecycleIdentityPrefix() + (System.nanoTime() & 0xFFFFFFFFL);
+      String identityId =
+          iamClient.createIdentity(
+              identityName,
+              "IAM benchmark lifecycle identity",
+              harness.getTenantId(),
+              harness.getRegion(),
+              Optional.empty(),
+              Optional.empty());
+      createdIdentities.add(identityName);
+      lifecycleIdentityName = identityName;
+      lifecyclePolicyMember = harness.toPolicyMember(identityName, identityId);
+
+      // Prime propagation here (not in the benchmark): attach then remove once, retrying the
+      // create->attach eventual-consistency window so the timed benchmark never pays for it.
+      attachWithPropagationRetry(harness.getPolicyName(), lifecyclePolicyMember);
+      iamClient.removePolicy(
+          lifecyclePolicyMember,
+          harness.getPolicyName(),
+          harness.getTenantId(),
+          harness.getRegion());
     } catch (Exception e) {
       throw new RuntimeException("Failed to setup benchmark", e);
     }
@@ -147,13 +200,26 @@ public abstract class AbstractIamBenchmarkTest {
       if (iamClient != null) {
         try {
           iamClient.removePolicy(
-              harness.getIdentityName(),
+              harness.getPolicyMemberName(),
               harness.getPolicyName(),
               harness.getTenantId(),
               harness.getRegion());
         } catch (Exception e) {
-          // Continue cleanup on error
+          logger.warn("Failed to remove seed policy in teardown: {}", e.getMessage());
         }
+
+        // Drain every identity minted this run so nothing leaks (mirrors
+        // AbstractDocstoreBenchmarkTest). GCP soft-deleted service accounts count against the
+        // 100/project quota for 30 days, so a leaked identity is not merely cosmetic.
+        for (String identityName : createdIdentities) {
+          try {
+            iamClient.deleteIdentity(identityName, harness.getTenantId(), harness.getRegion());
+          } catch (Exception e) {
+            logger.warn("Failed to delete benchmark identity {}: {}", identityName, e.getMessage());
+          }
+        }
+        createdIdentities.clear();
+
         iamClient.close();
       }
 
@@ -201,7 +267,7 @@ public abstract class AbstractIamBenchmarkTest {
           iamClient.getAttachedPolicies(
               GetAttachedPoliciesRequest.builder()
                   .roleName(harness.getRoleName())
-                  .identityName(harness.getIdentityName())
+                  .identityName(harness.getPolicyMemberName())
                   .tenantId(harness.getTenantId())
                   .region(harness.getRegion())
                   .build());
@@ -218,7 +284,7 @@ public abstract class AbstractIamBenchmarkTest {
       String policyDetails =
           iamClient.getInlinePolicyDetails(
               GetInlinePolicyDetailsRequest.builder()
-                  .identityName(harness.getIdentityName())
+                  .identityName(harness.getPolicyMemberName())
                   .policyName(harness.getPolicyName())
                   .roleName(harness.getRoleName())
                   .tenantId(harness.getTenantId())
@@ -230,45 +296,29 @@ public abstract class AbstractIamBenchmarkTest {
     }
   }
 
-  /** Create/Attach/Remove/Delete identity lifecycle; bundled so mutating ops self-clean. */
+  /**
+   * Attach then remove an inline policy on an already-propagated identity.
+   *
+   * <p>Times only the two mutating control-plane RPCs. The identity's create and its
+   * eventual-consistency wait happen once in {@link #setupBenchmark()}, and its delete in
+   * {@link #teardownBenchmark()} — none of that RPC cost bleeds into this measurement, and no
+   * {@code Thread.sleep} backoff runs inside the timed region. Reuses {@code getPolicyName()} for
+   * both calls because GCP's removePolicy matches on the role translated from the policy actions,
+   * not the document name, so attach and remove must name the same role.
+   */
   @Benchmark
-  public void benchmarkCreateAttachDeleteIdentity(Blackhole bh) {
-    String identityName = harness.getLifecycleIdentityPrefix() + nextLifecycleId.incrementAndGet();
-    // Reuse harness.getPolicyName() rather than a per-invocation name: GCP's removePolicy matches
-    // against the role translated from policy actions (not the document name), so the name must be
-    // identical between attach and remove. Uniqueness comes from identityName instead.
-    String lifecyclePolicyName = harness.getPolicyName();
-    boolean identityCreated = false;
-
-    try {
-      String identityId =
-          iamClient.createIdentity(
-              identityName,
-              "IAM benchmark lifecycle identity",
-              harness.getTenantId(),
-              harness.getRegion(),
-              Optional.empty(),
-              Optional.empty());
-      identityCreated = true;
-      bh.consume(identityId);
-
-      String policyMember = harness.toPolicyMember(identityName, identityId);
-
-      // Some providers create identities eventually-consistently: the attach can race propagation
-      // and fail with "does not exist". Retry briefly; read-after-write providers pass first try.
-      attachWithPropagationRetry(lifecyclePolicyName, policyMember);
-
-      iamClient.removePolicy(
-          policyMember, lifecyclePolicyName, harness.getTenantId(), harness.getRegion());
-    } finally {
-      if (identityCreated) {
-        try {
-          iamClient.deleteIdentity(identityName, harness.getTenantId(), harness.getRegion());
-        } catch (Exception e) {
-          // Guard cleanup so a failure mid-sequence doesn't wedge the trial
-        }
-      }
-    }
+  public void benchmarkAttachRemovePolicy(Blackhole bh) {
+    String policyName = harness.getPolicyName();
+    iamClient.attachInlinePolicy(
+        AttachInlinePolicyRequest.builder()
+            .policyDocument(buildPolicyDocument(policyName))
+            .tenantId(harness.getTenantId())
+            .region(harness.getRegion())
+            .identityName(lifecyclePolicyMember)
+            .build());
+    iamClient.removePolicy(
+        lifecyclePolicyMember, policyName, harness.getTenantId(), harness.getRegion());
+    bh.consume(lifecycleIdentityName);
   }
 
   // Bounded retry to absorb create->attach eventual-consistency lag (identity not yet propagated).

--- a/iam/iam-gcp/pom.xml
+++ b/iam/iam-gcp/pom.xml
@@ -96,6 +96,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.auto</groupId>
             <artifactId>auto-common</artifactId>
             <version>1.2.2</version>

--- a/iam/iam-gcp/src/test/java/com/salesforce/multicloudj/iam/gcp/GcpIamBenchmarkTest.java
+++ b/iam/iam-gcp/src/test/java/com/salesforce/multicloudj/iam/gcp/GcpIamBenchmarkTest.java
@@ -1,0 +1,78 @@
+package com.salesforce.multicloudj.iam.gcp;
+
+import com.salesforce.multicloudj.common.gcp.GcpConstants;
+import com.salesforce.multicloudj.iam.client.AbstractIamBenchmarkTest;
+import com.salesforce.multicloudj.iam.client.IamClient;
+import java.util.List;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class GcpIamBenchmarkTest extends AbstractIamBenchmarkTest {
+
+  @Override
+  protected Harness createHarness() {
+    return new HarnessImpl();
+  }
+
+  @Override
+  protected String getProviderId() {
+    return GcpConstants.PROVIDER_ID;
+  }
+
+  public static class HarnessImpl implements Harness {
+
+    private final String tenantId = requireEnv("IAM_BENCHMARK_GCP_TENANT_ID");
+    private final String region = requireEnv("IAM_BENCHMARK_GCP_REGION");
+    private final String identityName = requireEnv("IAM_BENCHMARK_GCP_IDENTITY_NAME");
+    private final String roleName = requireEnv("IAM_BENCHMARK_GCP_ROLE_NAME");
+
+    @Override
+    public IamClient createIamClient() {
+      // GCP IAM Admin/Resource Manager clients authenticate via Application Default Credentials
+      // (GOOGLE_APPLICATION_CREDENTIALS); GcpIam does not support CredentialsOverrider injection.
+      return IamClient.builder(GcpConstants.PROVIDER_ID).withRegion(region).build();
+    }
+
+    @Override
+    public String getIdentityName() {
+      return identityName;
+    }
+
+    @Override
+    public String getTenantId() {
+      return tenantId;
+    }
+
+    @Override
+    public String getRegion() {
+      return region;
+    }
+
+    @Override
+    public String getPolicyName() {
+      return roleName;
+    }
+
+    @Override
+    public String getRoleName() {
+      return roleName;
+    }
+
+    @Override
+    public List<String> getPolicyActions() {
+      return List.of("storage:GetObject");
+    }
+
+    @Override
+    public String toPolicyMember(String identityName, String identityId) {
+      // GCP's createIdentity returns the service account email; attach/removePolicy require the
+      // identityName to be a GCP member string ("serviceAccount:email"), not the bare account id.
+      return "serviceAccount:" + identityId;
+    }
+
+    @Override
+    public void close() {
+      // IamClient owns and closes the underlying GCP IAMClient/ProjectsClient
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a JMH benchmark suite for IAM: `AbstractIamBenchmarkTest` (iam-client) plus thin AWS/GCP concretes. Gated by `@EnabledIfSystemProperty(named="runBenchmarks", matches="true")` — inert in CI.

**Swept (4):** `getIdentity`, `getAttachedPolicies`, `getInlinePolicyDetails`, `createAttachDeleteIdentity`.
The lifecycle benchmark uses a bounded retry (`attachWithPropagationRetry`) to absorb create->attach eventual-consistency lag on providers that create identities asynchronously; read-after-write providers pass on the first attempt.

## Testing proof
Run locally against **live AWS + GCP on 2026-08-11**, both JMH modes. All 4 methods produced populated results on both clouds (8 entries each, zero errors). AWS IAM is global — the run must sign against `us-east-1` (documented in the run contract below).

Invocation (creds via OS env only):
```
mvn test -pl iam/iam-aws -Dtest=AwsIamBenchmarkTest -DrunBenchmarks=true \
  -DIAM_BENCHMARK_AWS_REGION=us-east-1 -DIAM_BENCHMARK_AWS_IDENTITY_NAME=<name> \
  -DIAM_BENCHMARK_AWS_TENANT_ID=<acct> -DIAM_BENCHMARK_AWS_POLICY_NAME=<policy> \
  -DIAM_BENCHMARK_AWS_ENDPOINT=https://iam.amazonaws.com -DIAM_BENCHMARK_AWS_POLICY_RESOURCE=<arn>
mvn test -pl iam/iam-gcp -Dtest=GcpIamBenchmarkTest -DrunBenchmarks=true \
  -DIAM_BENCHMARK_GCP_TENANT_ID=<project> -DIAM_BENCHMARK_GCP_REGION=<region> \
  -DIAM_BENCHMARK_GCP_IDENTITY_NAME=<sa-email> -DIAM_BENCHMARK_GCP_ROLE_NAME=<role>
```

## Run contract
- iam-aws: `IAM_BENCHMARK_AWS_{REGION,IDENTITY_NAME,TENANT_ID,POLICY_NAME,ENDPOINT,POLICY_RESOURCE}`
- iam-gcp: `IAM_BENCHMARK_GCP_{TENANT_ID,REGION,IDENTITY_NAME,ROLE_NAME}`

## JMH config note
Class-level `@Warmup`/`@Measurement`/`@Fork` are the local-run baseline; the downstream benchmark runner overrides these at execution time.

## Downstream
Running this in the downstream benchmark pipeline needs a separate vendor-sync of these files (new build target + wiring); it does not propagate automatically.

## Merge order
Independent. Recommend the root-pom JMH fix merges first.
