### PR TITLE
registry: add JMH benchmark suite

### DIFF
--- a/registry/registry-aws/pom.xml
+++ b/registry/registry-aws/pom.xml
@@ -26,6 +26,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ecr</artifactId>
             <version>${aws-sdk.version}</version>

--- a/registry/registry-aws/src/test/java/com/salesforce/multicloudj/registry/aws/AwsRegistryBenchmarkTest.java
+++ b/registry/registry-aws/src/test/java/com/salesforce/multicloudj/registry/aws/AwsRegistryBenchmarkTest.java
@@ -1,0 +1,54 @@
+package com.salesforce.multicloudj.registry.aws;
+
+import com.salesforce.multicloudj.registry.client.AbstractRegistryBenchmarkTest;
+import com.salesforce.multicloudj.registry.client.ContainerRegistryClient;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * Hits the real ECR endpoint directly (no wiremock replay), so it requires live AWS credentials via
+ * the default provider chain (OS env / profile) and network access to ECR.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AwsRegistryBenchmarkTest extends AbstractRegistryBenchmarkTest {
+
+  @Override
+  protected Harness createHarness() {
+    return new HarnessImpl();
+  }
+
+  @Override
+  protected String getProviderId() {
+    return "aws";
+  }
+
+  public static class HarnessImpl implements Harness {
+
+    private final String endpoint = requireEnv("REGISTRY_BENCHMARK_AWS_ENDPOINT");
+    private final String region = requireEnv("REGISTRY_BENCHMARK_AWS_REGION");
+    private final String smallImageRef = requireEnv("REGISTRY_BENCHMARK_AWS_SMALL_IMAGE_REF");
+    private final String multiArchImageRef =
+        optionalEnv("REGISTRY_BENCHMARK_AWS_MULTIARCH_IMAGE_REF");
+
+    @Override
+    public ContainerRegistryClient createClient() {
+      // Credentials flow via the AWS default provider chain (OS env / profile), never -D.
+      return ContainerRegistryClient.builder("aws")
+          .withRegistryEndpoint(endpoint)
+          .withRegion(region)
+          .build();
+    }
+
+    @Override
+    public String getSmallImageRef() {
+      return smallImageRef;
+    }
+
+    @Override
+    public String getMultiArchImageRef() {
+      return multiArchImageRef;
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/registry/registry-client/pom.xml
+++ b/registry/registry-client/pom.xml
@@ -74,6 +74,18 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+
+        <!-- JMH Dependencies for Benchmarking -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/registry/registry-client/src/test/java/com/salesforce/multicloudj/registry/client/AbstractRegistryBenchmarkTest.java
+++ b/registry/registry-client/src/test/java/com/salesforce/multicloudj/registry/client/AbstractRegistryBenchmarkTest.java
@@ -1,0 +1,205 @@
+package com.salesforce.multicloudj.registry.client;
+
+import com.salesforce.multicloudj.registry.model.Image;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * JMH benchmarks for container-registry data-plane operations via {@link ContainerRegistryClient}.
+ *
+ * <p>Registry pulls are data-plane: both throughput (bandwidth/decompress rate) and tail latency
+ * are honest signals, so this suite runs {@code Throughput} + {@code SampleTime}.
+ */
+@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class AbstractRegistryBenchmarkTest {
+
+  private static final int COPY_BUFFER_SIZE = 8192;
+
+  protected ContainerRegistryClient client;
+  private Image preloadedImage;
+  private String smallImageRef;
+  private String multiArchImageRef;
+
+  // Harness interface
+  public interface Harness extends AutoCloseable {
+    ContainerRegistryClient createClient();
+
+    String getSmallImageRef();
+
+    // May return null if the provider has no multi-arch test image available.
+    String getMultiArchImageRef();
+  }
+
+  protected Harness harness;
+
+  protected abstract Harness createHarness();
+
+  protected abstract String getProviderId();
+
+  /**
+   * Reads a required config value from OS environment first, then from -D system properties.
+   * Fails fast with a clear error if neither is set.
+   */
+  protected static String requireEnv(String name) {
+    String value = System.getenv(name);
+    if (StringUtils.isBlank(value)) {
+      value = System.getProperty(name);
+    }
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalStateException("Required environment variable not set: " + name);
+    }
+    return value;
+  }
+
+  /**
+   * Reads an optional config value from OS environment first, then from -D system properties.
+   * Returns null when unset (used for the optional multi-arch image ref).
+   */
+  protected static String optionalEnv(String name) {
+    String value = System.getenv(name);
+    if (StringUtils.isBlank(value)) {
+      value = System.getProperty(name);
+    }
+    return StringUtils.isBlank(value) ? null : value;
+  }
+
+  @Setup(Level.Trial)
+  public void setupBenchmark() throws Exception {
+    harness = createHarness();
+    client = harness.createClient();
+    smallImageRef = harness.getSmallImageRef();
+    multiArchImageRef = harness.getMultiArchImageRef();
+
+    // Pre-pull so benchmarkExtractLayers measures decompression, not manifest fetch.
+    preloadedImage = client.pull(smallImageRef);
+  }
+
+  @TearDown(Level.Trial)
+  public void teardownBenchmark() throws Exception {
+    if (client != null) {
+      client.close();
+    }
+    if (harness != null) {
+      harness.close();
+    }
+  }
+
+  /**
+   * Manifest fetch + parse latency for a small single-arch image.
+   *
+   * <p>Caveat: re-pulls the same {@code smallImageRef} on every invocation, so the registry's edge
+   * cache and the warm {@code OciHttpTransport} connection pool make this a best-case (cache-hit)
+   * latency, not a cold pull.
+   */
+  @Benchmark
+  public void benchmarkPullManifest(Blackhole bh) {
+    Image image = client.pull(smallImageRef);
+    bh.consume(image.getDigest());
+  }
+
+  /**
+   * Multi-arch pull, exercising selectPlatformFromIndex plus the second manifest fetch. Guarded:
+   * providers without a multi-arch test image skip the pull but the method still runs so JMH
+   * doesn't fail; results read as ~0 until a real multi-arch fixture is wired up.
+   */
+  @Benchmark
+  public void benchmarkPullMultiArch(Blackhole bh) {
+    if (multiArchImageRef == null) {
+      bh.consume(0);
+      return;
+    }
+    Image image = client.pull(multiArchImageRef);
+    bh.consume(image.getDigest());
+  }
+
+  /**
+   * Layer decompression throughput for a pre-pulled image. Drains the full tar stream so the
+   * measured time reflects decompress + whiteout-flatten cost, not just the first read.
+   */
+  @Benchmark
+  public void benchmarkExtractLayers(Blackhole bh) {
+    try (InputStream tar = client.extract(preloadedImage)) {
+      bh.consume(drain(tar));
+    } catch (IOException e) {
+      throw new RuntimeException("Benchmark extract layers failed", e);
+    }
+  }
+
+  /**
+   * End-to-end pull + extract, the realistic full-image-materialization path.
+   *
+   * <p>Same cache-hit caveat as {@link #benchmarkPullManifest} applies to the pull half.
+   */
+  @Benchmark
+  public void benchmarkPullAndExtract(Blackhole bh) {
+    Image image = client.pull(smallImageRef);
+    try (InputStream tar = client.extract(image)) {
+      bh.consume(drain(tar));
+    } catch (IOException e) {
+      throw new RuntimeException("Benchmark pull and extract failed", e);
+    }
+  }
+
+  private long drain(InputStream in) throws IOException {
+    byte[] buffer = new byte[COPY_BUFFER_SIZE];
+    long total = 0;
+    int read;
+    while ((read = in.read(buffer)) != -1) {
+      total += read;
+    }
+    return total;
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "runBenchmarks", matches = "true")
+  public void runBenchmarks() throws RunnerException {
+    List<String> forwardedArgs = new ArrayList<>();
+    for (String key : System.getProperties().stringPropertyNames()) {
+      if (key.startsWith("REGISTRY_BENCHMARK_")) {
+        forwardedArgs.add("-D" + key + "=" + System.getProperty(key));
+      }
+    }
+
+    Options opt =
+        new OptionsBuilder()
+            .include(".*" + this.getClass().getName() + ".*")
+            .forks(1)
+            .resultFormat(ResultFormatType.JSON)
+            .result("target/jmh-registry-results-" + getProviderId() + ".json")
+            .jvmArgsAppend(forwardedArgs.toArray(new String[0]))
+            .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/registry/registry-client/src/test/java/com/salesforce/multicloudj/registry/client/AbstractRegistryBenchmarkTest.java
+++ b/registry/registry-client/src/test/java/com/salesforce/multicloudj/registry/client/AbstractRegistryBenchmarkTest.java
@@ -47,7 +47,6 @@ public abstract class AbstractRegistryBenchmarkTest {
   private static final int COPY_BUFFER_SIZE = 8192;
 
   protected ContainerRegistryClient client;
-  private Image preloadedImage;
   private String smallImageRef;
   private String multiArchImageRef;
 
@@ -59,6 +58,11 @@ public abstract class AbstractRegistryBenchmarkTest {
 
     // May return null if the provider has no multi-arch test image available.
     String getMultiArchImageRef();
+
+    // Whether a multi-arch test image is configured; drives the benchmarkPullMultiArch exclude.
+    default boolean supportsMultiArch() {
+      return getMultiArchImageRef() != null;
+    }
   }
 
   protected Harness harness;
@@ -100,9 +104,6 @@ public abstract class AbstractRegistryBenchmarkTest {
     client = harness.createClient();
     smallImageRef = harness.getSmallImageRef();
     multiArchImageRef = harness.getMultiArchImageRef();
-
-    // Pre-pull so benchmarkExtractLayers measures decompression, not manifest fetch.
-    preloadedImage = client.pull(smallImageRef);
   }
 
   @TearDown(Level.Trial)
@@ -129,31 +130,14 @@ public abstract class AbstractRegistryBenchmarkTest {
   }
 
   /**
-   * Multi-arch pull, exercising selectPlatformFromIndex plus the second manifest fetch. Guarded:
-   * providers without a multi-arch test image skip the pull but the method still runs so JMH
-   * doesn't fail; results read as ~0 until a real multi-arch fixture is wired up.
+   * Multi-arch pull, exercising selectPlatformFromIndex plus the second manifest fetch. Excluded by
+   * {@link #runBenchmarks()} when the provider has no multi-arch fixture, so this never publishes a
+   * datapoint for work that didn't run.
    */
   @Benchmark
   public void benchmarkPullMultiArch(Blackhole bh) {
-    if (multiArchImageRef == null) {
-      bh.consume(0);
-      return;
-    }
     Image image = client.pull(multiArchImageRef);
     bh.consume(image.getDigest());
-  }
-
-  /**
-   * Layer decompression throughput for a pre-pulled image. Drains the full tar stream so the
-   * measured time reflects decompress + whiteout-flatten cost, not just the first read.
-   */
-  @Benchmark
-  public void benchmarkExtractLayers(Blackhole bh) {
-    try (InputStream tar = client.extract(preloadedImage)) {
-      bh.consume(drain(tar));
-    } catch (IOException e) {
-      throw new RuntimeException("Benchmark extract layers failed", e);
-    }
   }
 
   /**
@@ -191,15 +175,20 @@ public abstract class AbstractRegistryBenchmarkTest {
       }
     }
 
-    Options opt =
-        new OptionsBuilder()
-            .include(".*" + this.getClass().getName() + ".*")
-            .forks(1)
-            .resultFormat(ResultFormatType.JSON)
-            .result("target/jmh-registry-results-" + getProviderId() + ".json")
-            .jvmArgsAppend(forwardedArgs.toArray(new String[0]))
-            .build();
+    OptionsBuilder builder = new OptionsBuilder();
+    builder
+        .include(".*" + this.getClass().getName() + ".*")
+        .forks(1)
+        .resultFormat(ResultFormatType.JSON)
+        .result("target/jmh-registry-results-" + getProviderId() + ".json")
+        .jvmArgsAppend(forwardedArgs.toArray(new String[0]));
 
-    new Runner(opt).run();
+    // Skip the multi-arch benchmark on providers without a multi-arch fixture, rather than
+    // publishing an empty-method datapoint under the name of a real pull.
+    if (!createHarness().supportsMultiArch()) {
+      builder.exclude(".*benchmarkPullMultiArch.*");
+    }
+
+    new Runner(builder.build()).run();
   }
 }

--- a/registry/registry-gcp/pom.xml
+++ b/registry/registry-gcp/pom.xml
@@ -20,6 +20,11 @@
             <artifactId>registry-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
             <version>1.40.0</version>

--- a/registry/registry-gcp/src/test/java/com/salesforce/multicloudj/registry/gcp/GcpRegistryBenchmarkTest.java
+++ b/registry/registry-gcp/src/test/java/com/salesforce/multicloudj/registry/gcp/GcpRegistryBenchmarkTest.java
@@ -1,0 +1,53 @@
+package com.salesforce.multicloudj.registry.gcp;
+
+import com.salesforce.multicloudj.common.gcp.GcpConstants;
+import com.salesforce.multicloudj.registry.client.AbstractRegistryBenchmarkTest;
+import com.salesforce.multicloudj.registry.client.ContainerRegistryClient;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * Hits the real Artifact Registry endpoint directly (no wiremock replay), so it requires live
+ * Application Default Credentials (GOOGLE_APPLICATION_CREDENTIALS) and network access to GAR.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class GcpRegistryBenchmarkTest extends AbstractRegistryBenchmarkTest {
+
+  @Override
+  protected Harness createHarness() {
+    return new HarnessImpl();
+  }
+
+  @Override
+  protected String getProviderId() {
+    return GcpConstants.PROVIDER_ID;
+  }
+
+  public static class HarnessImpl implements Harness {
+
+    private final String endpoint = requireEnv("REGISTRY_BENCHMARK_GCP_ENDPOINT");
+    private final String smallImageRef = requireEnv("REGISTRY_BENCHMARK_GCP_SMALL_IMAGE_REF");
+    private final String multiArchImageRef =
+        optionalEnv("REGISTRY_BENCHMARK_GCP_MULTIARCH_IMAGE_REF");
+
+    @Override
+    public ContainerRegistryClient createClient() {
+      // Uses application default credentials; run with GOOGLE_APPLICATION_CREDENTIALS set.
+      return ContainerRegistryClient.builder(GcpConstants.PROVIDER_ID)
+          .withRegistryEndpoint(endpoint)
+          .build();
+    }
+
+    @Override
+    public String getSmallImageRef() {
+      return smallImageRef;
+    }
+
+    @Override
+    public String getMultiArchImageRef() {
+      return multiArchImageRef;
+    }
+
+    @Override
+    public void close() {}
+  }
+}


### PR DESCRIPTION
## Summary
Adds a JMH benchmark suite for the container registry: `AbstractRegistryBenchmarkTest` (registry-client) plus thin AWS/GCP concretes. Gated by `@EnabledIfSystemProperty(named="runBenchmarks", matches="true")` — inert in CI.

**Swept (4):** `pullManifest`, `extractLayers`, `pullAndExtract`, `pullMultiArch` (self-guards to a no-op unless a multi-arch test image is configured).

## Measurement caveat
The pull benchmarks re-pull the same image ref each invocation, so the registry's edge cache and the warm connection pool make these **steady-state / cache-hit** numbers, not cold-pull latency. Documented in-source.

## Testing proof
Run locally against **live AWS ECR + GCP Artifact Registry on 2026-08-11**, both JMH modes. The 3 real methods produced populated results on both clouds; `pullMultiArch` reads ~0 until a multi-arch fixture is wired (by design).

Invocation (creds via OS env only):
```
mvn test -pl registry/registry-aws -Dtest=AwsRegistryBenchmarkTest -DrunBenchmarks=true \
  -DREGISTRY_BENCHMARK_AWS_ENDPOINT=<ecr-endpoint> -DREGISTRY_BENCHMARK_AWS_REGION=us-west-2 \
  -DREGISTRY_BENCHMARK_AWS_SMALL_IMAGE_REF=<image:tag>
mvn test -pl registry/registry-gcp -Dtest=GcpRegistryBenchmarkTest -DrunBenchmarks=true \
  -DREGISTRY_BENCHMARK_GCP_ENDPOINT=<ar-endpoint> -DREGISTRY_BENCHMARK_GCP_SMALL_IMAGE_REF=<image:tag>
```
Rendered AWS-vs-GCP pages are being published to the benchmark-visualizer.

## Run contract
- registry-aws: `REGISTRY_BENCHMARK_AWS_{ENDPOINT,REGION,SMALL_IMAGE_REF}` (+ optional `_MULTIARCH_IMAGE_REF`)
- registry-gcp: `REGISTRY_BENCHMARK_GCP_{ENDPOINT,SMALL_IMAGE_REF}` (+ optional `_MULTIARCH_IMAGE_REF`)

## JMH config note
Class-level annotations are the local-run baseline; the chameleon pipeline overrides via its own `BenchmarkRunner`.

## Downstream
Needs a separate vendor-sync PR into sfdc-bazel to run in the pipeline; not automatic.

## Merge order
Independent. Recommend the root-pom JMH fix merges first.

GUS: [W-23830175](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002hP986YAC/view)
