### PR TITLE
test: broaden blob/docstore/pubsub benchmark coverage

### DIFF
--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/async/client/AbstractAsyncBlobBenchmarkTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/async/client/AbstractAsyncBlobBenchmarkTest.java
@@ -1,6 +1,7 @@
 package com.salesforce.multicloudj.blob.async.client;
 
 import com.salesforce.multicloudj.blob.async.driver.AsyncBlobStore;
+import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.ByteArray;
@@ -122,6 +123,11 @@ public abstract class AbstractAsyncBlobBenchmarkTest {
   protected static final String WRITE_READ_DELETE_PREFIX = "bench-write-read-delete/";
   protected static final String MULTIPART_PREFIX = "bench-multipart/";
   protected static final String COPY_DEST_PREFIX = "bench-copy-dest/";
+  protected static final String BULK_DELETE_PREFIX = "bench-bulk-delete/";
+  protected static final String DELETE_DIR_PREFIX = "bench-delete-dir/";
+
+  private static final int BULK_DELETE_BATCH = 25;
+  private static final int DELETE_DIR_FILE_COUNT = 20;
 
   // Number of pre-staged download corpus prefixes; matches the highest @Threads value below
   // so each thread reads from a distinct prefix to avoid hot-key effects under concurrent load.
@@ -163,6 +169,8 @@ public abstract class AbstractAsyncBlobBenchmarkTest {
   private final AtomicInteger nextWriteReadDeleteId = new AtomicInteger(0);
   private final AtomicInteger nextMultipartUploadId = new AtomicInteger(0);
   private final AtomicInteger nextCopyId = new AtomicInteger(0);
+  private final AtomicInteger nextBulkDeleteId = new AtomicInteger(0);
+  private final AtomicInteger nextDeleteDirId = new AtomicInteger(0);
 
   private String bucketName;
   private Harness harness;
@@ -585,6 +593,48 @@ public abstract class AbstractAsyncBlobBenchmarkTest {
     bh.consume(response);
   }
 
+  /**
+   * Delete-directory lifecycle: upload a small file set under a unique prefix, then delete the
+   * whole prefix in one {@code deleteDirectory} call. Async-only API with no prior benchmark.
+   * Single-threaded and upload-bundled — the shared @State precludes per-invocation staging of a
+   * delete-only prefix, so upload cost is included and documented rather than hidden.
+   */
+  @Benchmark
+  @Threads(1)
+  public void benchmarkDeleteDirectory(Blackhole bh) {
+    String prefix = DELETE_DIR_PREFIX + nextDeleteDirId.incrementAndGet() + "/";
+    for (int i = 0; i < DELETE_DIR_FILE_COUNT; i++) {
+      UploadRequest request =
+          new UploadRequest.Builder()
+              .withKey(prefix + "blob_" + i + ".dat")
+              .withContentLength(smallBlob.length)
+              .build();
+      asyncClient.upload(request, smallBlob).orTimeout(OP_TIMEOUT_SECONDS, TimeUnit.SECONDS).join();
+    }
+    asyncClient.deleteDirectory(prefix).orTimeout(OP_TIMEOUT_SECONDS, TimeUnit.SECONDS).join();
+    bh.consume(prefix);
+  }
+
+  /**
+   * Bulk-delete lifecycle: upload a batch then delete it in one {@code delete(Collection)} call.
+   * Mirrors the sync suite's benchmarkBulkDelete for cross-suite parity. Single-threaded and
+   * upload-bundled by design (shared @State precludes delete-only staging).
+   */
+  @Benchmark
+  @Threads(1)
+  public void benchmarkBulkDelete(Blackhole bh) {
+    List<BlobIdentifier> ids = new ArrayList<>(BULK_DELETE_BATCH);
+    for (int i = 0; i < BULK_DELETE_BATCH; i++) {
+      String key = BULK_DELETE_PREFIX + nextBulkDeleteId.incrementAndGet() + ".dat";
+      UploadRequest request =
+          new UploadRequest.Builder().withKey(key).withContentLength(smallBlob.length).build();
+      asyncClient.upload(request, smallBlob).orTimeout(OP_TIMEOUT_SECONDS, TimeUnit.SECONDS).join();
+      ids.add(new BlobIdentifier(key, null));
+    }
+    asyncClient.delete(ids).orTimeout(OP_TIMEOUT_SECONDS, TimeUnit.SECONDS).join();
+    bh.consume(ids.size());
+  }
+
   // ─── Single-object data setup/teardown helpers ───
 
   private void setupSingleObjectData() {
@@ -638,7 +688,7 @@ public abstract class AbstractAsyncBlobBenchmarkTest {
     String[] prefixes = {
         DOWNLOAD_BLOBS_PREFIX, UPLOAD_SMALL_PREFIX, UPLOAD_MEDIUM_PREFIX,
         UPLOAD_LARGE_PREFIX, WRITE_READ_DELETE_PREFIX, MULTIPART_PREFIX,
-        COPY_DEST_PREFIX
+        COPY_DEST_PREFIX, BULK_DELETE_PREFIX, DELETE_DIR_PREFIX
     };
     for (String prefix : prefixes) {
       try {

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobBenchmarkTest.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobBenchmarkTest.java
@@ -1,6 +1,7 @@
 package com.salesforce.multicloudj.blob.client;
 
 import com.salesforce.multicloudj.blob.driver.AbstractBlobStore;
+import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
 import com.salesforce.multicloudj.blob.driver.BlobInfo;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import com.salesforce.multicloudj.blob.driver.CopyRequest;
@@ -96,6 +97,9 @@ public abstract class AbstractBlobBenchmarkTest {
   protected static final String WRITE_READ_DELETE_PREFIX = "bench-write-read-delete/";
   protected static final String MULTIPART_PREFIX = "bench-multipart/";
   protected static final String COPY_DEST_PREFIX = "bench-copy-dest/";
+  protected static final String BULK_DELETE_PREFIX = "bench-bulk-delete/";
+
+  private static final int BULK_DELETE_BATCH = 25;
 
   private static final int SMALL_COUNT = 100;
   private static final int MEDIUM_COUNT = 20;
@@ -118,6 +122,7 @@ public abstract class AbstractBlobBenchmarkTest {
   private final AtomicInteger nextWriteReadDeleteId = new AtomicInteger(0);
   private final AtomicInteger nextMultipartUploadId = new AtomicInteger(0);
   private final AtomicInteger nextCopyId = new AtomicInteger(0);
+  private final AtomicInteger nextBulkDeleteId = new AtomicInteger(0);
 
   private final ConcurrentLinkedQueue<String> copyDestKeys = new ConcurrentLinkedQueue<>();
 
@@ -228,7 +233,7 @@ public abstract class AbstractBlobBenchmarkTest {
     String[] prefixes = {
         DOWNLOAD_BLOBS_PREFIX, UPLOAD_SMALL_PREFIX, UPLOAD_MEDIUM_PREFIX,
         UPLOAD_LARGE_PREFIX, WRITE_READ_DELETE_PREFIX, MULTIPART_PREFIX,
-        COPY_DEST_PREFIX
+        COPY_DEST_PREFIX, BULK_DELETE_PREFIX
     };
     for (String prefix : prefixes) {
       try {
@@ -449,6 +454,33 @@ public abstract class AbstractBlobBenchmarkTest {
       copyDestKeys.add(destKey);
     } catch (Exception e) {
       throw new RuntimeException("Benchmark copy failed", e);
+    }
+  }
+
+  /**
+   * Bulk-delete lifecycle: upload a batch then delete it in one {@code delete(Collection)} call.
+   * The bulk-delete API had no benchmark; it guards the {@literal >}1000-object batching path.
+   * Single-threaded and upload-bundled by design — the shared @State precludes per-invocation
+   * staging of delete-only targets, so upload cost is included and documented rather than hidden.
+   */
+  @Benchmark
+  @Threads(1)
+  public void benchmarkBulkDelete(Blackhole bh) {
+    List<BlobIdentifier> ids = new ArrayList<>(BULK_DELETE_BATCH);
+    try {
+      for (int i = 0; i < BULK_DELETE_BATCH; i++) {
+        String key = BULK_DELETE_PREFIX + nextBulkDeleteId.incrementAndGet() + ".dat";
+        try (InputStream is = new ByteArrayInputStream(smallBlob)) {
+          UploadRequest request =
+              new UploadRequest.Builder().withKey(key).withContentLength(smallBlob.length).build();
+          bucketClient.upload(request, is);
+        }
+        ids.add(new BlobIdentifier(key, null));
+      }
+      bucketClient.delete(ids);
+      bh.consume(ids.size());
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark bulk delete failed", e);
     }
   }
 

--- a/docstore/docstore-client/src/test/java/com/salesforce/multicloudj/docstore/client/AbstractDocstoreBenchmarkTest.java
+++ b/docstore/docstore-client/src/test/java/com/salesforce/multicloudj/docstore/client/AbstractDocstoreBenchmarkTest.java
@@ -470,6 +470,42 @@ public abstract class AbstractDocstoreBenchmarkTest {
     benchmarkGetByList(bh, largePlayerKeys, "Large");
   }
 
+  /**
+   * Conditional create (fail-if-exists). Distinct backend cost from benchmarkPut: providers add a
+   * not-exists precondition (DynamoDB attribute_not_exists ConditionExpression, Firestore create).
+   * Unique key per invocation, tracked for teardown.
+   */
+  @Benchmark
+  @Threads(4)
+  public void benchmarkCreate(Blackhole bh) {
+    try {
+      String key = "benchmarkcreate-player-" + ThreadLocalRandom.current().nextLong();
+      benchmarkCreatedKeys.add(key);
+      Player player = createPlayer(key, 0, 500);
+      docStoreClient.create(new Document(player));
+      bh.consume(player.getPName());
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark create failed", e);
+    }
+  }
+
+  /**
+   * Conditional replace (fail-if-not-exists). Distinct backend cost from benchmarkPut: providers
+   * add an exists precondition. Overwrites a pre-seeded key so no new docs accumulate.
+   */
+  @Benchmark
+  @Threads(4)
+  public void benchmarkReplace(Blackhole bh) {
+    try {
+      String key = smallPlayerKeys.get(ThreadLocalRandom.current().nextInt(smallPlayerKeys.size()));
+      Player player = createPlayer(key, ThreadLocalRandom.current().nextInt(1000), 500);
+      docStoreClient.replace(new Document(player));
+      bh.consume(player.getPName());
+    } catch (Exception e) {
+      throw new RuntimeException("Benchmark replace failed", e);
+    }
+  }
+
   /** Benchmark atomic writes */
   @Benchmark
   @Threads(1)

--- a/pubsub/pubsub-client/src/test/java/com/salesforce/multicloudj/pubsub/client/AbstractPubsubBenchmarkTest.java
+++ b/pubsub/pubsub-client/src/test/java/com/salesforce/multicloudj/pubsub/client/AbstractPubsubBenchmarkTest.java
@@ -62,15 +62,9 @@ public abstract class AbstractPubsubBenchmarkTest {
   protected static final int MEDIUM_MESSAGE = 10240; // 10KB
   protected static final int LARGE_MESSAGE = 102400; // 100KB
 
-  protected static final int BATCH_SIZE_SMALL = 10;
-
   // Pre-population constants — kept small to avoid long setup (each SNS publish ~3-5s round-trip)
   protected static final int PREPOPULATE_RECEIVE = 50;
   protected static final int MESSAGE_AVAILABILITY_DELAY_MS = 1000;
-
-  // @Param for batch ack benchmarks — drives both benchmarkBatchAck and benchmarkLargeBatchAck
-  @Param({"1", "10"})
-  protected int batchSize;
 
   protected TopicClient topicClient;
   protected SubscriptionClient subscriptionClient;
@@ -104,14 +98,6 @@ public abstract class AbstractPubsubBenchmarkTest {
       throw new IllegalStateException("Required environment variable not set: " + name);
     }
     return value;
-  }
-
-  /**
-   * Returns the maximum number of messages allowed in a single batch ack call.
-   * AWS: 10 messages per batch, GCP: 1000 messages per batch.
-   */
-  protected int getMaxBatchAckSize() {
-    return BATCH_SIZE_SMALL;
   }
 
   @Setup(Level.Trial)
@@ -376,24 +362,31 @@ public abstract class AbstractPubsubBenchmarkTest {
     }
   }
 
+  /** Scopes the batchSize {@code @Param} to the batch-ack benchmark only, not the whole class. */
+  @State(Scope.Benchmark)
+  public static class BatchParams {
+    @Param({"1", "10"})
+    public int batchSize;
+  }
+
   /**
    * Batch acknowledgment benchmark.
    *
    * <p>Publishes {@code batchSize} messages then receives and acks them in a single batch call.
-   * Parameterised via {@link #batchSize} ({@code @Param({"1","10"})}).
+   * Parameterised via {@link BatchParams#batchSize} ({@code @Param({"1","10"})}).
    *
    * <p>Note: {@code sendAcks()} enqueues the batch ack asynchronously; the underlying RPC cost is
    * NOT captured in this benchmark's latency measurement.
    */
   @Benchmark
   @Threads(4)
-  public void benchmarkBatchAck(Blackhole bh) {
+  public void benchmarkBatchAck(BatchParams params, Blackhole bh) {
     try {
-      for (int i = 0; i < batchSize; i++) {
+      for (int i = 0; i < params.batchSize; i++) {
         topicClient.send(createMessage(SMALL_MESSAGE));
       }
       List<AckID> ackIds = new ArrayList<>();
-      for (int i = 0; i < batchSize; i++) {
+      for (int i = 0; i < params.batchSize; i++) {
         Message msg = subscriptionClient.receive();
         ackIds.add(msg.getAckID());
         bh.consume(msg);
@@ -403,38 +396,6 @@ public abstract class AbstractPubsubBenchmarkTest {
     } catch (Exception e) {
       logger.error(">>> Benchmark batch ack FAILED: {}", e.getMessage());
       throw new RuntimeException("Benchmark batch ack failed", e);
-    }
-  }
-
-  /**
-   * Large batch acknowledgment benchmark — shows provider scaling advantage.
-   *
-   * <p>Publishes then receives {@code Math.min(batchSize, getMaxBatchAckSize())} messages in one
-   * batch ack (AWS: 10, GCP: 1000). Parameterised via {@link #batchSize}
-   * ({@code @Param({"1","10"})}).
-   *
-   * <p>Note: {@code sendAcks()} enqueues the batch ack asynchronously; the underlying RPC cost is
-   * NOT captured in this benchmark's latency measurement.
-   */
-  @Benchmark
-  @Threads(4)
-  public void benchmarkLargeBatchAck(Blackhole bh) {
-    int effectiveBatch = Math.min(batchSize, getMaxBatchAckSize());
-    try {
-      for (int i = 0; i < effectiveBatch; i++) {
-        topicClient.send(createMessage(SMALL_MESSAGE));
-      }
-      List<AckID> ackIds = new ArrayList<>();
-      for (int i = 0; i < effectiveBatch; i++) {
-        Message msg = subscriptionClient.receive();
-        ackIds.add(msg.getAckID());
-        bh.consume(msg);
-      }
-      subscriptionClient.sendAcks(ackIds);
-      bh.consume(ackIds.size());
-    } catch (Exception e) {
-      logger.error(">>> Benchmark large batch ack FAILED: {}", e.getMessage());
-      throw new RuntimeException("Benchmark large batch ack failed", e);
     }
   }
 

--- a/pubsub/pubsub-client/src/test/java/com/salesforce/multicloudj/pubsub/client/AbstractPubsubBenchmarkTest.java
+++ b/pubsub/pubsub-client/src/test/java/com/salesforce/multicloudj/pubsub/client/AbstractPubsubBenchmarkTest.java
@@ -62,9 +62,15 @@ public abstract class AbstractPubsubBenchmarkTest {
   protected static final int MEDIUM_MESSAGE = 10240; // 10KB
   protected static final int LARGE_MESSAGE = 102400; // 100KB
 
+  protected static final int BATCH_SIZE_SMALL = 10;
+
   // Pre-population constants — kept small to avoid long setup (each SNS publish ~3-5s round-trip)
   protected static final int PREPOPULATE_RECEIVE = 50;
   protected static final int MESSAGE_AVAILABILITY_DELAY_MS = 1000;
+
+  // @Param for batch ack benchmarks — drives both benchmarkBatchAck and benchmarkLargeBatchAck
+  @Param({"1", "10"})
+  protected int batchSize;
 
   protected TopicClient topicClient;
   protected SubscriptionClient subscriptionClient;
@@ -98,6 +104,14 @@ public abstract class AbstractPubsubBenchmarkTest {
       throw new IllegalStateException("Required environment variable not set: " + name);
     }
     return value;
+  }
+
+  /**
+   * Returns the maximum number of messages allowed in a single batch ack call.
+   * AWS: 10 messages per batch, GCP: 1000 messages per batch.
+   */
+  protected int getMaxBatchAckSize() {
+    return BATCH_SIZE_SMALL;
   }
 
   @Setup(Level.Trial)
@@ -362,31 +376,24 @@ public abstract class AbstractPubsubBenchmarkTest {
     }
   }
 
-  /** Scopes the batchSize {@code @Param} to the batch-ack benchmark only, not the whole class. */
-  @State(Scope.Benchmark)
-  public static class BatchParams {
-    @Param({"1", "10"})
-    public int batchSize;
-  }
-
   /**
    * Batch acknowledgment benchmark.
    *
    * <p>Publishes {@code batchSize} messages then receives and acks them in a single batch call.
-   * Parameterised via {@link BatchParams#batchSize} ({@code @Param({"1","10"})}).
+   * Parameterised via {@link #batchSize} ({@code @Param({"1","10"})}).
    *
    * <p>Note: {@code sendAcks()} enqueues the batch ack asynchronously; the underlying RPC cost is
    * NOT captured in this benchmark's latency measurement.
    */
   @Benchmark
   @Threads(4)
-  public void benchmarkBatchAck(BatchParams params, Blackhole bh) {
+  public void benchmarkBatchAck(Blackhole bh) {
     try {
-      for (int i = 0; i < params.batchSize; i++) {
+      for (int i = 0; i < batchSize; i++) {
         topicClient.send(createMessage(SMALL_MESSAGE));
       }
       List<AckID> ackIds = new ArrayList<>();
-      for (int i = 0; i < params.batchSize; i++) {
+      for (int i = 0; i < batchSize; i++) {
         Message msg = subscriptionClient.receive();
         ackIds.add(msg.getAckID());
         bh.consume(msg);
@@ -396,6 +403,55 @@ public abstract class AbstractPubsubBenchmarkTest {
     } catch (Exception e) {
       logger.error(">>> Benchmark batch ack FAILED: {}", e.getMessage());
       throw new RuntimeException("Benchmark batch ack failed", e);
+    }
+  }
+
+  /**
+   * Large batch acknowledgment benchmark — shows provider scaling advantage.
+   *
+   * <p>Publishes then receives {@code Math.min(batchSize, getMaxBatchAckSize())} messages in one
+   * batch ack (AWS: 10, GCP: 1000). Parameterised via {@link #batchSize}
+   * ({@code @Param({"1","10"})}).
+   *
+   * <p>Note: {@code sendAcks()} enqueues the batch ack asynchronously; the underlying RPC cost is
+   * NOT captured in this benchmark's latency measurement.
+   */
+  @Benchmark
+  @Threads(4)
+  public void benchmarkLargeBatchAck(Blackhole bh) {
+    int effectiveBatch = Math.min(batchSize, getMaxBatchAckSize());
+    try {
+      for (int i = 0; i < effectiveBatch; i++) {
+        topicClient.send(createMessage(SMALL_MESSAGE));
+      }
+      List<AckID> ackIds = new ArrayList<>();
+      for (int i = 0; i < effectiveBatch; i++) {
+        Message msg = subscriptionClient.receive();
+        ackIds.add(msg.getAckID());
+        bh.consume(msg);
+      }
+      subscriptionClient.sendAcks(ackIds);
+      bh.consume(ackIds.size());
+    } catch (Exception e) {
+      logger.error(">>> Benchmark large batch ack FAILED: {}", e.getMessage());
+      throw new RuntimeException("Benchmark large batch ack failed", e);
+    }
+  }
+
+  /**
+   * Subscription getAttributes benchmark — control-plane metadata read. Single-threaded because
+   * this is a low-QPS admin call that providers rate-limit; concurrency would measure the throttle,
+   * not the SDK.
+   */
+  @Benchmark
+  @Threads(1)
+  public void benchmarkGetAttributes(Blackhole bh) {
+    try {
+      GetAttributeResult result = subscriptionClient.getAttributes();
+      bh.consume(result);
+    } catch (Exception e) {
+      logger.error(">>> Benchmark get attributes FAILED: {}", e.getMessage());
+      throw new RuntimeException("Benchmark get attributes failed", e);
     }
   }
 


### PR DESCRIPTION
## Summary
Broadens the already-merged JMH suites with mutate/delete coverage that was missing. **Test-file-only — no pom change**, since these suites already carry JMH.

- **blob (sync)** `AbstractBlobBenchmarkTest`: `benchmarkBulkDelete`
- **blob (async)** `AbstractAsyncBlobBenchmarkTest`: `benchmarkDeleteDirectory`, `benchmarkBulkDelete`
- **docstore** `AbstractDocstoreBenchmarkTest`: `benchmarkCreate`, `benchmarkReplace`
- **pubsub** `AbstractPubsubBenchmarkTest`: `benchmarkGetAttributes`

## Measurement caveat
The blob `benchmarkBulkDelete` and `benchmarkDeleteDirectory` bundle the upload staging into the measured method — the shared `@State` precludes per-invocation staging of a delete-only target, so the number is "stage + delete", not delete alone. Documented in-source. `benchmarkCreate` tracks its keys and deletes them in teardown (no doc accumulation); `benchmarkReplace` overwrites pre-seeded keys.

## Testing proof
These extend suites that already run in the existing benchmark harness. Test-compile + checkstyle clean on blob/docstore/pubsub -client modules; the new methods follow the same @State/@Threads patterns as the surrounding benchmarks.

## JMH config note
Class-level annotations are the local-run baseline; the chameleon pipeline overrides via its own `BenchmarkRunner`.

## Downstream
These modules are already vendored in sfdc-bazel, but the vendored copies are frozen at sync time — picking up these new methods needs a re-sync PR; not automatic.

## Merge order
Independent of the other PRs.

GUS: [W-23830177](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002hPHP4YAO/view)
