### PR TITLE
docstore: fix - combination of Lists and Maps in the document getting intermingled in the firestore

### DIFF
--- a/docstore/docstore-gcp-firestore/src/main/java/com/salesforce/multicloudj/docstore/gcp/FSEncoder.java
+++ b/docstore/docstore-gcp-firestore/src/main/java/com/salesforce/multicloudj/docstore/gcp/FSEncoder.java
@@ -6,6 +6,7 @@ import com.google.firestore.v1.Value;
 import com.google.protobuf.ByteString;
 import com.salesforce.multicloudj.docstore.driver.codec.Encoder;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +19,7 @@ public class FSEncoder implements Encoder {
 
   private final Map<String, Value> map = new HashMap<>();
 
-  private Value value;
+  protected Value value;
 
   @Override
   public void encodeNil() {
@@ -86,7 +87,60 @@ public class FSEncoder implements Encoder {
     return null;
   }
 
-  public static class MapEncoder extends FSEncoder {
+  /**
+   * Base class for the nested encoders ({@link MapEncoder}, {@link ListEncoder}). A nested encoder
+   * holds a single child value at a time (either a nested map or a nested list) in its own backing
+   * collection so that sibling values never share a backing collection. The container-specific
+   * subclass decides where a completed child value is stored (a map key or a list index).
+   */
+  private abstract static class NestedEncoder extends FSEncoder {
+    // Exactly one of these is non-null at a time, reflecting the child currently being encoded.
+    private Map<String, Value> nestedMap;
+    private List<Value> nestedList;
+
+    @Override
+    public Encoder encodeList(int n) {
+      nestedList = new ArrayList<>();
+      this.value =
+          Value.newBuilder()
+              .setArrayValue(ArrayValue.newBuilder().addAllValues(nestedList).build())
+              .build();
+      return new ListEncoder(nestedList);
+    }
+
+    @Override
+    public Encoder encodeMap(int n) {
+      nestedMap = new HashMap<>();
+      this.value =
+          Value.newBuilder()
+              .setMapValue(MapValue.newBuilder().putAllFields(nestedMap).build())
+              .build();
+      return new MapEncoder(nestedMap);
+    }
+
+    @Override
+    public Value getValue() {
+      // Rebuild from the backing collection without clearing it, so repeated calls are idempotent
+      // (mirroring the top-level getValue). The collection is guarded because the child value's
+      // type case is the source of truth for which collection holds the child.
+      if (value != null && value.getValueTypeCase() == Value.ValueTypeCase.MAP_VALUE) {
+        Map<String, Value> fields = nestedMap != null ? nestedMap : Collections.emptyMap();
+        this.value =
+            Value.newBuilder()
+                .setMapValue(MapValue.newBuilder().putAllFields(fields).build())
+                .build();
+      } else if (value != null && value.getValueTypeCase() == Value.ValueTypeCase.ARRAY_VALUE) {
+        List<Value> values = nestedList != null ? nestedList : Collections.emptyList();
+        this.value =
+            Value.newBuilder()
+                .setArrayValue(ArrayValue.newBuilder().addAllValues(values).build())
+                .build();
+      }
+      return this.value;
+    }
+  }
+
+  public static class MapEncoder extends NestedEncoder {
     private final Map<String, Value> m;
 
     public MapEncoder(Map<String, Value> map) {
@@ -114,7 +168,7 @@ public class FSEncoder implements Encoder {
     return this.value;
   }
 
-  public static class ListEncoder extends FSEncoder {
+  public static class ListEncoder extends NestedEncoder {
     private final List<Value> l;
 
     public ListEncoder(List<Value> list) {

--- a/docstore/docstore-gcp-firestore/src/main/java/com/salesforce/multicloudj/docstore/gcp/FSEncoder.java
+++ b/docstore/docstore-gcp-firestore/src/main/java/com/salesforce/multicloudj/docstore/gcp/FSEncoder.java
@@ -6,7 +6,6 @@ import com.google.firestore.v1.Value;
 import com.google.protobuf.ByteString;
 import com.salesforce.multicloudj.docstore.driver.codec.Encoder;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,7 +16,7 @@ public class FSEncoder implements Encoder {
 
   private List<Value> list = new ArrayList<>();
 
-  private final Map<String, Value> map = new HashMap<>();
+  private Map<String, Value> map = new HashMap<>();
 
   protected Value value;
 
@@ -58,10 +57,8 @@ public class FSEncoder implements Encoder {
 
   @Override
   public Encoder encodeList(int n) {
-    this.value =
-        Value.newBuilder()
-            .setArrayValue(ArrayValue.newBuilder().addAllValues(list).build())
-            .build();
+    list = new ArrayList<>();
+    value = arrayValue(list);
     return new ListEncoder(list);
   }
 
@@ -72,8 +69,8 @@ public class FSEncoder implements Encoder {
 
   @Override
   public Encoder encodeMap(int n) {
-    this.value =
-        Value.newBuilder().setMapValue(MapValue.newBuilder().putAllFields(map).build()).build();
+    map = new HashMap<>();
+    value = mapValue(map);
     return new MapEncoder(map);
   }
 
@@ -87,60 +84,16 @@ public class FSEncoder implements Encoder {
     return null;
   }
 
-  /**
-   * Base class for the nested encoders ({@link MapEncoder}, {@link ListEncoder}). A nested encoder
-   * holds a single child value at a time (either a nested map or a nested list) in its own backing
-   * collection so that sibling values never share a backing collection. The container-specific
-   * subclass decides where a completed child value is stored (a map key or a list index).
-   */
-  private abstract static class NestedEncoder extends FSEncoder {
-    // Exactly one of these is non-null at a time, reflecting the child currently being encoded.
-    private Map<String, Value> nestedMap;
-    private List<Value> nestedList;
-
-    @Override
-    public Encoder encodeList(int n) {
-      nestedList = new ArrayList<>();
-      this.value =
-          Value.newBuilder()
-              .setArrayValue(ArrayValue.newBuilder().addAllValues(nestedList).build())
-              .build();
-      return new ListEncoder(nestedList);
+  public Value getValue() {
+    if (value.getValueTypeCase() == Value.ValueTypeCase.MAP_VALUE) {
+      value = mapValue(map);
+    } else if (value.getValueTypeCase() == Value.ValueTypeCase.ARRAY_VALUE) {
+      value = arrayValue(list);
     }
-
-    @Override
-    public Encoder encodeMap(int n) {
-      nestedMap = new HashMap<>();
-      this.value =
-          Value.newBuilder()
-              .setMapValue(MapValue.newBuilder().putAllFields(nestedMap).build())
-              .build();
-      return new MapEncoder(nestedMap);
-    }
-
-    @Override
-    public Value getValue() {
-      // Rebuild from the backing collection without clearing it, so repeated calls are idempotent
-      // (mirroring the top-level getValue). The collection is guarded because the child value's
-      // type case is the source of truth for which collection holds the child.
-      if (value != null && value.getValueTypeCase() == Value.ValueTypeCase.MAP_VALUE) {
-        Map<String, Value> fields = nestedMap != null ? nestedMap : Collections.emptyMap();
-        this.value =
-            Value.newBuilder()
-                .setMapValue(MapValue.newBuilder().putAllFields(fields).build())
-                .build();
-      } else if (value != null && value.getValueTypeCase() == Value.ValueTypeCase.ARRAY_VALUE) {
-        List<Value> values = nestedList != null ? nestedList : Collections.emptyList();
-        this.value =
-            Value.newBuilder()
-                .setArrayValue(ArrayValue.newBuilder().addAllValues(values).build())
-                .build();
-      }
-      return this.value;
-    }
+    return value;
   }
 
-  public static class MapEncoder extends NestedEncoder {
+  public static class MapEncoder extends FSEncoder {
     private final Map<String, Value> m;
 
     public MapEncoder(Map<String, Value> map) {
@@ -153,22 +106,7 @@ public class FSEncoder implements Encoder {
     }
   }
 
-  public Value getValue() {
-    if (value.getValueTypeCase() == Value.ValueTypeCase.MAP_VALUE) {
-      // The change to map is stored in the map field. Set the value with map again.
-      this.value =
-          Value.newBuilder().setMapValue(MapValue.newBuilder().putAllFields(map).build()).build();
-    } else if (value.getValueTypeCase() == Value.ValueTypeCase.ARRAY_VALUE) {
-      // The change to list is stored in the list field. Set the value with list again.
-      this.value =
-          Value.newBuilder()
-              .setArrayValue(ArrayValue.newBuilder().addAllValues(list).build())
-              .build();
-    }
-    return this.value;
-  }
-
-  public static class ListEncoder extends NestedEncoder {
+  public static class ListEncoder extends FSEncoder {
     private final List<Value> l;
 
     public ListEncoder(List<Value> list) {
@@ -179,5 +117,17 @@ public class FSEncoder implements Encoder {
     public void listIndex(int i) {
       l.add(i, getValue());
     }
+  }
+
+  private static Value mapValue(Map<String, Value> fields) {
+    return Value.newBuilder()
+        .setMapValue(MapValue.newBuilder().putAllFields(fields).build())
+        .build();
+  }
+
+  private static Value arrayValue(List<Value> values) {
+    return Value.newBuilder()
+        .setArrayValue(ArrayValue.newBuilder().addAllValues(values).build())
+        .build();
   }
 }

--- a/docstore/docstore-gcp-firestore/src/test/java/com/salesforce/multicloudj/docstore/gcp/FSEncoderTest.java
+++ b/docstore/docstore-gcp-firestore/src/test/java/com/salesforce/multicloudj/docstore/gcp/FSEncoderTest.java
@@ -5,6 +5,7 @@ import com.google.protobuf.Timestamp;
 import com.salesforce.multicloudj.docstore.driver.codec.Codec;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
@@ -79,5 +80,35 @@ public class FSEncoderTest {
     Value got = encoder.getValue();
     Assertions.assertTrue(got.hasNullValue());
     Assertions.assertEquals(com.google.protobuf.NullValue.NULL_VALUE, got.getNullValue());
+  }
+
+  /**
+   * Verifies that sibling nested maps are encoded independently: each keeps its own backing
+   * collection, so {@code {"a": {"x": 1}, "b": {"y": 2}}} round-trips with "a" and "b" holding
+   * exactly their own single field.
+   */
+  @Test
+  public void testSiblingMapsDoNotMerge() {
+    Map<String, Object> doc = new LinkedHashMap<>();
+    doc.put("a", new LinkedHashMap<>(Map.of("x", 1)));
+    doc.put("b", new LinkedHashMap<>(Map.of("y", 2)));
+
+    FSEncoder encoder = new FSEncoder();
+    Codec.encode(doc, encoder);
+    Value result = encoder.getValue();
+
+    Assertions.assertTrue(result.hasMapValue());
+    Map<String, Value> fields = result.getMapValue().getFieldsMap();
+    Assertions.assertEquals(2, fields.size());
+
+    Value a = fields.get("a");
+    Assertions.assertTrue(a.hasMapValue());
+    Assertions.assertEquals(1, a.getMapValue().getFieldsCount());
+    Assertions.assertEquals(1, a.getMapValue().getFieldsMap().get("x").getIntegerValue());
+
+    Value b = fields.get("b");
+    Assertions.assertTrue(b.hasMapValue());
+    Assertions.assertEquals(1, b.getMapValue().getFieldsCount());
+    Assertions.assertEquals(2, b.getMapValue().getFieldsMap().get("y").getIntegerValue());
   }
 }

--- a/docstore/docstore-gcp-firestore/src/test/java/com/salesforce/multicloudj/docstore/gcp/FSEncoderTest.java
+++ b/docstore/docstore-gcp-firestore/src/test/java/com/salesforce/multicloudj/docstore/gcp/FSEncoderTest.java
@@ -82,11 +82,6 @@ public class FSEncoderTest {
     Assertions.assertEquals(com.google.protobuf.NullValue.NULL_VALUE, got.getNullValue());
   }
 
-  /**
-   * Verifies that sibling nested maps are encoded independently: each keeps its own backing
-   * collection, so {@code {"a": {"x": 1}, "b": {"y": 2}}} round-trips with "a" and "b" holding
-   * exactly their own single field.
-   */
   @Test
   public void testSiblingMapsDoNotMerge() {
     Map<String, Object> doc = new LinkedHashMap<>();
@@ -110,5 +105,35 @@ public class FSEncoderTest {
     Assertions.assertTrue(b.hasMapValue());
     Assertions.assertEquals(1, b.getMapValue().getFieldsCount());
     Assertions.assertEquals(2, b.getMapValue().getFieldsMap().get("y").getIntegerValue());
+  }
+
+  @Test
+  public void testMixedMapAndListSiblings() {
+    Map<String, Object> doc = new LinkedHashMap<>();
+    doc.put("id", "test123");
+    doc.put("features", new LinkedHashMap<>(Map.of("color", "red")));
+    doc.put("ratings", Arrays.asList(1, 2, 3));
+
+    FSEncoder encoder = new FSEncoder();
+    Codec.encode(doc, encoder);
+    Value result = encoder.getValue();
+
+    Assertions.assertTrue(result.hasMapValue());
+    Map<String, Value> fields = result.getMapValue().getFieldsMap();
+    Assertions.assertEquals(3, fields.size());
+    Assertions.assertEquals("test123", fields.get("id").getStringValue());
+
+    Value features = fields.get("features");
+    Assertions.assertTrue(features.hasMapValue());
+    Assertions.assertEquals(1, features.getMapValue().getFieldsCount());
+    Assertions.assertEquals(
+        "red", features.getMapValue().getFieldsMap().get("color").getStringValue());
+
+    Value ratings = fields.get("ratings");
+    Assertions.assertTrue(ratings.hasArrayValue());
+    Assertions.assertEquals(3, ratings.getArrayValue().getValuesCount());
+    Assertions.assertEquals(1, ratings.getArrayValue().getValues(0).getIntegerValue());
+    Assertions.assertEquals(2, ratings.getArrayValue().getValues(1).getIntegerValue());
+    Assertions.assertEquals(3, ratings.getArrayValue().getValues(2).getIntegerValue());
   }
 }


### PR DESCRIPTION
## Summary

< Provide a brief description of the changes in this PR >

## Some conventions to follow
1. add the module name as a prefix
   - for example: add a prefix: `docstore:` for document store module, `blobstore` for Blob Store module
2. for a test only PR, add `test:`
3. for a perf improvement only PR, add `perf:`
4. for a refactoring only PR, add "refactor:"
