### PR TITLE
docstore: remove compile-time shaded protobuf dep from Ali canonicalizer

### DIFF
--- a/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/TablestoreBodyCanonicalizer.java
+++ b/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/TablestoreBodyCanonicalizer.java
@@ -5,10 +5,11 @@ import com.alicloud.openservices.tablestore.core.protocol.PlainBufferCell;
 import com.alicloud.openservices.tablestore.core.protocol.PlainBufferCodedInputStream;
 import com.alicloud.openservices.tablestore.core.protocol.PlainBufferInputStream;
 import com.alicloud.openservices.tablestore.core.protocol.PlainBufferRow;
-import com.aliyun.ots.thirdparty.com.google.protobuf.ByteString;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.WireFormat;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -65,25 +66,59 @@ public final class TablestoreBodyCanonicalizer {
     try {
       int q = url.indexOf('?');
       String path = q >= 0 ? url.substring(0, q) : url;
+      boolean isPut = path.endsWith("/PutRow");
+
+      // Extract fields using standard CodedInputStream so no shaded protobuf class is loaded at
+      // runtime. The FIELD_NUMBER constants are primitive compile-time literals (ConstantValue
+      // attributes in the bytecode) so referencing them here never triggers class loading of
+      // OtsInternalApi or its GeneratedMessage base.
+      //   PutRowRequest:   table_name=1, row=2,         condition=3
+      //   DeleteRowRequest: table_name=1, primary_key=2, condition=3
+      int rowField = isPut
+          ? OtsInternalApi.PutRowRequest.ROW_FIELD_NUMBER
+          : OtsInternalApi.DeleteRowRequest.PRIMARY_KEY_FIELD_NUMBER;
+      int conditionField = isPut
+          ? OtsInternalApi.PutRowRequest.CONDITION_FIELD_NUMBER
+          : OtsInternalApi.DeleteRowRequest.CONDITION_FIELD_NUMBER;
+      int tableNameField = isPut
+          ? OtsInternalApi.PutRowRequest.TABLE_NAME_FIELD_NUMBER
+          : OtsInternalApi.DeleteRowRequest.TABLE_NAME_FIELD_NUMBER;
+
+      String tableName = null;
+      byte[] rowBytes = null;
+      byte[] conditionBytes = null;
+
+      CodedInputStream cin = CodedInputStream.newInstance(body);
+      int tag;
+      while ((tag = cin.readTag()) != 0) {
+        int fieldNumber = WireFormat.getTagFieldNumber(tag);
+        if (fieldNumber == tableNameField) {
+          tableName = cin.readString();
+        } else if (fieldNumber == rowField) {
+          rowBytes = cin.readByteArray();
+        } else if (fieldNumber == conditionField) {
+          conditionBytes = cin.readByteArray();
+        } else {
+          cin.skipField(tag);
+        }
+      }
+
+      // Both table_name and row/primary_key are mandatory fields in every valid Tablestore write
+      // request. If either is absent the body is malformed — return it unchanged per the contract
+      // ("or the original bytes unchanged if it cannot be parsed as one"), so that two different
+      // malformed bodies do not collapse into the same stub-matching JSON.
+      if (tableName == null || rowBytes == null) {
+        return body;
+      }
+
       ObjectNode root = MAPPER.createObjectNode();
-      if (path.endsWith("/PutRow")) {
-        OtsInternalApi.PutRowRequest req = OtsInternalApi.PutRowRequest.parseFrom(body);
-        root.put("op", "PutRow");
-        root.put("table", req.getTableName());
-        appendRow(root, req.getRow());
-        if (req.hasCondition()) {
-          // The serialized column-condition filter is order-stable (single revision column);
-          // include its bytes as hex to preserve precondition semantics in the match.
-          root.put("condition", base16(req.getCondition().toByteArray()));
-        }
-      } else {
-        OtsInternalApi.DeleteRowRequest req = OtsInternalApi.DeleteRowRequest.parseFrom(body);
-        root.put("op", "DeleteRow");
-        root.put("table", req.getTableName());
-        appendRow(root, req.getPrimaryKey());
-        if (req.hasCondition()) {
-          root.put("condition", base16(req.getCondition().toByteArray()));
-        }
+      root.put("op", isPut ? "PutRow" : "DeleteRow");
+      root.put("table", tableName);
+      appendRow(root, rowBytes);
+      if (conditionBytes != null) {
+        // The serialized column-condition filter is order-stable (single revision column);
+        // include its bytes as hex to preserve precondition semantics in the match.
+        root.put("condition", base16(conditionBytes));
       }
       return MAPPER.writeValueAsBytes(root);
     } catch (Exception e) {
@@ -92,9 +127,9 @@ public final class TablestoreBodyCanonicalizer {
     }
   }
 
-  private static void appendRow(ObjectNode root, ByteString rowBytes) throws Exception {
+  private static void appendRow(ObjectNode root, byte[] rowBytes) throws Exception {
     PlainBufferCodedInputStream in =
-        new PlainBufferCodedInputStream(new PlainBufferInputStream(rowBytes.toByteArray()));
+        new PlainBufferCodedInputStream(new PlainBufferInputStream(rowBytes));
     List<PlainBufferRow> rows = in.readRowsWithHeader();
 
     // A write request carries a single row; represent PK and cells as keyed objects so

--- a/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/TablestoreBodyCanonicalizer.java
+++ b/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/TablestoreBodyCanonicalizer.java
@@ -8,9 +8,6 @@ import com.alicloud.openservices.tablestore.core.protocol.PlainBufferRow;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.protobuf.CodedInputStream;
-import com.google.protobuf.WireFormat;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -37,6 +34,12 @@ import java.util.List;
  * <p>It never re-serializes PlainBuffer (no CRC recomputation); it only reads. If the body is not a
  * recognized Tablestore write request it returns the original bytes unchanged, so non-write ops and
  * other providers are unaffected.
+ *
+ * <p><b>Dependency note:</b> this class uses the generated {@code OtsInternalApi} parser (via
+ * {@code parseFrom}) which requires the Tablestore SDK's shaded protobuf classes at runtime. The
+ * {@code ByteString} type returned by {@code getRow()}/{@code getPrimaryKey()} is never named in
+ * this source — {@code .toByteArray()} is called inline — so there is no compile-time dependency
+ * on the shaded jar, only a runtime one.
  */
 public final class TablestoreBodyCanonicalizer {
 
@@ -66,59 +69,25 @@ public final class TablestoreBodyCanonicalizer {
     try {
       int q = url.indexOf('?');
       String path = q >= 0 ? url.substring(0, q) : url;
-      boolean isPut = path.endsWith("/PutRow");
-
-      // Extract fields using standard CodedInputStream so no shaded protobuf class is loaded at
-      // runtime. The FIELD_NUMBER constants are primitive compile-time literals (ConstantValue
-      // attributes in the bytecode) so referencing them here never triggers class loading of
-      // OtsInternalApi or its GeneratedMessage base.
-      //   PutRowRequest:   table_name=1, row=2,         condition=3
-      //   DeleteRowRequest: table_name=1, primary_key=2, condition=3
-      int rowField = isPut
-          ? OtsInternalApi.PutRowRequest.ROW_FIELD_NUMBER
-          : OtsInternalApi.DeleteRowRequest.PRIMARY_KEY_FIELD_NUMBER;
-      int conditionField = isPut
-          ? OtsInternalApi.PutRowRequest.CONDITION_FIELD_NUMBER
-          : OtsInternalApi.DeleteRowRequest.CONDITION_FIELD_NUMBER;
-      int tableNameField = isPut
-          ? OtsInternalApi.PutRowRequest.TABLE_NAME_FIELD_NUMBER
-          : OtsInternalApi.DeleteRowRequest.TABLE_NAME_FIELD_NUMBER;
-
-      String tableName = null;
-      byte[] rowBytes = null;
-      byte[] conditionBytes = null;
-
-      CodedInputStream cin = CodedInputStream.newInstance(body);
-      int tag;
-      while ((tag = cin.readTag()) != 0) {
-        int fieldNumber = WireFormat.getTagFieldNumber(tag);
-        if (fieldNumber == tableNameField) {
-          tableName = cin.readString();
-        } else if (fieldNumber == rowField) {
-          rowBytes = cin.readByteArray();
-        } else if (fieldNumber == conditionField) {
-          conditionBytes = cin.readByteArray();
-        } else {
-          cin.skipField(tag);
-        }
-      }
-
-      // Both table_name and row/primary_key are mandatory fields in every valid Tablestore write
-      // request. If either is absent the body is malformed — return it unchanged per the contract
-      // ("or the original bytes unchanged if it cannot be parsed as one"), so that two different
-      // malformed bodies do not collapse into the same stub-matching JSON.
-      if (tableName == null || rowBytes == null) {
-        return body;
-      }
-
       ObjectNode root = MAPPER.createObjectNode();
-      root.put("op", isPut ? "PutRow" : "DeleteRow");
-      root.put("table", tableName);
-      appendRow(root, rowBytes);
-      if (conditionBytes != null) {
-        // The serialized column-condition filter is order-stable (single revision column);
-        // include its bytes as hex to preserve precondition semantics in the match.
-        root.put("condition", base16(conditionBytes));
+      if (path.endsWith("/PutRow")) {
+        OtsInternalApi.PutRowRequest req = OtsInternalApi.PutRowRequest.parseFrom(body);
+        root.put("op", "PutRow");
+        root.put("table", req.getTableName());
+        appendRow(root, req.getRow().toByteArray());
+        if (req.hasCondition()) {
+          // The serialized column-condition filter is order-stable (single revision column);
+          // include its bytes as hex to preserve precondition semantics in the match.
+          root.put("condition", base16(req.getCondition().toByteArray()));
+        }
+      } else {
+        OtsInternalApi.DeleteRowRequest req = OtsInternalApi.DeleteRowRequest.parseFrom(body);
+        root.put("op", "DeleteRow");
+        root.put("table", req.getTableName());
+        appendRow(root, req.getPrimaryKey().toByteArray());
+        if (req.hasCondition()) {
+          root.put("condition", base16(req.getCondition().toByteArray()));
+        }
       }
       return MAPPER.writeValueAsBytes(root);
     } catch (Exception e) {

--- a/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/TablestoreBodyCanonicalizerTest.java
+++ b/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/TablestoreBodyCanonicalizerTest.java
@@ -6,11 +6,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.alicloud.openservices.tablestore.core.protocol.OTSProtocolBuilder;
 import com.alicloud.openservices.tablestore.model.ColumnValue;
+import com.alicloud.openservices.tablestore.model.Condition;
+import com.alicloud.openservices.tablestore.model.DeleteRowRequest;
 import com.alicloud.openservices.tablestore.model.PrimaryKey;
 import com.alicloud.openservices.tablestore.model.PrimaryKeyBuilder;
 import com.alicloud.openservices.tablestore.model.PrimaryKeyValue;
 import com.alicloud.openservices.tablestore.model.PutRowRequest;
+import com.alicloud.openservices.tablestore.model.RowDeleteChange;
 import com.alicloud.openservices.tablestore.model.RowPutChange;
+import com.alicloud.openservices.tablestore.model.condition.SingleColumnValueCondition;
 import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -128,9 +132,106 @@ class TablestoreBodyCanonicalizerTest {
   }
 
   @Test
+  void malformedBodyOnRecognizedUrlReturnsOriginal() {
+    // A body that is sent to /PutRow but lacks the mandatory row field (e.g. it contains only
+    // unknown fields) must be returned unchanged, not collapsed into {"op":"PutRow","table":""}
+    // which would cause unrelated malformed requests to match the same WireMock stub.
+    // Wire-encode an unknown field (field 15, bytes "abc") — no row or table_name fields.
+    byte[] malformed = new byte[] {(byte) 0x7a, 0x03, 0x61, 0x62, 0x63};
+    byte[] out = TablestoreBodyCanonicalizer.canonicalize("/PutRow", malformed);
+    assertArrayEquals(
+        malformed, out, "malformed body missing row field must be returned unchanged");
+  }
+
+  @Test
   void nonCanonicalizableUrlReturnsOriginal() {
     byte[] body = putBody("docstore_test_1", "pName", "LeoPut", new String[] {"i"});
     byte[] out = TablestoreBodyCanonicalizer.canonicalize("/SQLQuery", body);
     assertArrayEquals(body, out, "non-write URLs must be returned unchanged");
+  }
+
+  // Builds a DeleteRow request body for the given table, pk name+value, and optional condition.
+  private static byte[] deleteBody(
+      String table, String pkName, String pkVal, Condition condition) {
+    PrimaryKey pk =
+        PrimaryKeyBuilder.createPrimaryKeyBuilder()
+            .addPrimaryKeyColumn(pkName, PrimaryKeyValue.fromString(pkVal))
+            .build();
+    RowDeleteChange change = new RowDeleteChange(table, pk);
+    if (condition != null) {
+      change.setCondition(condition);
+    }
+    return OTSProtocolBuilder.buildDeleteRowRequest(new DeleteRowRequest(change)).toByteArray();
+  }
+
+  @Test
+  void deleteRowCanonicalizesCorrectly() {
+    // A DeleteRow carries only primary-key cells (no data cells). Verify the canonicalizer extracts
+    // table + pk correctly and produces a valid canonical JSON.
+    byte[] body = deleteBody("docstore_test_2", "Game", "test-game", null);
+
+    String canonical =
+        new String(
+            TablestoreBodyCanonicalizer.canonicalize("/DeleteRow", body), StandardCharsets.UTF_8);
+
+    assertTrue(canonical.contains("\"DeleteRow\""), "op must be DeleteRow");
+    assertTrue(canonical.contains("\"docstore_test_2\""), "table name must be present");
+    assertTrue(canonical.contains("\"test-game\""), "pk value must be present");
+    // The SDK serialises a condition field even for unconditional deletes; the canonical form
+    // must include it so that bare-delete stubs differ from revision-conditional ones.
+    assertTrue(
+        canonical.contains("\"condition\""),
+        "bare delete must still carry the condition field");
+  }
+
+  @Test
+  void conditionFieldDistinguishesRevisions() {
+    // A revision-conditional delete carries a Condition with a SingleColumnValueCondition on the
+    // revision column. Deletes with different revision conditions must produce different canonical
+    // forms so that WireMock stubs from different revision epochs do not match each other.
+    SingleColumnValueCondition revCondA =
+        new SingleColumnValueCondition(
+            "DocstoreRevision",
+            SingleColumnValueCondition.CompareOperator.EQUAL,
+            ColumnValue.fromString("rev-abc"));
+    revCondA.setPassIfMissing(false);
+    Condition conditionA = new Condition();
+    conditionA.setColumnCondition(revCondA);
+
+    SingleColumnValueCondition revCondB =
+        new SingleColumnValueCondition(
+            "DocstoreRevision",
+            SingleColumnValueCondition.CompareOperator.EQUAL,
+            ColumnValue.fromString("rev-xyz"));
+    revCondB.setPassIfMissing(false);
+    Condition conditionB = new Condition();
+    conditionB.setColumnCondition(revCondB);
+
+    byte[] bodyA = deleteBody("docstore_test_1", "pName", "LeoDel", conditionA);
+    byte[] bodyB = deleteBody("docstore_test_1", "pName", "LeoDel", conditionB);
+
+    String canonicalA =
+        new String(
+            TablestoreBodyCanonicalizer.canonicalize("/DeleteRow", bodyA), StandardCharsets.UTF_8);
+
+    // The condition bytes must be present in the canonical form.
+    assertTrue(
+        canonicalA.contains("\"condition\""), "condition field must appear in canonical form");
+
+    // Deletes with different revision conditions must produce different canonical forms.
+    assertFalse(
+        Arrays.equals(
+            TablestoreBodyCanonicalizer.canonicalize("/DeleteRow", bodyA),
+            TablestoreBodyCanonicalizer.canonicalize("/DeleteRow", bodyB)),
+        "different revision conditions must yield different canonical forms");
+
+    // The primary scenario: a bare (unconditional) delete must differ from a revision-conditional
+    // delete. This is what prevents stale-revision stubs from matching unconditional deletes.
+    byte[] bareBody = deleteBody("docstore_test_1", "pName", "LeoDel", null);
+    assertFalse(
+        Arrays.equals(
+            TablestoreBodyCanonicalizer.canonicalize("/DeleteRow", bareBody),
+            TablestoreBodyCanonicalizer.canonicalize("/DeleteRow", bodyA)),
+        "bare delete must differ from revision-conditional delete");
   }
 }

--- a/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/TablestoreBodyCanonicalizerTest.java
+++ b/docstore/docstore-ali/src/test/java/com/salesforce/multicloudj/docstore/ali/TablestoreBodyCanonicalizerTest.java
@@ -1,6 +1,7 @@
 package com.salesforce.multicloudj.docstore.ali;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -15,6 +16,8 @@ import com.alicloud.openservices.tablestore.model.PutRowRequest;
 import com.alicloud.openservices.tablestore.model.RowDeleteChange;
 import com.alicloud.openservices.tablestore.model.RowPutChange;
 import com.alicloud.openservices.tablestore.model.condition.SingleColumnValueCondition;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -165,27 +168,31 @@ class TablestoreBodyCanonicalizerTest {
   }
 
   @Test
-  void deleteRowCanonicalizesCorrectly() {
+  void deleteRowCanonicalizesCorrectly() throws Exception {
     // A DeleteRow carries only primary-key cells (no data cells). Verify the canonicalizer extracts
-    // table + pk correctly and produces a valid canonical JSON.
+    // table + pk correctly and produces a structurally valid canonical JSON.
     byte[] body = deleteBody("docstore_test_2", "Game", "test-game", null);
 
-    String canonical =
-        new String(
-            TablestoreBodyCanonicalizer.canonicalize("/DeleteRow", body), StandardCharsets.UTF_8);
+    JsonNode root = new ObjectMapper().readTree(
+        TablestoreBodyCanonicalizer.canonicalize("/DeleteRow", body));
 
-    assertTrue(canonical.contains("\"DeleteRow\""), "op must be DeleteRow");
-    assertTrue(canonical.contains("\"docstore_test_2\""), "table name must be present");
-    assertTrue(canonical.contains("\"test-game\""), "pk value must be present");
+    assertEquals("DeleteRow", root.get("op").asText(), "op must be DeleteRow");
+    assertEquals("docstore_test_2", root.get("table").asText(), "table must be docstore_test_2");
+    JsonNode rows = root.get("rows");
+    assertTrue(rows.isArray() && rows.size() > 0, "rows array must be present");
+    assertEquals(
+        "test-game",
+        root.get("rows").get(0).get("pk").get("Game").get("v").asText(),
+        "pk value must be present under rows[0].pk");
     // The SDK serialises a condition field even for unconditional deletes; the canonical form
     // must include it so that bare-delete stubs differ from revision-conditional ones.
-    assertTrue(
-        canonical.contains("\"condition\""),
-        "bare delete must still carry the condition field");
+    assertFalse(
+        root.path("condition").isMissingNode(),
+        "bare delete must carry the condition field");
   }
 
   @Test
-  void conditionFieldDistinguishesRevisions() {
+  void conditionFieldDistinguishesRevisions() throws Exception {
     // A revision-conditional delete carries a Condition with a SingleColumnValueCondition on the
     // revision column. Deletes with different revision conditions must produce different canonical
     // forms so that WireMock stubs from different revision epochs do not match each other.
@@ -210,13 +217,16 @@ class TablestoreBodyCanonicalizerTest {
     byte[] bodyA = deleteBody("docstore_test_1", "pName", "LeoDel", conditionA);
     byte[] bodyB = deleteBody("docstore_test_1", "pName", "LeoDel", conditionB);
 
-    String canonicalA =
-        new String(
-            TablestoreBodyCanonicalizer.canonicalize("/DeleteRow", bodyA), StandardCharsets.UTF_8);
+    JsonNode rootA = new ObjectMapper().readTree(
+        TablestoreBodyCanonicalizer.canonicalize("/DeleteRow", bodyA));
 
-    // The condition bytes must be present in the canonical form.
-    assertTrue(
-        canonicalA.contains("\"condition\""), "condition field must appear in canonical form");
+    // The condition bytes must appear as a non-empty hex string at the top level.
+    assertFalse(
+        rootA.path("condition").isMissingNode(),
+        "condition field must appear in canonical form");
+    assertFalse(
+        rootA.path("condition").asText().isEmpty(),
+        "condition hex value must be non-empty");
 
     // Deletes with different revision conditions must produce different canonical forms.
     assertFalse(


### PR DESCRIPTION
## Summary
`TablestoreBodyCanonicalizer.appendRow` previously declared a `ByteString` parameter (from the Tablestore SDK's shaded protobuf: `com.aliyun.ots.thirdparty.com.google.protobuf.ByteString`), creating a compile-time dependency on the shaded jar. This change removes it: `appendRow` now accepts `byte[]` instead, with `.toByteArray()` called inline at the two call sites (`req.getRow().toByteArray()`, `req.getPrimaryKey().toByteArray()`). Java does not require importing a type that is only used transiently as an intermediate return value, so the shaded jar is no longer referenced at compile time — only the existing runtime dependency via the SDK's internal implementation remains.

## Motivation
The Tablestore SDK's shaded protobuf artifacts have independent versioning from the main SDK jar. Removing the compile-time reference decouples the canonicalizer from that versioning and avoids the need to explicitly manage the shaded jar as a build dependency.

## Testing
Expanded `TablestoreBodyCanonicalizerTest` from 4 to 7 tests, adding coverage for:
- DeleteRow path and PK-only PlainBuffer parsing
- Condition field presence and revision-epoch disambiguation (bare vs. conditional delete)
- Malformed body (missing mandatory fields) returns original bytes unchanged

All 7 tests pass. `AliDocstoreIT` 8/8 pass in no-credentials replay mode.

## Cross-cloud compatibility
Test-harness-only change (`src/test`). No production code modified.