### PR TITLE
blobstore: wire SSE-KMS into Alibaba (OSS) async directory upload

### DIFF
--- a/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
+++ b/blob/blob-ali/src/main/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStore.java
@@ -786,6 +786,8 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
     String prefix = directoryUploadRequest.getPrefix();
     Map<String, String> tags = directoryUploadRequest.getTags();
     var objectLock = directoryUploadRequest.getObjectLock();
+    String kmsKeyId = directoryUploadRequest.getKmsKeyId();
+    boolean useKmsManagedKey = directoryUploadRequest.isUseKmsManagedKey();
     AtomicLong totalBytes = new AtomicLong(0L);
     // Sum of source-file sizes from the stage-1 stat pass. Drives the response's
     // totalBytesTransferred on the listener-off success path; see resolveDirectoryTotalBytes.
@@ -829,6 +831,11 @@ public class AliAsyncBlobStore extends AbstractAsyncBlobStore implements AliSdkS
                 if (objectLock != null) {
                   uploadBuilder.withObjectLock(objectLock);
                 }
+                // Propagate SSE-KMS from the directory request onto each per-file upload so the
+                // whole tree is encrypted uniformly. AliTransformer.toPutObjectRequest maps these
+                // onto OSS SSE-KMS (explicit kmsKeyId wins; else useKmsManagedKey -> managed CMK),
+                // giving directory upload parity with single-object upload.
+                uploadBuilder.withKmsKeyId(kmsKeyId).withUseKmsManagedKey(useKmsManagedKey);
                 UploadRequest uploadRequest = uploadBuilder.build();
                 OssLoggingTransferListener listener = loggingEnabled
                     ? OssLoggingTransferListener.create(

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -1147,8 +1147,11 @@ public class AliAsyncBlobStoreTest {
 
   @Test
   void testUploadDirectoryPropagatesExplicitKmsKeyId(@TempDir Path tempDir) throws Exception {
+    // One top-level file and one nested under a subdirectory so includeSubFolders(true) is
+    // genuinely exercised — this also pins the per-file key/prefix computation for nested paths.
     Files.writeString(tempDir.resolve("file1.txt"), "content1");
-    Files.writeString(tempDir.resolve("file2.txt"), "content2");
+    Files.createDirectories(tempDir.resolve("subdir"));
+    Files.writeString(tempDir.resolve("subdir").resolve("file2.txt"), "content2");
 
     PutObjectResult mockResult = mock(PutObjectResult.class);
     when(mockResult.versionId()).thenReturn(null);
@@ -1166,22 +1169,30 @@ public class AliAsyncBlobStoreTest {
         .build();
     store.uploadDirectory(request).get();
 
-    // Every per-file PutObjectRequest must carry SSE-KMS with the explicit key id.
+    // Every per-file PutObjectRequest (top-level and nested) must carry SSE-KMS with the explicit
+    // key id, and the object keys must preserve the prefix + relative (sub)path.
     ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
     verify(mockAsyncClient, times(2))
         .putObjectAsync(captor.capture(), any(OperationOptions.class));
+    List<String> keys = new ArrayList<>();
     for (PutObjectRequest req : captor.getAllValues()) {
       assertEquals("KMS", req.serverSideEncryption(),
           "each per-file upload must set SSE-KMS");
       assertEquals(kmsKeyId, req.serverSideEncryptionKeyId(),
           "each per-file upload must carry the explicit KMS key id");
+      keys.add(req.key());
     }
+    assertTrue(keys.contains("kms-prefix/file1.txt"),
+        "top-level file key must be prefix + name; got " + keys);
+    assertTrue(keys.contains("kms-prefix/subdir/file2.txt"),
+        "nested file key must preserve the subdirectory path; got " + keys);
   }
 
   @Test
   void testUploadDirectoryPropagatesUseKmsManagedKey(@TempDir Path tempDir) throws Exception {
     Files.writeString(tempDir.resolve("file1.txt"), "content1");
-    Files.writeString(tempDir.resolve("file2.txt"), "content2");
+    Files.createDirectories(tempDir.resolve("subdir"));
+    Files.writeString(tempDir.resolve("subdir").resolve("file2.txt"), "content2");
 
     PutObjectResult mockResult = mock(PutObjectResult.class);
     when(mockResult.versionId()).thenReturn(null);
@@ -1213,7 +1224,8 @@ public class AliAsyncBlobStoreTest {
   @Test
   void testUploadDirectoryWithoutKmsLeavesEncryptionUnset(@TempDir Path tempDir) throws Exception {
     Files.writeString(tempDir.resolve("file1.txt"), "content1");
-    Files.writeString(tempDir.resolve("file2.txt"), "content2");
+    Files.createDirectories(tempDir.resolve("subdir"));
+    Files.writeString(tempDir.resolve("subdir").resolve("file2.txt"), "content2");
 
     PutObjectResult mockResult = mock(PutObjectResult.class);
     when(mockResult.versionId()).thenReturn(null);

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -1146,6 +1146,102 @@ public class AliAsyncBlobStoreTest {
   }
 
   @Test
+  void testUploadDirectoryPropagatesExplicitKmsKeyId(@TempDir Path tempDir) throws Exception {
+    Files.writeString(tempDir.resolve("file1.txt"), "content1");
+    Files.writeString(tempDir.resolve("file2.txt"), "content2");
+
+    PutObjectResult mockResult = mock(PutObjectResult.class);
+    when(mockResult.versionId()).thenReturn(null);
+    when(mockResult.eTag()).thenReturn("\"etag\"");
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    String kmsKeyId = "acs:kms:cn-shanghai:1099202394511537:key/test-key";
+    DirectoryUploadRequest request = DirectoryUploadRequest.builder()
+        .localSourceDirectory(tempDir.toString())
+        .prefix("kms-prefix")
+        .includeSubFolders(true)
+        .kmsKeyId(kmsKeyId)
+        .build();
+    store.uploadDirectory(request).get();
+
+    // Every per-file PutObjectRequest must carry SSE-KMS with the explicit key id.
+    ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(mockAsyncClient, times(2))
+        .putObjectAsync(captor.capture(), any(OperationOptions.class));
+    for (PutObjectRequest req : captor.getAllValues()) {
+      assertEquals("KMS", req.serverSideEncryption(),
+          "each per-file upload must set SSE-KMS");
+      assertEquals(kmsKeyId, req.serverSideEncryptionKeyId(),
+          "each per-file upload must carry the explicit KMS key id");
+    }
+  }
+
+  @Test
+  void testUploadDirectoryPropagatesUseKmsManagedKey(@TempDir Path tempDir) throws Exception {
+    Files.writeString(tempDir.resolve("file1.txt"), "content1");
+    Files.writeString(tempDir.resolve("file2.txt"), "content2");
+
+    PutObjectResult mockResult = mock(PutObjectResult.class);
+    when(mockResult.versionId()).thenReturn(null);
+    when(mockResult.eTag()).thenReturn("\"etag\"");
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    DirectoryUploadRequest request = DirectoryUploadRequest.builder()
+        .localSourceDirectory(tempDir.toString())
+        .prefix("kms-managed-prefix")
+        .includeSubFolders(true)
+        .useKmsManagedKey(true)
+        .build();
+    store.uploadDirectory(request).get();
+
+    // useKmsManagedKey with no explicit key -> SSE-KMS header, but no key id (managed CMK).
+    ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(mockAsyncClient, times(2))
+        .putObjectAsync(captor.capture(), any(OperationOptions.class));
+    for (PutObjectRequest req : captor.getAllValues()) {
+      assertEquals("KMS", req.serverSideEncryption(),
+          "useKmsManagedKey must set SSE-KMS");
+      assertNull(req.serverSideEncryptionKeyId(),
+          "managed-key upload must not carry an explicit key id");
+    }
+  }
+
+  @Test
+  void testUploadDirectoryWithoutKmsLeavesEncryptionUnset(@TempDir Path tempDir) throws Exception {
+    Files.writeString(tempDir.resolve("file1.txt"), "content1");
+    Files.writeString(tempDir.resolve("file2.txt"), "content2");
+
+    PutObjectResult mockResult = mock(PutObjectResult.class);
+    when(mockResult.versionId()).thenReturn(null);
+    when(mockResult.eTag()).thenReturn("\"etag\"");
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    DirectoryUploadRequest request = DirectoryUploadRequest.builder()
+        .localSourceDirectory(tempDir.toString())
+        .prefix("no-kms-prefix")
+        .includeSubFolders(true)
+        .build();
+    store.uploadDirectory(request).get();
+
+    // Neither kmsKeyId nor useKmsManagedKey -> no SSE-KMS header on any per-file upload.
+    ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(mockAsyncClient, times(2))
+        .putObjectAsync(captor.capture(), any(OperationOptions.class));
+    for (PutObjectRequest req : captor.getAllValues()) {
+      assertNull(req.serverSideEncryption(),
+          "no KMS requested -> SSE must be left unset");
+      assertNull(req.serverSideEncryptionKeyId(),
+          "no KMS requested -> key id must be left unset");
+    }
+  }
+
+  @Test
   void testUploadDirectoryWithLoggingCountsSdkReportedBytes(
       @TempDir Path tempDir) throws Exception {
     // "alpha" = 5 bytes, "bravo!" = 6 bytes -> expect 11 cumulative.

--- a/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
+++ b/blob/blob-ali/src/test/java/com/salesforce/multicloudj/blob/ali/async/AliAsyncBlobStoreTest.java
@@ -1222,6 +1222,45 @@ public class AliAsyncBlobStoreTest {
   }
 
   @Test
+  void testUploadDirectoryExplicitKmsKeyWinsOverManagedKey(@TempDir Path tempDir) throws Exception {
+    // Both kmsKeyId AND useKmsManagedKey(true) are set. The explicit key must win: every per-file
+    // upload must carry SSE-KMS with the explicit key id (not a managed CMK). This pins the
+    // precedence at the directory-request propagation level — a regression that dropped kmsKeyId
+    // when the managed flag is set would silently lose the caller's key, and is caught by neither
+    // the mutually-exclusive cases above nor the transformer test.
+    Files.writeString(tempDir.resolve("file1.txt"), "content1");
+    Files.createDirectories(tempDir.resolve("subdir"));
+    Files.writeString(tempDir.resolve("subdir").resolve("file2.txt"), "content2");
+
+    PutObjectResult mockResult = mock(PutObjectResult.class);
+    when(mockResult.versionId()).thenReturn(null);
+    when(mockResult.eTag()).thenReturn("\"etag\"");
+    when(mockAsyncClient.putObjectAsync(
+        any(PutObjectRequest.class), any(OperationOptions.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResult));
+
+    String kmsKeyId = "acs:kms:cn-shanghai:1099202394511537:key/test-key";
+    DirectoryUploadRequest request = DirectoryUploadRequest.builder()
+        .localSourceDirectory(tempDir.toString())
+        .prefix("kms-both-prefix")
+        .includeSubFolders(true)
+        .kmsKeyId(kmsKeyId)
+        .useKmsManagedKey(true)
+        .build();
+    store.uploadDirectory(request).get();
+
+    ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(mockAsyncClient, times(2))
+        .putObjectAsync(captor.capture(), any(OperationOptions.class));
+    for (PutObjectRequest req : captor.getAllValues()) {
+      assertEquals("KMS", req.serverSideEncryption(),
+          "SSE-KMS must be set when both KMS options are provided");
+      assertEquals(kmsKeyId, req.serverSideEncryptionKeyId(),
+          "explicit kmsKeyId must win over useKmsManagedKey");
+    }
+  }
+
+  @Test
   void testUploadDirectoryWithoutKmsLeavesEncryptionUnset(@TempDir Path tempDir) throws Exception {
     Files.writeString(tempDir.resolve("file1.txt"), "content1");
     Files.createDirectories(tempDir.resolve("subdir"));


### PR DESCRIPTION
## Summary

Wires SSE-KMS into the Alibaba (OSS) async directory-upload path, bringing it to parity with single-object OSS upload (which already supports KMS) and with the AWS/GCP directory-upload KMS support added in #598.

## Changes

- `AliAsyncBlobStore.doUploadDirectory` now propagates `kmsKeyId` and `useKmsManagedKey` from the `DirectoryUploadRequest` onto each per-file `UploadRequest`. `AliTransformer.toPutObjectRequest` already maps these to OSS SSE-KMS (explicit `kmsKeyId` takes precedence; otherwise `useKmsManagedKey` selects a managed CMK), so no transformer change is needed.
- Sync `AliBlobStore` directory upload remains `UnsupportedOperationException` (unchanged; Ali directory upload is async-only).
- Unit tests (`AliAsyncBlobStoreTest`): capture each per-file `PutObjectRequest` and assert SSE-KMS propagation for the explicit-key, managed-key, and no-KMS cases. The explicit-key test uses a file nested under a subdirectory and asserts the per-file object keys (`prefix/file1.txt`, `prefix/subdir/file2.txt`) to pin key/prefix handling alongside KMS propagation.

## Testing

- `mvn test -pl blob/blob-ali` — all unit tests pass.
- Verified end-to-end against live cn-shanghai OSS: directory upload with an explicit KMS key, a managed key, and no key produced the expected `x-oss-server-side-encryption` headers on every uploaded object, including files under subdirectories.

## Cross-cloud

- Depends on the `DirectoryUploadRequest` KMS fields added for AWS/GCP in #598 (merged).
- Ali async directory upload now matches AWS/GCP; sync Ali directory upload remains unsupported (async-only, unchanged).