### PR TITLE
blobstore: add SSE-KMS support to directory upload

### DIFF
--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsTransformer.java
@@ -922,11 +922,14 @@ public class AwsTransformer {
 
     boolean hasTags = request.getTags() != null && !request.getTags().isEmpty();
     boolean hasObjectLock = request.getObjectLock() != null;
+    boolean hasKmsKeyId = StringUtils.isNotEmpty(request.getKmsKeyId());
+    boolean useKmsManagedKey = request.isUseKmsManagedKey();
+    boolean hasKms = hasKmsKeyId || useKmsManagedKey;
     boolean transferStatusLoggingEnabled =
         request.isTransferStatusLoggingEnabled() && totalBytesTransferred != null;
     boolean countRequested = totalBytesRequested != null;
 
-    if (!hasTags && !hasObjectLock && !transferStatusLoggingEnabled && !countRequested) {
+    if (!hasTags && !hasObjectLock && !hasKms && !transferStatusLoggingEnabled && !countRequested) {
       return builder.build();
     }
 
@@ -937,11 +940,12 @@ public class AwsTransformer {
               .collect(Collectors.toList())
             : null;
     ObjectLockConfiguration lockConfig = request.getObjectLock();
+    String kmsKeyId = request.getKmsKeyId();
     S3LoggingTransferListener transferListener =
         transferStatusLoggingEnabled
             ? S3LoggingTransferListener.create(totalBytesTransferred)
             : null;
-    // Merge tags / object lock into the existing PutObjectRequest per file;
+    // Merge tags / object lock / SSE-KMS into the existing PutObjectRequest per file;
     // putObjectRequest(Consumer) would replace it and drop bucket/key.
     // S3 Transfer Manager doesn't expose a directory-listing filter for uploads, so this
     // per-file hook is also where we stat each source's planned size into
@@ -950,7 +954,7 @@ public class AwsTransformer {
     // over-count; the same trade-off applies as the download filter above.
     builder.uploadFileRequestTransformer(
         fileRequestBuilder -> {
-          if (hasTags || hasObjectLock) {
+          if (hasTags || hasObjectLock || hasKms) {
             PutObjectRequest existing = fileRequestBuilder.build().putObjectRequest();
             PutObjectRequest.Builder putBuilder = existing.toBuilder();
             if (hasTags) {
@@ -958,6 +962,13 @@ public class AwsTransformer {
             }
             if (hasObjectLock) {
               applyObjectLockToPutObjectBuilder(putBuilder, lockConfig);
+            }
+            if (hasKmsKeyId) {
+              putBuilder
+                  .serverSideEncryption(ServerSideEncryption.AWS_KMS)
+                  .ssekmsKeyId(kmsKeyId);
+            } else if (useKmsManagedKey) {
+              putBuilder.serverSideEncryption(ServerSideEncryption.AWS_KMS);
             }
             fileRequestBuilder.putObjectRequest(putBuilder.build());
           }

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsTransformerTest.java
@@ -84,6 +84,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectTaggingRequest;
 import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
@@ -1509,6 +1510,106 @@ public class AwsTransformerTest {
     assertEquals(retainUntil, putRequest.objectLockRetainUntilDate());
     assertEquals(ObjectLockLegalHoldStatus.ON, putRequest.objectLockLegalHoldStatus());
     assertNotNull(putRequest.tagging());
+  }
+
+  @Test
+  void testToUploadDirectoryRequest_WithKmsKeyId() {
+    String kmsKeyId = "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab";
+    DirectoryUploadRequest directoryUploadRequest =
+        DirectoryUploadRequest.builder()
+            .localSourceDirectory("/home/documents")
+            .prefix("/files")
+            .includeSubFolders(true)
+            .kmsKeyId(kmsKeyId)
+            .build();
+
+    UploadDirectoryRequest request =
+        transformer.toUploadDirectoryRequest(directoryUploadRequest, null, null);
+
+    assertNotNull(request);
+    // The KMS-only request must not be dropped by the early-return guard.
+    assertNotNull(request.uploadFileRequestTransformer());
+    UploadFileRequest.Builder fileBuilder =
+        UploadFileRequest.builder()
+            .source(Paths.get("/tmp/test.txt"))
+            .putObjectRequest(
+                PutObjectRequest.builder().bucket(BUCKET).key("/files/test.txt").build());
+    request.uploadFileRequestTransformer().accept(fileBuilder);
+    PutObjectRequest putRequest = fileBuilder.build().putObjectRequest();
+    assertEquals(ServerSideEncryption.AWS_KMS, putRequest.serverSideEncryption());
+    assertEquals(kmsKeyId, putRequest.ssekmsKeyId());
+  }
+
+  @Test
+  void testToUploadDirectoryRequest_WithUseKmsManagedKey() {
+    DirectoryUploadRequest directoryUploadRequest =
+        DirectoryUploadRequest.builder()
+            .localSourceDirectory("/home/documents")
+            .prefix("/files")
+            .includeSubFolders(true)
+            .useKmsManagedKey(true)
+            .build();
+
+    UploadDirectoryRequest request =
+        transformer.toUploadDirectoryRequest(directoryUploadRequest, null, null);
+
+    assertNotNull(request);
+    UploadFileRequest.Builder fileBuilder =
+        UploadFileRequest.builder()
+            .source(Paths.get("/tmp/test.txt"))
+            .putObjectRequest(
+                PutObjectRequest.builder().bucket(BUCKET).key("/files/test.txt").build());
+    request.uploadFileRequestTransformer().accept(fileBuilder);
+    PutObjectRequest putRequest = fileBuilder.build().putObjectRequest();
+    assertEquals(ServerSideEncryption.AWS_KMS, putRequest.serverSideEncryption());
+    assertNull(putRequest.ssekmsKeyId());
+  }
+
+  @Test
+  void testToUploadDirectoryRequest_KmsKeyIdWinsOverUseKmsManagedKey() {
+    String kmsKeyId = "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab";
+    DirectoryUploadRequest directoryUploadRequest =
+        DirectoryUploadRequest.builder()
+            .localSourceDirectory("/home/documents")
+            .kmsKeyId(kmsKeyId)
+            .useKmsManagedKey(true)
+            .build();
+
+    UploadDirectoryRequest request =
+        transformer.toUploadDirectoryRequest(directoryUploadRequest, null, null);
+
+    UploadFileRequest.Builder fileBuilder =
+        UploadFileRequest.builder()
+            .source(Paths.get("/tmp/test.txt"))
+            .putObjectRequest(
+                PutObjectRequest.builder().bucket(BUCKET).key("/files/test.txt").build());
+    request.uploadFileRequestTransformer().accept(fileBuilder);
+    PutObjectRequest putRequest = fileBuilder.build().putObjectRequest();
+    assertEquals(ServerSideEncryption.AWS_KMS, putRequest.serverSideEncryption());
+    assertEquals(kmsKeyId, putRequest.ssekmsKeyId());
+  }
+
+  @Test
+  void testToUploadDirectoryRequest_NoKmsLeavesEncryptionUnset() {
+    DirectoryUploadRequest directoryUploadRequest =
+        DirectoryUploadRequest.builder()
+            .localSourceDirectory("/home/documents")
+            .prefix("/files")
+            .tags(Map.of("env", "prod"))
+            .build();
+
+    UploadDirectoryRequest request =
+        transformer.toUploadDirectoryRequest(directoryUploadRequest, null, null);
+
+    UploadFileRequest.Builder fileBuilder =
+        UploadFileRequest.builder()
+            .source(Paths.get("/tmp/test.txt"))
+            .putObjectRequest(
+                PutObjectRequest.builder().bucket(BUCKET).key("/files/test.txt").build());
+    request.uploadFileRequestTransformer().accept(fileBuilder);
+    PutObjectRequest putRequest = fileBuilder.build().putObjectRequest();
+    assertNull(putRequest.serverSideEncryption());
+    assertNull(putRequest.ssekmsKeyId());
   }
 
   @Test

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/DirectoryUploadRequest.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/DirectoryUploadRequest.java
@@ -30,4 +30,19 @@ public class DirectoryUploadRequest {
    * directory marker when a prefix is used.
    */
   private final ObjectLockConfiguration objectLock;
+
+  /**
+   * (Optional parameter) The KMS key ID or ARN to use for server-side encryption of every object
+   * uploaded from the directory. When set, the KMS key is applied to each object; when null,
+   * either the bucket default or {@link #useKmsManagedKey} determines the encryption applied.
+   */
+  private final String kmsKeyId;
+
+  /**
+   * Set the serviceSideEncryption Header but don't set the kmsKeyId. When false and kmsKeyId is
+   * null, no SSE headers are sent (bucket default applies). This option will trigger the use of the
+   * cloud provider managed key. Providers whose native APIs do not accept a provider-managed-key
+   * signal on write treat this field as a no-op.
+   */
+  private final boolean useKmsManagedKey;
 }

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -5826,6 +5826,107 @@ public abstract class AbstractBlobStoreIT {
   }
 
   @Test
+  public void testUploadDirectory_withKmsKey(@TempDir Path tempDir) throws Exception {
+    Assumptions.assumeTrue(
+        harness.isDirectoryUploadSupported(), "Directory upload not supported by this provider");
+
+    String kmsKeyId = harness.getKmsKeyId();
+    Assumptions.assumeTrue(
+        kmsKeyId != null && !kmsKeyId.isEmpty(), "KMS key not configured for this harness");
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    Path file1 = tempDir.resolve("kms-file1.txt");
+    Path subdir = tempDir.resolve("subdir");
+    Files.createDirectories(subdir);
+    Path file2 = subdir.resolve("kms-file2.txt");
+
+    byte[] content1 = "kms-directory-content-1".getBytes(StandardCharsets.UTF_8);
+    byte[] content2 = "kms-directory-content-2".getBytes(StandardCharsets.UTF_8);
+    Files.write(file1, content1);
+    Files.write(file2, content2);
+
+    String prefix = "conformance-tests/directory/upload-kms-v1";
+    String key1 = prefix + "/kms-file1.txt";
+    String key2 = prefix + "/subdir/kms-file2.txt";
+
+    DirectoryUploadRequest request =
+        DirectoryUploadRequest.builder()
+            .localSourceDirectory(tempDir.toString())
+            .prefix(prefix)
+            .includeSubFolders(true)
+            .kmsKeyId(kmsKeyId)
+            .build();
+
+    try {
+      DirectoryUploadResponse response = blobStore.uploadDirectory(request);
+      Assertions.assertNotNull(response);
+      Assertions.assertTrue(
+          response.getFailedTransfers().isEmpty(),
+          "Upload with KMS key should succeed without failures");
+
+      for (Map.Entry<String, byte[]> entry :
+          Map.of(key1, content1, key2, content2).entrySet()) {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+          DownloadRequest downloadRequest =
+              new DownloadRequest.Builder().withKey(entry.getKey()).build();
+          bucketClient.download(downloadRequest, out);
+          Assertions.assertArrayEquals(
+              entry.getValue(),
+              out.toByteArray(),
+              "Content roundtrip should succeed for " + entry.getKey());
+        }
+      }
+    } finally {
+      safeDeleteBlobs(bucketClient, key1, key2);
+    }
+
+    blobStore.close();
+  }
+
+  @Test
+  public void testUploadDirectory_withNullKmsKey(@TempDir Path tempDir) throws Exception {
+    Assumptions.assumeTrue(
+        harness.isDirectoryUploadSupported(), "Directory upload not supported by this provider");
+
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, false);
+    BucketClient bucketClient = new BucketClient(blobStore);
+
+    Path file1 = tempDir.resolve("null-kms.txt");
+    byte[] content = "null-kms-content".getBytes(StandardCharsets.UTF_8);
+    Files.write(file1, content);
+
+    String prefix = "conformance-tests/directory/upload-kms-null-v1";
+    String key1 = prefix + "/null-kms.txt";
+
+    DirectoryUploadRequest request =
+        DirectoryUploadRequest.builder()
+            .localSourceDirectory(tempDir.toString())
+            .prefix(prefix)
+            .includeSubFolders(true)
+            .kmsKeyId(null)
+            .build();
+
+    try {
+      DirectoryUploadResponse response = blobStore.uploadDirectory(request);
+      Assertions.assertNotNull(response);
+      Assertions.assertTrue(
+          response.getFailedTransfers().isEmpty(),
+          "Upload with null KMS key should fall back to bucket defaults without error");
+
+      try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+        bucketClient.download(new DownloadRequest.Builder().withKey(key1).build(), out);
+        Assertions.assertArrayEquals(content, out.toByteArray(), "Content roundtrip should match");
+      }
+    } finally {
+      safeDeleteBlobs(bucketClient, key1);
+    }
+
+    blobStore.close();
+  }
+
+  @Test
   public void testDownloadDirectory_basic(@TempDir Path tempDir) throws Exception {
     Assumptions.assumeTrue(
         harness.isDirectoryUploadSupported(), "Directory upload not supported by this provider");

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -1083,7 +1083,7 @@ public class GcpBlobStore extends AbstractBlobStore {
       // BlobInfo, so failures returned by the TransferManager can be attributed back
       // to the originating file.
       final Map<String, Path> keyToSource = new ConcurrentHashMap<>();
-      ParallelUploadConfig uploadConfig =
+      ParallelUploadConfig.Builder configBuilder =
           ParallelUploadConfig.newBuilder()
               .setBucketName(getBucket())
               .setUploadBlobInfoFactory(
@@ -1092,8 +1092,18 @@ public class GcpBlobStore extends AbstractBlobStore {
                       prefix,
                       metadata,
                       keyToSource,
-                      directoryUploadRequest.getObjectLock()))
-              .build();
+                      directoryUploadRequest.getObjectLock()));
+
+      // GCS CMEK is expressed on each write via BlobWriteOption.kmsKeyName. BlobInfo.kmsKeyName is
+      // read-back-only, so the KMS key must be threaded through ParallelUploadConfig rather than
+      // the UploadBlobInfoFactory.
+      String kmsKeyId = directoryUploadRequest.getKmsKeyId();
+      if (kmsKeyId != null && !kmsKeyId.isEmpty()) {
+        configBuilder.setWriteOptsPerRequest(
+            List.of(Storage.BlobWriteOption.kmsKeyName(kmsKeyId)));
+      }
+
+      ParallelUploadConfig uploadConfig = configBuilder.build();
 
       UploadJob job = transferManager.uploadFiles(filePaths, uploadConfig);
       return DirectoryUploadResponse.builder()

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -2595,6 +2595,37 @@ class GcpBlobStoreTest {
     assertTrue(writeOpts == null || writeOpts.isEmpty());
   }
 
+  @Test
+  void testUploadDirectory_WithUseKmsManagedKey_NoWriteOpts() throws Exception {
+    // GCS uses CMEK keys only; there is no service-managed-KMS equivalent. The
+    // useKmsManagedKey flag must be silently ignored so that a caller toggling it
+    // does not accidentally add write options.
+    DirectoryUploadRequest request =
+        DirectoryUploadRequest.builder()
+            .localSourceDirectory(tempDir.toString())
+            .prefix("uploads/")
+            .includeSubFolders(true)
+            .useKmsManagedKey(true)
+            .build();
+
+    Path file1 = tempDir.resolve("file1.txt");
+    when(mockTransformer.toFilePaths(request)).thenReturn(List.of(file1));
+
+    UploadJob mockJob = mock(UploadJob.class);
+    when(mockJob.getUploadResults())
+        .thenReturn(List.of(makeUploadResult("uploads/file1.txt", TransferStatus.SUCCESS, null)));
+    when(mockTransferManager.uploadFiles(anyList(), any(ParallelUploadConfig.class)))
+        .thenReturn(mockJob);
+
+    gcpBlobStore.uploadDirectory(request);
+
+    ArgumentCaptor<ParallelUploadConfig> configCaptor =
+        ArgumentCaptor.forClass(ParallelUploadConfig.class);
+    verify(mockTransferManager).uploadFiles(anyList(), configCaptor.capture());
+    List<Storage.BlobWriteOption> writeOpts = configCaptor.getValue().getWriteOptsPerRequest();
+    assertTrue(writeOpts == null || writeOpts.isEmpty());
+  }
+
   /**
    * Regression test for the relative-source-directory case. The real GCS TransferManager
    * always calls our factory with {@code sourceFile.toAbsolutePath().toString()} as the

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -2567,6 +2567,34 @@ class GcpBlobStoreTest {
     assertTrue(writeOpts == null || writeOpts.isEmpty());
   }
 
+  @Test
+  void testUploadDirectory_WithEmptyKmsKeyId_NoWriteOpts() throws Exception {
+    DirectoryUploadRequest request =
+        DirectoryUploadRequest.builder()
+            .localSourceDirectory(tempDir.toString())
+            .prefix("uploads/")
+            .includeSubFolders(true)
+            .kmsKeyId("")
+            .build();
+
+    Path file1 = tempDir.resolve("file1.txt");
+    when(mockTransformer.toFilePaths(request)).thenReturn(List.of(file1));
+
+    UploadJob mockJob = mock(UploadJob.class);
+    when(mockJob.getUploadResults())
+        .thenReturn(List.of(makeUploadResult("uploads/file1.txt", TransferStatus.SUCCESS, null)));
+    when(mockTransferManager.uploadFiles(anyList(), any(ParallelUploadConfig.class)))
+        .thenReturn(mockJob);
+
+    gcpBlobStore.uploadDirectory(request);
+
+    ArgumentCaptor<ParallelUploadConfig> configCaptor =
+        ArgumentCaptor.forClass(ParallelUploadConfig.class);
+    verify(mockTransferManager).uploadFiles(anyList(), configCaptor.capture());
+    List<Storage.BlobWriteOption> writeOpts = configCaptor.getValue().getWriteOptsPerRequest();
+    assertTrue(writeOpts == null || writeOpts.isEmpty());
+  }
+
   /**
    * Regression test for the relative-source-directory case. The real GCS TransferManager
    * always calls our factory with {@code sourceFile.toAbsolutePath().toString()} as the

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -2509,6 +2509,64 @@ class GcpBlobStoreTest {
     }
   }
 
+  @Test
+  void testUploadDirectory_WithKmsKeyId() throws Exception {
+    String kmsKeyId = "projects/p/locations/us/keyRings/r/cryptoKeys/k";
+    DirectoryUploadRequest request =
+        DirectoryUploadRequest.builder()
+            .localSourceDirectory(tempDir.toString())
+            .prefix("uploads/")
+            .includeSubFolders(true)
+            .kmsKeyId(kmsKeyId)
+            .build();
+
+    Path file1 = tempDir.resolve("file1.txt");
+    when(mockTransformer.toFilePaths(request)).thenReturn(List.of(file1));
+
+    UploadJob mockJob = mock(UploadJob.class);
+    when(mockJob.getUploadResults())
+        .thenReturn(List.of(makeUploadResult("uploads/file1.txt", TransferStatus.SUCCESS, null)));
+    when(mockTransferManager.uploadFiles(anyList(), any(ParallelUploadConfig.class)))
+        .thenReturn(mockJob);
+
+    gcpBlobStore.uploadDirectory(request);
+
+    ArgumentCaptor<ParallelUploadConfig> configCaptor =
+        ArgumentCaptor.forClass(ParallelUploadConfig.class);
+    verify(mockTransferManager).uploadFiles(anyList(), configCaptor.capture());
+    List<Storage.BlobWriteOption> writeOpts = configCaptor.getValue().getWriteOptsPerRequest();
+    assertNotNull(writeOpts);
+    assertEquals(1, writeOpts.size());
+    assertEquals(Storage.BlobWriteOption.kmsKeyName(kmsKeyId), writeOpts.get(0));
+  }
+
+  @Test
+  void testUploadDirectory_WithoutKmsKeyId_NoWriteOpts() throws Exception {
+    DirectoryUploadRequest request =
+        DirectoryUploadRequest.builder()
+            .localSourceDirectory(tempDir.toString())
+            .prefix("uploads/")
+            .includeSubFolders(true)
+            .build();
+
+    Path file1 = tempDir.resolve("file1.txt");
+    when(mockTransformer.toFilePaths(request)).thenReturn(List.of(file1));
+
+    UploadJob mockJob = mock(UploadJob.class);
+    when(mockJob.getUploadResults())
+        .thenReturn(List.of(makeUploadResult("uploads/file1.txt", TransferStatus.SUCCESS, null)));
+    when(mockTransferManager.uploadFiles(anyList(), any(ParallelUploadConfig.class)))
+        .thenReturn(mockJob);
+
+    gcpBlobStore.uploadDirectory(request);
+
+    ArgumentCaptor<ParallelUploadConfig> configCaptor =
+        ArgumentCaptor.forClass(ParallelUploadConfig.class);
+    verify(mockTransferManager).uploadFiles(anyList(), configCaptor.capture());
+    List<Storage.BlobWriteOption> writeOpts = configCaptor.getValue().getWriteOptsPerRequest();
+    assertTrue(writeOpts == null || writeOpts.isEmpty());
+  }
+
   /**
    * Regression test for the relative-source-directory case. The real GCS TransferManager
    * always calls our factory with {@code sourceFile.toAbsolutePath().toString()} as the

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "874d608f-ef26-43b4-a25a-5163026e7d16",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withKmsKey-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fsubdir%2Fkms-file2.txt",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AJjja9ZW-C46exwK4WZTg-kOTAryMsv9j65vmBSqrvOkRoEEeogJZp6J7Hz6fxaBtTGwyoqULkhz",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:27 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "874d608f-ef26-43b4-a25a-5163026e7d16",
+  "persistent" : true,
+  "insertionIndex" : 1501
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-delete-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-delete-2.json
@@ -1,0 +1,25 @@
+{
+  "id" : "2236b641-9111-4f11-b3b7-fc861ca17681",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withKmsKey-DELETE-2",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fkms-file1.txt",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AJjja9aAOcoWCfmWLMGhazO-59ax6Vn0TxO6Rd7zjHBR9IueGJoDxqsfHaTLNaAi_v8JRYnC0CRz",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:26 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "2236b641-9111-4f11-b3b7-fc861ca17681",
+  "persistent" : true,
+  "insertionIndex" : 1503
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-get-1.json
@@ -1,0 +1,47 @@
+{
+  "id" : "32224c5b-81a8-473d-ab32-9150ae4d39de",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withKmsKey-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "prefix" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/directory/upload-kms-v1/subdir/kms-file2.txt"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/directory/upload-kms-v1/subdir/kms-file2.txt/1787084544251442\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fsubdir%2Fkms-file2.txt\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fsubdir%2Fkms-file2.txt?generation=1787084544251442&alt=media\",\n      \"name\": \"conformance-tests/directory/upload-kms-v1/subdir/kms-file2.txt\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1787084544251442\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"23\",\n      \"etag\": \"CLKsxtuAq5YDEAE=\",\n      \"kmsKeyName\": \"projects/substrate-sdk-gcp-poc1/locations/us/keyRings/chameleon-test/cryptoKeys/chameleon-test/cryptoKeyVersions/1\",\n      \"timeCreated\": \"2026-08-18T20:22:24.308Z\",\n      \"updated\": \"2026-08-18T20:22:24.308Z\",\n      \"timeStorageClassUpdated\": \"2026-08-18T20:22:24.308Z\",\n      \"timeFinalized\": \"2026-08-18T20:22:24.308Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AJjja9YoRUndHfcM85P3D-MCCZY1AKTKGGSr9Sj6E3fmEAH3cxEGPQyMpJmBcXreK0qcGi-3bgxu",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 18 Aug 2026 20:22:26 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:26 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "32224c5b-81a8-473d-ab32-9150ae4d39de",
+  "persistent" : true,
+  "insertionIndex" : 1502
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-get-3.json
@@ -1,0 +1,47 @@
+{
+  "id" : "8f710839-c2b0-4345-81c3-b022e3efee3a",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withKmsKey-GET-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "prefix" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/directory/upload-kms-v1/kms-file1.txt"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/directory/upload-kms-v1/kms-file1.txt/1787084544232853\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fkms-file1.txt\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fkms-file1.txt?generation=1787084544232853&alt=media\",\n      \"name\": \"conformance-tests/directory/upload-kms-v1/kms-file1.txt\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1787084544232853\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"23\",\n      \"etag\": \"CJWbxduAq5YDEAE=\",\n      \"kmsKeyName\": \"projects/substrate-sdk-gcp-poc1/locations/us/keyRings/chameleon-test/cryptoKeys/chameleon-test/cryptoKeyVersions/1\",\n      \"timeCreated\": \"2026-08-18T20:22:24.286Z\",\n      \"updated\": \"2026-08-18T20:22:24.286Z\",\n      \"timeStorageClassUpdated\": \"2026-08-18T20:22:24.286Z\",\n      \"timeFinalized\": \"2026-08-18T20:22:24.286Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AJjja9YzZDvfCJ9coS1knr_WgaBu8n-Rg7NewiWYfRb8Iv8yOTeDCD0st9olQZzXVBLWR4vPJS5Ldg",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 18 Aug 2026 20:22:25 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:25 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "8f710839-c2b0-4345-81c3-b022e3efee3a",
+  "persistent" : true,
+  "insertionIndex" : 1504
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-get-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-get-4.json
@@ -1,0 +1,47 @@
+{
+  "id" : "3781550e-2d68-4c91-a7f0-e2c1dc2ade1d",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withKmsKey-GET-4",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fsubdir%2Fkms-file2.txt",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "a21zLWRpcmVjdG9yeS1jb250ZW50LTI=",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1787084544251442",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Tue, 18 Aug 2026 20:22:24 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Tue, 18 Aug 2026 20:22:25 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=GW4b8w==,md5=rRveRDID05J5UBgj8W/opA==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CLKsxtuAq5YDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AJjja9ZL7tBSa91ViKH_rCijifc5s85H0h6u12EAaU4Kuuhr6M87HJUKAkmhl7rHggbILPflqdee",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "23",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "3781550e-2d68-4c91-a7f0-e2c1dc2ade1d",
+  "persistent" : true,
+  "insertionIndex" : 1505
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-get-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-get-5.json
@@ -1,0 +1,39 @@
+{
+  "id" : "ff894fbd-38d0-4fd1-ba7c-8be8c44b953e",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withKmsKey-GET-5",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fsubdir%2Fkms-file2.txt",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/directory/upload-kms-v1/subdir/kms-file2.txt/1787084544251442\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fsubdir%2Fkms-file2.txt\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fsubdir%2Fkms-file2.txt?generation=1787084544251442&alt=media\",\n  \"name\": \"conformance-tests/directory/upload-kms-v1/subdir/kms-file2.txt\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1787084544251442\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"23\",\n  \"md5Hash\": \"rRveRDID05J5UBgj8W/opA==\",\n  \"crc32c\": \"GW4b8w==\",\n  \"etag\": \"CLKsxtuAq5YDEAE=\",\n  \"kmsKeyName\": \"projects/substrate-sdk-gcp-poc1/locations/us/keyRings/chameleon-test/cryptoKeys/chameleon-test/cryptoKeyVersions/1\",\n  \"timeCreated\": \"2026-08-18T20:22:24.308Z\",\n  \"updated\": \"2026-08-18T20:22:24.308Z\",\n  \"timeStorageClassUpdated\": \"2026-08-18T20:22:24.308Z\",\n  \"timeFinalized\": \"2026-08-18T20:22:24.308Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CLKsxtuAq5YDEAE=",
+      "X-GUploader-UploadID" : "AJjja9acCQzRrjLGbXAXaUl_72FCIz5yBkrOvpSy6-Pq-4uOHAdie0gYW9Zk2GvaRw_FQgLaNrKmFA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Pragma" : "no-cache",
+      "Date" : "Tue, 18 Aug 2026 20:22:25 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "ff894fbd-38d0-4fd1-ba7c-8be8c44b953e",
+  "persistent" : true,
+  "insertionIndex" : 1506
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-get-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-get-6.json
@@ -1,0 +1,47 @@
+{
+  "id" : "97eb47d4-9fda-4992-85e8-c2803937b6cd",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withKmsKey-GET-6",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fkms-file1.txt",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "a21zLWRpcmVjdG9yeS1jb250ZW50LTE=",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1787084544232853",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Tue, 18 Aug 2026 20:22:24 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Tue, 18 Aug 2026 20:22:25 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=Cj7oBw==,md5=o9PiPoT45x0JFFG/mMMo7A==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CJWbxduAq5YDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AJjja9YptDEBvYuUGtiyYWKuUqhOgJ_ife7-qPBuM9H2F3TYfFD3jaFvQLvGSErDrUh0hEJu0za6",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "23",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "97eb47d4-9fda-4992-85e8-c2803937b6cd",
+  "persistent" : true,
+  "insertionIndex" : 1507
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-get-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-get-7.json
@@ -1,0 +1,39 @@
+{
+  "id" : "bf124b8f-44c8-4874-90fa-e24220bf8f91",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withKmsKey-GET-7",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fkms-file1.txt",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/directory/upload-kms-v1/kms-file1.txt/1787084544232853\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fkms-file1.txt\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fkms-file1.txt?generation=1787084544232853&alt=media\",\n  \"name\": \"conformance-tests/directory/upload-kms-v1/kms-file1.txt\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1787084544232853\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"23\",\n  \"md5Hash\": \"o9PiPoT45x0JFFG/mMMo7A==\",\n  \"crc32c\": \"Cj7oBw==\",\n  \"etag\": \"CJWbxduAq5YDEAE=\",\n  \"kmsKeyName\": \"projects/substrate-sdk-gcp-poc1/locations/us/keyRings/chameleon-test/cryptoKeys/chameleon-test/cryptoKeyVersions/1\",\n  \"timeCreated\": \"2026-08-18T20:22:24.286Z\",\n  \"updated\": \"2026-08-18T20:22:24.286Z\",\n  \"timeStorageClassUpdated\": \"2026-08-18T20:22:24.286Z\",\n  \"timeFinalized\": \"2026-08-18T20:22:24.286Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CJWbxduAq5YDEAE=",
+      "X-GUploader-UploadID" : "AJjja9bAvLRZmdI-4zy4SB2BvFUYyGgFlKxbaayNT-y_1PEc6P7YjOVN9XpQqLf4FuBBKuyuUYqu",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Pragma" : "no-cache",
+      "Date" : "Tue, 18 Aug 2026 20:22:24 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "bf124b8f-44c8-4874-90fa-e24220bf8f91",
+  "persistent" : true,
+  "insertionIndex" : 1508
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-post-10.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-post-10.json
@@ -1,0 +1,53 @@
+{
+  "id" : "b0fa39ee-1a79-4a0f-b842-a907d3231306",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withKmsKey-POST-10",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "kmsKeyName" : {
+        "hasExactly" : [ {
+          "equalTo" : "projects/substrate-sdk-gcp-poc1/locations/us/keyRings/chameleon-test/cryptoKeys/chameleon-test"
+        } ]
+      },
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/directory/upload-kms-v1/kms-file1.txt"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket\",\"name\":\"conformance-tests/directory/upload-kms-v1/kms-file1.txt\"}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AJjja9ZMwDrGtkznDtvn1-gx1la3vy2DvAEII-x9_pEyQRyRLyy4cdjeOUgHO4XMkLrf5yj8_dABauxpFP4qGT3UirON4rpJW9NUKjU9VI3d5g",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:23 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?kmsKeyName=projects/substrate-sdk-gcp-poc1/locations/us/keyRings/chameleon-test/cryptoKeys/chameleon-test&name=conformance-tests/directory/upload-kms-v1/kms-file1.txt&uploadType=resumable&upload_id=AJjja9ZMwDrGtkznDtvn1-gx1la3vy2DvAEII-x9_pEyQRyRLyy4cdjeOUgHO4XMkLrf5yj8_dABauxpFP4qGT3UirON4rpJW9NUKjU9VI3d5g",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "b0fa39ee-1a79-4a0f-b842-a907d3231306",
+  "persistent" : true,
+  "insertionIndex" : 1511
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-post-11.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-post-11.json
@@ -1,0 +1,53 @@
+{
+  "id" : "19e82f1a-dbad-43d9-b861-4b1fa0c48006",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withKmsKey-POST-11",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "kmsKeyName" : {
+        "hasExactly" : [ {
+          "equalTo" : "projects/substrate-sdk-gcp-poc1/locations/us/keyRings/chameleon-test/cryptoKeys/chameleon-test"
+        } ]
+      },
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/directory/upload-kms-v1/subdir/kms-file2.txt"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket\",\"name\":\"conformance-tests/directory/upload-kms-v1/subdir/kms-file2.txt\"}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AJjja9YcvekryZaZ_IBSjprYiF2VwIalbGO79caPKNi47TWF2GTrhNHrjRwoFADXXczNETDrwoguHnE8UEJxWSyE9tWKOZHYZMr4f7yKF3_k4fc",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:23 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?kmsKeyName=projects/substrate-sdk-gcp-poc1/locations/us/keyRings/chameleon-test/cryptoKeys/chameleon-test&name=conformance-tests/directory/upload-kms-v1/subdir/kms-file2.txt&uploadType=resumable&upload_id=AJjja9YcvekryZaZ_IBSjprYiF2VwIalbGO79caPKNi47TWF2GTrhNHrjRwoFADXXczNETDrwoguHnE8UEJxWSyE9tWKOZHYZMr4f7yKF3_k4fc",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "19e82f1a-dbad-43d9-b861-4b1fa0c48006",
+  "persistent" : true,
+  "insertionIndex" : 1512
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-put-8.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-put-8.json
@@ -1,0 +1,58 @@
+{
+  "id" : "11eb0202-468f-4f4b-bbf8-d8d6ebb25a69",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withKmsKey-PUT-8",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "4"
+      }
+    },
+    "queryParameters" : {
+      "kmsKeyName" : {
+        "hasExactly" : [ {
+          "equalTo" : "projects/substrate-sdk-gcp-poc1/locations/us/keyRings/chameleon-test/cryptoKeys/chameleon-test"
+        } ]
+      },
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/directory/upload-kms-v1/kms-file1.txt"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AJjja9ZMwDrGtkznDtvn1-gx1la3vy2DvAEII-x9_pEyQRyRLyy4cdjeOUgHO4XMkLrf5yj8_dABauxpFP4qGT3UirON4rpJW9NUKjU9VI3d5g"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "kms-directory-content-1",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/directory/upload-kms-v1/kms-file1.txt/1787084544232853\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fkms-file1.txt\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fkms-file1.txt?generation=1787084544232853&alt=media\",\n  \"name\": \"conformance-tests/directory/upload-kms-v1/kms-file1.txt\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1787084544232853\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"23\",\n  \"md5Hash\": \"o9PiPoT45x0JFFG/mMMo7A==\",\n  \"crc32c\": \"Cj7oBw==\",\n  \"etag\": \"CJWbxduAq5YDEAE=\",\n  \"kmsKeyName\": \"projects/substrate-sdk-gcp-poc1/locations/us/keyRings/chameleon-test/cryptoKeys/chameleon-test/cryptoKeyVersions/1\",\n  \"timeCreated\": \"2026-08-18T20:22:24.286Z\",\n  \"updated\": \"2026-08-18T20:22:24.286Z\",\n  \"timeStorageClassUpdated\": \"2026-08-18T20:22:24.286Z\",\n  \"timeFinalized\": \"2026-08-18T20:22:24.286Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CJWbxduAq5YDEAE=",
+      "X-GUploader-UploadID" : "AJjja9ZMwDrGtkznDtvn1-gx1la3vy2DvAEII-x9_pEyQRyRLyy4cdjeOUgHO4XMkLrf5yj8_dABauxpFP4qGT3UirON4rpJW9NUKjU9VI3d5g",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:24 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "11eb0202-468f-4f4b-bbf8-d8d6ebb25a69",
+  "persistent" : true,
+  "insertionIndex" : 1509
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-put-9.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withkmskey-put-9.json
@@ -1,0 +1,58 @@
+{
+  "id" : "1ed719a6-dd5b-4ce0-8d47-f57f31f5575d",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withKmsKey-PUT-9",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "4"
+      }
+    },
+    "queryParameters" : {
+      "kmsKeyName" : {
+        "hasExactly" : [ {
+          "equalTo" : "projects/substrate-sdk-gcp-poc1/locations/us/keyRings/chameleon-test/cryptoKeys/chameleon-test"
+        } ]
+      },
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/directory/upload-kms-v1/subdir/kms-file2.txt"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AJjja9YcvekryZaZ_IBSjprYiF2VwIalbGO79caPKNi47TWF2GTrhNHrjRwoFADXXczNETDrwoguHnE8UEJxWSyE9tWKOZHYZMr4f7yKF3_k4fc"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "kms-directory-content-2",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/directory/upload-kms-v1/subdir/kms-file2.txt/1787084544251442\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fsubdir%2Fkms-file2.txt\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-v1%2Fsubdir%2Fkms-file2.txt?generation=1787084544251442&alt=media\",\n  \"name\": \"conformance-tests/directory/upload-kms-v1/subdir/kms-file2.txt\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1787084544251442\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"23\",\n  \"md5Hash\": \"rRveRDID05J5UBgj8W/opA==\",\n  \"crc32c\": \"GW4b8w==\",\n  \"etag\": \"CLKsxtuAq5YDEAE=\",\n  \"kmsKeyName\": \"projects/substrate-sdk-gcp-poc1/locations/us/keyRings/chameleon-test/cryptoKeys/chameleon-test/cryptoKeyVersions/1\",\n  \"timeCreated\": \"2026-08-18T20:22:24.308Z\",\n  \"updated\": \"2026-08-18T20:22:24.308Z\",\n  \"timeStorageClassUpdated\": \"2026-08-18T20:22:24.308Z\",\n  \"timeFinalized\": \"2026-08-18T20:22:24.308Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CLKsxtuAq5YDEAE=",
+      "X-GUploader-UploadID" : "AJjja9YcvekryZaZ_IBSjprYiF2VwIalbGO79caPKNi47TWF2GTrhNHrjRwoFADXXczNETDrwoguHnE8UEJxWSyE9tWKOZHYZMr4f7yKF3_k4fc",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:24 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "1ed719a6-dd5b-4ce0-8d47-f57f31f5575d",
+  "persistent" : true,
+  "insertionIndex" : 1510
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withnullkmskey-delete-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withnullkmskey-delete-0.json
@@ -1,0 +1,25 @@
+{
+  "id" : "6911262f-cccb-41b3-930b-a01ca380cd83",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withNullKmsKey-DELETE-0",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-null-v1%2Fnull-kms.txt",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AJjja9aRpFjBWOBgRj1Bg5vG6SUAyu_dkPbwnWuSSw5OzuS4Ov35tUvk3SuMqI5W4HYSssfBv_yn",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:23 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "6911262f-cccb-41b3-930b-a01ca380cd83",
+  "persistent" : true,
+  "insertionIndex" : 1494
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withnullkmskey-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withnullkmskey-get-1.json
@@ -1,0 +1,47 @@
+{
+  "id" : "d7bc7eec-ce12-4c0c-a4ce-144bf90a46d2",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withNullKmsKey-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "prefix" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/directory/upload-kms-null-v1/null-kms.txt"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/directory/upload-kms-null-v1/null-kms.txt/1787084541736790\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-null-v1%2Fnull-kms.txt\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-null-v1%2Fnull-kms.txt?generation=1787084541736790&alt=media\",\n      \"name\": \"conformance-tests/directory/upload-kms-null-v1/null-kms.txt\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n      \"generation\": \"1787084541736790\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"16\",\n      \"md5Hash\": \"8jr579kC73tw8JqQxhc2xA==\",\n      \"crc32c\": \"tAW5Zg==\",\n      \"etag\": \"CNburNqAq5YDEAE=\",\n      \"timeCreated\": \"2026-08-18T20:22:21.791Z\",\n      \"updated\": \"2026-08-18T20:22:21.791Z\",\n      \"timeStorageClassUpdated\": \"2026-08-18T20:22:21.791Z\",\n      \"timeFinalized\": \"2026-08-18T20:22:21.791Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AJjja9b-rDcQ9ijT-Ijh6KV5Rn7yBAU0jBoLtxFrDst8_pPzJtPA3aD-LWwi-UcguOiiadlymldS",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 18 Aug 2026 20:22:22 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:22 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "d7bc7eec-ce12-4c0c-a4ce-144bf90a46d2",
+  "persistent" : true,
+  "insertionIndex" : 1495
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withnullkmskey-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withnullkmskey-get-2.json
@@ -1,0 +1,47 @@
+{
+  "id" : "cb061da5-5fd0-4547-b1d4-8edc0df677ba",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withNullKmsKey-GET-2",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-null-v1%2Fnull-kms.txt",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "bnVsbC1rbXMtY29udGVudA==",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1787084541736790",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Tue, 18 Aug 2026 20:22:21 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Tue, 18 Aug 2026 20:22:22 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=tAW5Zg==,md5=8jr579kC73tw8JqQxhc2xA==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CNburNqAq5YDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AJjja9b-V49bPlF1sihSEqEi4fpMIpfF7FhzhYOfxjZR-1sbaDGuWEiHjGW2NF3oV7lMNmW1AB_K",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "16",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "cb061da5-5fd0-4547-b1d4-8edc0df677ba",
+  "persistent" : true,
+  "insertionIndex" : 1496
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withnullkmskey-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withnullkmskey-get-3.json
@@ -1,0 +1,38 @@
+{
+  "id" : "70a48f33-ca25-48c5-bf2b-dc896f4e3392",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withNullKmsKey-GET-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-null-v1%2Fnull-kms.txt",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/directory/upload-kms-null-v1/null-kms.txt/1787084541736790\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-null-v1%2Fnull-kms.txt\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-null-v1%2Fnull-kms.txt?generation=1787084541736790&alt=media\",\n  \"name\": \"conformance-tests/directory/upload-kms-null-v1/null-kms.txt\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1787084541736790\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"16\",\n  \"md5Hash\": \"8jr579kC73tw8JqQxhc2xA==\",\n  \"crc32c\": \"tAW5Zg==\",\n  \"etag\": \"CNburNqAq5YDEAE=\",\n  \"timeCreated\": \"2026-08-18T20:22:21.791Z\",\n  \"updated\": \"2026-08-18T20:22:21.791Z\",\n  \"timeStorageClassUpdated\": \"2026-08-18T20:22:21.791Z\",\n  \"timeFinalized\": \"2026-08-18T20:22:21.791Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CNburNqAq5YDEAE=",
+      "X-GUploader-UploadID" : "AJjja9ZOxYGf21Og6v-nfA18kXkVnb_mcU5CqBRJpTDvaqcLbL7nzWyXSRU4mxcL9wLucHLokp_FAA",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Tue, 18 Aug 2026 20:22:22 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:22 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "70a48f33-ca25-48c5-bf2b-dc896f4e3392",
+  "persistent" : true,
+  "insertionIndex" : 1497
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withnullkmskey-post-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withnullkmskey-post-5.json
@@ -1,0 +1,48 @@
+{
+  "id" : "dc03a465-f3c9-4749-bd9b-72286b04082e",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withNullKmsKey-POST-5",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/directory/upload-kms-null-v1/null-kms.txt"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket\",\"name\":\"conformance-tests/directory/upload-kms-null-v1/null-kms.txt\"}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AJjja9aI7Qdn8th-3LN2tPgNS5F-OchYxaEWnJyGs11WLZcRILv0FlUDp8fJNLyq5OLVEBWRrdf_o1OYhf16qOo__29aAXdQzCUDs0z2eJpsUw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:21 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o?name=conformance-tests/directory/upload-kms-null-v1/null-kms.txt&uploadType=resumable&upload_id=AJjja9aI7Qdn8th-3LN2tPgNS5F-OchYxaEWnJyGs11WLZcRILv0FlUDp8fJNLyq5OLVEBWRrdf_o1OYhf16qOo__29aAXdQzCUDs0z2eJpsUw",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "dc03a465-f3c9-4749-bd9b-72286b04082e",
+  "persistent" : true,
+  "insertionIndex" : 1499
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withnullkmskey-put-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testuploaddirectory_withnullkmskey-put-4.json
@@ -1,0 +1,53 @@
+{
+  "id" : "4b4f0995-853b-4c66-8a58-97e89dfdbc16",
+  "name" : "GcpBlobStoreIT_testUploadDirectory_withNullKmsKey-PUT-4",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/directory/upload-kms-null-v1/null-kms.txt"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AJjja9aI7Qdn8th-3LN2tPgNS5F-OchYxaEWnJyGs11WLZcRILv0FlUDp8fJNLyq5OLVEBWRrdf_o1OYhf16qOo__29aAXdQzCUDs0z2eJpsUw"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "null-kms-content",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket/conformance-tests/directory/upload-kms-null-v1/null-kms.txt/1787084541736790\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-null-v1%2Fnull-kms.txt\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket/o/conformance-tests%2Fdirectory%2Fupload-kms-null-v1%2Fnull-kms.txt?generation=1787084541736790&alt=media\",\n  \"name\": \"conformance-tests/directory/upload-kms-null-v1/null-kms.txt\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket\",\n  \"generation\": \"1787084541736790\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"16\",\n  \"md5Hash\": \"8jr579kC73tw8JqQxhc2xA==\",\n  \"crc32c\": \"tAW5Zg==\",\n  \"etag\": \"CNburNqAq5YDEAE=\",\n  \"timeCreated\": \"2026-08-18T20:22:21.791Z\",\n  \"updated\": \"2026-08-18T20:22:21.791Z\",\n  \"timeStorageClassUpdated\": \"2026-08-18T20:22:21.791Z\",\n  \"timeFinalized\": \"2026-08-18T20:22:21.791Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CNburNqAq5YDEAE=",
+      "X-GUploader-UploadID" : "AJjja9aI7Qdn8th-3LN2tPgNS5F-OchYxaEWnJyGs11WLZcRILv0FlUDp8fJNLyq5OLVEBWRrdf_o1OYhf16qOo__29aAXdQzCUDs0z2eJpsUw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Tue, 18 Aug 2026 20:22:21 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "4b4f0995-853b-4c66-8a58-97e89dfdbc16",
+  "persistent" : true,
+  "insertionIndex" : 1498
+}


### PR DESCRIPTION
## Summary
Extends `DirectoryUploadRequest` with `kmsKeyId` and `useKmsManagedKey` so callers can drive server-side KMS encryption through the multi-file upload path, and wires those fields through the AWS and GCP providers. This brings directory upload to parity with the single-file upload path, which already supports KMS.

## Changes

**API (blob-client)**
- `DirectoryUploadRequest`: added `kmsKeyId` (customer/provider KMS key identifier) and `useKmsManagedKey` (opt-in to provider-managed KMS when no explicit key is given) as Lombok builder fields.

**AWS (blob-aws)**
- `AwsTransformer.toUploadDirectoryRequest` now registers a per-file `uploadFileRequestTransformer` that sets `ServerSideEncryption.AWS_KMS` on the underlying `PutObjectRequest.Builder`. Explicit `kmsKeyId` takes precedence over `useKmsManagedKey`.
- Extended the early-return guard so KMS-only requests still get the transformer wired.

**GCP (blob-gcp)**
- `GcpBlobStore.doUploadDirectory` applies `Storage.BlobWriteOption.kmsKeyName(kmsKeyId)` via `ParallelUploadConfig.setWriteOptsPerRequest` when `kmsKeyId` is set. `useKmsManagedKey` is a documented no-op on GCS (GCS always encrypts at rest with Google-managed keys by default; there is no wire-level provider-managed-KMS opt-in signal).

### API example
```java
  DirectoryUploadRequest request =
      DirectoryUploadRequest.builder()
          .localSourceDirectory("/tmp/uploads")
          .prefix("archive/")
          .includeSubFolders(true)
          .kmsKeyId("arn:aws:kms:us-west-2:123456789012:key/abc-def")
          .build();

  bucketClient.uploadDirectory(request);
  ```

### Testing

**Unit tests**
- `AwsTransformerTest`: 4 new tests covering the KMS branch — explicit key, provider-managed key, precedence rule, and the no-KMS case (encryption left unset).
- `GcpBlobStoreTest`: 2 new tests covering the write-opts-per-request mutation on `ParallelUploadConfig` and the null-key fallback. 

**Conformance tests (`AbstractBlobStoreIT`)**
- `testUploadDirectory_withKmsKey` (positive) — uploads two files with a real KMS key, roundtrips content on download.
- `testUploadDirectory_withNullKmsKey` (fallback) — verifies null kmsKeyId gracefully falls back to bucket defaults.
- Both recorded on GCP (18 WireMock mappings under `blob/blob-gcp/src/test/resources/mappings/`); replay-mode CI verified green locally.
- Both guarded by `Assumptions.assumeTrue(harness.isDirectoryUploadSupported()`, ...) so they skip cleanly on the sync AWS and Ali harnesses.

**Cross-cloud compatibility**

- AWS: SSE-KMS via `PutObjectRequest.serverSideEncryption(AWS_KMS) + ssekmsKeyId(...)`.
- GCP: CMEK via `Storage.BlobWriteOption.kmsKeyName(...)` on the transfer-manager parallel upload config.
- Ali: out of scope for this change; a sibling story owns the Ali side.

**Note on AWS coverage**

The AWS SSE-KMS wiring lives in `AwsTransformer.toUploadDirectoryRequest`, which is called at runtime by `AwsAsyncBlobStore.doUploadDirectory`. Directory upload on AWS is implemented only on the async blob store — the sync `AwsBlobStore` does not support it, so the sync IT harness reports `isDirectoryUploadSupported=false` and the new abstract conformance tests skip there.

Coverage on the AWS side is therefore unit-test only for this change. There is no `AwsAsyncBlobStoreIT` today (predates this change); adding one would provide record/replay coverage for the entire async directory-upload feature, not just KMS, and should be tracked as a separate follow-up story rather than expanded into this one.
