### PR TITLE
build: centralize benchmark-jar config and guard in the root pom

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,25 @@ MultiCloudJ follows standard Java coding conventions:
 mvn clean test
 ```
 
+### Publishing benchmarks for a module
+
+Benchmarks are published as a separate `benchmarks`-classifier jar (JMH classes and
+metadata only, no test infrastructure). The jar config and a build-time guard live once in
+the root `pom.xml`; a module opts in through properties, not copied XML.
+
+- Any benchmark-bearing module: set `<benchmarks.jar.phase>package</benchmarks.jar.phase>`,
+  and declare a bare `maven-jar-plugin` if the module does not already.
+- Provider modules (runnable benchmarks): additionally set
+  `<benchmarks.expected.package>com.salesforce.multicloudj.<service>.<cloud>.</benchmarks.expected.package>`
+  (keep the trailing dot). The guard then fails the build at `verify` if a fresh jar was not
+  built, its `META-INF/BenchmarkList` is empty, or it does not contain that package.
+- Client modules (abstract benchmark base classes only): set just `benchmarks.jar.phase`; the
+  guard stays inactive because no `benchmarks.expected.package` is set.
+
+Modules that set neither property produce no benchmarks jar. The guard also fails any module
+that ships a jar of runnable benchmarks without declaring `benchmarks.expected.package`, so a
+new provider cannot accidentally publish an unverified benchmarks jar.
+
 ---
 
 ## Documentation Contributions

--- a/blob/blob-aws/pom.xml
+++ b/blob/blob-aws/pom.xml
@@ -13,6 +13,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.blob.aws.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -707,64 +714,10 @@
     </dependencies>
     <build>
         <plugins>
-            <!-- benchmark-only artifact: benchmark classes + JMH-generated classes + JMH metadata (BenchmarkList, CompilerHints), no test infra -->
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
-                <executions>
-                    <execution>
-                        <id>benchmarks-classifier-jar</id>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                        <configuration>
-                            <classifier>benchmarks</classifier>
-                            <includes>
-                                <include>**/*Benchmark*.class</include>
-                                <include>**/jmh_generated/**</include>
-                                <include>META-INF/BenchmarkList</include>
-                                <include>META-INF/CompilerHints</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- guard the benchmarks jar: fail the build (and any publish) if it carries no discoverable benchmarks -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>verify-benchmarks-jar</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <loadresource property="benchmarkList" quiet="true">
-                                    <zipentry zipfile="${project.build.directory}/${project.build.finalName}-benchmarks.jar"
-                                              name="META-INF/BenchmarkList"/>
-                                </loadresource>
-                                <fail message="benchmarks jar has a missing or empty BenchmarkList - zero benchmarks">
-                                    <condition>
-                                        <not><isset property="benchmarkList"/></not>
-                                    </condition>
-                                </fail>
-                                <fail message="benchmarks jar is missing com.salesforce.multicloudj.blob.aws benchmarks">
-                                    <condition>
-                                        <not>
-                                            <contains string="${benchmarkList}"
-                                                      substring="com.salesforce.multicloudj.blob.aws."/>
-                                        </not>
-                                    </condition>
-                                </fail>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>

--- a/blob/blob-client/pom.xml
+++ b/blob/blob-client/pom.xml
@@ -164,7 +164,6 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>3.4.2</version>
             <executions>
                 <execution>
                     <goals>

--- a/blob/blob-client/pom.xml
+++ b/blob/blob-client/pom.xml
@@ -13,6 +13,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar (abstract benchmark base classes); no guard on the client module -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.wiremock</groupId>
@@ -166,22 +171,7 @@
                         <goal>test-jar</goal>
                     </goals>
                 </execution>
-                <!-- benchmark-only artifact: benchmark classes + JMH-generated classes + JMH metadata (BenchmarkList, CompilerHints), no test infra -->
-                <execution>
-                    <id>benchmarks-classifier-jar</id>
-                    <goals>
-                        <goal>test-jar</goal>
-                    </goals>
-                    <configuration>
-                        <classifier>benchmarks</classifier>
-                        <includes>
-                            <include>**/*Benchmark*.class</include>
-                            <include>**/jmh_generated/**</include>
-                            <include>META-INF/BenchmarkList</include>
-                            <include>META-INF/CompilerHints</include>
-                        </includes>
-                    </configuration>
-                </execution>
+                <!-- benchmarks-classifier-jar execution inherited from the root pluginManagement -->
             </executions>
         </plugin>
         <plugin>

--- a/blob/blob-gcp/pom.xml
+++ b/blob/blob-gcp/pom.xml
@@ -13,6 +13,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.blob.gcp.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.cloud</groupId>
@@ -354,6 +361,11 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>

--- a/dbbackuprestore/dbbackuprestore-aws/pom.xml
+++ b/dbbackuprestore/dbbackuprestore-aws/pom.xml
@@ -13,6 +13,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.dbbackuprestore.aws.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -117,6 +124,11 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>

--- a/dbbackuprestore/dbbackuprestore-client/pom.xml
+++ b/dbbackuprestore/dbbackuprestore-client/pom.xml
@@ -72,7 +72,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/dbbackuprestore/dbbackuprestore-client/pom.xml
+++ b/dbbackuprestore/dbbackuprestore-client/pom.xml
@@ -13,6 +13,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- benchmarks-classifier-jar execution inherited from the root pluginManagement -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.wiremock</groupId>

--- a/dbbackuprestore/dbbackuprestore-gcp-firestore/pom.xml
+++ b/dbbackuprestore/dbbackuprestore-gcp-firestore/pom.xml
@@ -13,6 +13,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.dbbackuprestore.gcp.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -112,6 +119,11 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>

--- a/docstore/docstore-aws/pom.xml
+++ b/docstore/docstore-aws/pom.xml
@@ -13,6 +13,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.docstore.aws.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -431,6 +438,11 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>

--- a/docstore/docstore-client/pom.xml
+++ b/docstore/docstore-client/pom.xml
@@ -340,7 +340,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/docstore/docstore-client/pom.xml
+++ b/docstore/docstore-client/pom.xml
@@ -13,6 +13,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar (abstract benchmark base classes); no guard on the client module -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.wiremock</groupId>

--- a/docstore/docstore-gcp-firestore/pom.xml
+++ b/docstore/docstore-gcp-firestore/pom.xml
@@ -13,6 +13,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.docstore.gcp.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -426,6 +433,11 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>

--- a/iam/iam-aws/pom.xml
+++ b/iam/iam-aws/pom.xml
@@ -13,6 +13,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.iam.aws.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -87,6 +94,11 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>

--- a/iam/iam-client/pom.xml
+++ b/iam/iam-client/pom.xml
@@ -83,7 +83,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/iam/iam-client/pom.xml
+++ b/iam/iam-client/pom.xml
@@ -13,6 +13,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- benchmarks-classifier-jar execution inherited from the root pluginManagement -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+    </properties>
+
     <dependencies>
         <!-- Core dependencies -->
         <dependency>

--- a/iam/iam-gcp/pom.xml
+++ b/iam/iam-gcp/pom.xml
@@ -13,6 +13,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.iam.gcp.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.api</groupId>
@@ -138,6 +145,11 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -619,6 +619,27 @@
                                         </and>
                                     </condition>
                                 </fail>
+                                <!-- completeness: every benchmark-pattern class compiled for this module must survive into the jar. If the include filter regresses (a class pattern dropped), compiled count exceeds jar count and we refuse to publish an incomplete bundle - this covers abstract bases that runnable benchmarks extend, so a filter regression cannot ship an unrunnable jar. Only class-bearing patterns are compared here; META-INF metadata is checked by the BenchmarkList guards below. Gated on Fresh so the counts reflect this run, and the jar (built from testOutputDirectory via the filter) is always a subset, making equality the correctness condition. -->
+                                <resourcecount property="compiledBenchmarkClassCount" if:set="benchmarksJarFresh">
+                                    <fileset dir="${project.build.testOutputDirectory}" erroronmissingdir="false">
+                                        <include name="**/*Benchmark*.class"/>
+                                        <include name="**/jmh_generated/**"/>
+                                    </fileset>
+                                </resourcecount>
+                                <resourcecount property="jarBenchmarkClassCount" if:set="benchmarksJarFresh">
+                                    <zipfileset src="${benchmarksJar}">
+                                        <include name="**/*Benchmark*.class"/>
+                                        <include name="**/jmh_generated/**"/>
+                                    </zipfileset>
+                                </resourcecount>
+                                <fail message="${project.artifactId}: benchmarks jar has ${jarBenchmarkClassCount} benchmark classes but ${compiledBenchmarkClassCount} were compiled - the include filter dropped classes; refusing to publish an incomplete bundle" unless:set="benchmarksGuardSkip">
+                                    <condition>
+                                        <and>
+                                            <isset property="benchmarksJarFresh"/>
+                                            <not><equals arg1="${compiledBenchmarkClassCount}" arg2="${jarBenchmarkClassCount}"/></not>
+                                        </and>
+                                    </condition>
+                                </fail>
                                 <!-- provider declared intent but no fresh jar was built (phase not set to package, or bare maven-jar-plugin not declared) -->
                                 <fail message="${project.artifactId}: benchmarks.expected.package is set but no fresh benchmarks jar was built - set benchmarks.jar.phase to package and declare a bare maven-jar-plugin" unless:set="benchmarksGuardSkip">
                                     <condition>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,8 @@
         <opentelemetry.version>1.62.0</opentelemetry.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <revision>0.2.5-SNAPSHOT</revision>
+        <!-- benchmarks jar off by default: 'none' leaves the inherited jar execution unbound from the lifecycle (intentional disable, not a typo). A benchmark-bearing module opts in by overriding this to 'package'. -->
+        <benchmarks.jar.phase>none</benchmarks.jar.phase>
     </properties>
     
     <repositories>
@@ -541,9 +543,104 @@
                         </dependency>
                     </dependencies>
                 </plugin>
+                <!-- benchmark-only artifact: benchmark classes + JMH-generated classes + JMH metadata (BenchmarkList, CompilerHints), no test infra. A module opts in by setting benchmarks.jar.phase to package. -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.4.2</version>
+                    <executions>
+                        <execution>
+                            <id>benchmarks-classifier-jar</id>
+                            <phase>${benchmarks.jar.phase}</phase>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                            <configuration>
+                                <classifier>benchmarks</classifier>
+                                <includes>
+                                    <include>**/*Benchmark*.class</include>
+                                    <include>**/jmh_generated/**</include>
+                                    <include>META-INF/BenchmarkList</include>
+                                    <include>META-INF/CompilerHints</include>
+                                </includes>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <!-- version pinning only; the benchmarks-jar guard execution lives in the root build/plugins so it applies to every module automatically -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
+            <!-- benchmarks-jar guard: runs for every module. Enforces on providers (benchmarks.expected.package set), and also fails any module that builds a jar of runnable benchmarks without declaring that property. A no-op on modules that build no benchmarks jar. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>verify-benchmarks-jar</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target xmlns:if="ant:if">
+                                <property name="benchmarksJar" value="${project.build.directory}/${project.build.finalName}-benchmarks.jar"/>
+                                <available file="${benchmarksJar}" property="benchmarksJarPresent"/>
+                                <!-- fresh = jar exists and is newer than the compiled test-classes, i.e. built this run (a stale jar from an earlier build does not count) -->
+                                <uptodate property="benchmarksJarFresh" targetfile="${benchmarksJar}">
+                                    <srcfiles dir="${project.build.testOutputDirectory}" includes="**/*" erroronmissingdir="false"/>
+                                </uptodate>
+                                <!-- read the index only when a jar is present, so modules that build none never hard-error here -->
+                                <loadresource property="benchmarkList" quiet="true" if:set="benchmarksJarPresent">
+                                    <zipentry zipfile="${benchmarksJar}" name="META-INF/BenchmarkList"/>
+                                </loadresource>
+                                <!-- provider declared intent but no fresh jar was built (phase not set to package, or bare maven-jar-plugin not declared) -->
+                                <fail message="${project.artifactId}: benchmarks.expected.package is set but no fresh benchmarks jar was built - set benchmarks.jar.phase to package and declare a bare maven-jar-plugin">
+                                    <condition>
+                                        <and>
+                                            <isset property="benchmarks.expected.package"/>
+                                            <not><isset property="benchmarksJarFresh"/></not>
+                                        </and>
+                                    </condition>
+                                </fail>
+                                <!-- provider jar built but its BenchmarkList is missing/empty (zero runnable benchmarks) -->
+                                <fail message="${project.artifactId}: benchmarks jar has a missing or empty BenchmarkList - zero benchmarks">
+                                    <condition>
+                                        <and>
+                                            <isset property="benchmarks.expected.package"/>
+                                            <not><isset property="benchmarkList"/></not>
+                                        </and>
+                                    </condition>
+                                </fail>
+                                <!-- provider jar built but does not contain this module's own benchmarks -->
+                                <fail message="${project.artifactId}: benchmarks jar is missing ${benchmarks.expected.package} benchmarks">
+                                    <condition>
+                                        <and>
+                                            <isset property="benchmarks.expected.package"/>
+                                            <isset property="benchmarkList"/>
+                                            <not><contains string="${benchmarkList}" substring="${benchmarks.expected.package}"/></not>
+                                        </and>
+                                    </condition>
+                                </fail>
+                                <!-- a module shipped runnable benchmarks but never declared benchmarks.expected.package, so the guard could not verify it -->
+                                <fail message="${project.artifactId}: benchmarks jar contains runnable benchmarks but benchmarks.expected.package is not set - declare it so the guard verifies this module">
+                                    <condition>
+                                        <and>
+                                            <not><isset property="benchmarks.expected.package"/></not>
+                                            <isset property="benchmarkList"/>
+                                        </and>
+                                    </condition>
+                                </fail>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -547,7 +547,8 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <!-- pin to the version main already resolves by default (3.5.0), NOT #604's inline 3.4.2 which would downgrade the plugin repo-wide. One plugin builds both the main jar and the benchmarks classifier, so they necessarily share this version; pinning here also supplies it to the bare provider declarations. -->
+                    <version>3.5.0</version>
                     <executions>
                         <execution>
                             <id>benchmarks-classifier-jar</id>
@@ -588,7 +589,11 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <target xmlns:if="ant:if">
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
+                                <!-- tests (and thus the benchmarks jar) are skipped entirely under -Dmaven.test.skip=true; there is nothing to verify, so the whole guard no-ops -->
+                                <condition property="benchmarksGuardSkip">
+                                    <istrue value="${maven.test.skip}"/>
+                                </condition>
                                 <property name="benchmarksJar" value="${project.build.directory}/${project.build.finalName}-benchmarks.jar"/>
                                 <available file="${benchmarksJar}" property="benchmarksJarPresent"/>
                                 <!-- fresh = jar exists and is newer than the compiled test-classes, i.e. built this run (a stale jar from an earlier build does not count) -->
@@ -599,8 +604,23 @@
                                 <loadresource property="benchmarkList" quiet="true" if:set="benchmarksJarPresent">
                                     <zipentry zipfile="${benchmarksJar}" name="META-INF/BenchmarkList"/>
                                 </loadresource>
+                                <!-- allowlist: the jar must contain ONLY our own classes + JMH/Maven metadata. Count any file entry outside that set; a third-party lib (org/**, io/**, ...) would land here. zipfileset yields only file entries, so bare directory entries never false-positive. -->
+                                <resourcecount property="forbiddenEntryCount" if:set="benchmarksJarPresent">
+                                    <zipfileset src="${benchmarksJar}">
+                                        <exclude name="com/salesforce/multicloudj/**"/>
+                                        <exclude name="META-INF/**"/>
+                                    </zipfileset>
+                                </resourcecount>
+                                <fail message="${project.artifactId}: benchmarks jar contains ${forbiddenEntryCount} entries outside com/salesforce/multicloudj and META-INF - refusing to publish non-benchmark content" unless:set="benchmarksGuardSkip">
+                                    <condition>
+                                        <and>
+                                            <isset property="forbiddenEntryCount"/>
+                                            <not><equals arg1="${forbiddenEntryCount}" arg2="0"/></not>
+                                        </and>
+                                    </condition>
+                                </fail>
                                 <!-- provider declared intent but no fresh jar was built (phase not set to package, or bare maven-jar-plugin not declared) -->
-                                <fail message="${project.artifactId}: benchmarks.expected.package is set but no fresh benchmarks jar was built - set benchmarks.jar.phase to package and declare a bare maven-jar-plugin">
+                                <fail message="${project.artifactId}: benchmarks.expected.package is set but no fresh benchmarks jar was built - set benchmarks.jar.phase to package and declare a bare maven-jar-plugin" unless:set="benchmarksGuardSkip">
                                     <condition>
                                         <and>
                                             <isset property="benchmarks.expected.package"/>
@@ -609,7 +629,7 @@
                                     </condition>
                                 </fail>
                                 <!-- provider jar built but its BenchmarkList is missing/empty (zero runnable benchmarks) -->
-                                <fail message="${project.artifactId}: benchmarks jar has a missing or empty BenchmarkList - zero benchmarks">
+                                <fail message="${project.artifactId}: benchmarks jar has a missing or empty BenchmarkList - zero benchmarks" unless:set="benchmarksGuardSkip">
                                     <condition>
                                         <and>
                                             <isset property="benchmarks.expected.package"/>
@@ -618,7 +638,7 @@
                                     </condition>
                                 </fail>
                                 <!-- provider jar built but does not contain this module's own benchmarks -->
-                                <fail message="${project.artifactId}: benchmarks jar is missing ${benchmarks.expected.package} benchmarks">
+                                <fail message="${project.artifactId}: benchmarks jar is missing ${benchmarks.expected.package} benchmarks" unless:set="benchmarksGuardSkip">
                                     <condition>
                                         <and>
                                             <isset property="benchmarks.expected.package"/>
@@ -628,7 +648,7 @@
                                     </condition>
                                 </fail>
                                 <!-- a module shipped runnable benchmarks but never declared benchmarks.expected.package, so the guard could not verify it -->
-                                <fail message="${project.artifactId}: benchmarks jar contains runnable benchmarks but benchmarks.expected.package is not set - declare it so the guard verifies this module">
+                                <fail message="${project.artifactId}: benchmarks jar contains runnable benchmarks but benchmarks.expected.package is not set - declare it so the guard verifies this module" unless:set="benchmarksGuardSkip">
                                     <condition>
                                         <and>
                                             <not><isset property="benchmarks.expected.package"/></not>

--- a/pubsub/pubsub-aws/pom.xml
+++ b/pubsub/pubsub-aws/pom.xml
@@ -13,6 +13,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.pubsub.aws.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.salesforce.multicloudj</groupId>
@@ -97,6 +104,11 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>

--- a/pubsub/pubsub-client/pom.xml
+++ b/pubsub/pubsub-client/pom.xml
@@ -148,7 +148,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pubsub/pubsub-client/pom.xml
+++ b/pubsub/pubsub-client/pom.xml
@@ -13,6 +13,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- benchmarks-classifier-jar execution inherited from the root pluginManagement -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.salesforce.multicloudj</groupId>

--- a/pubsub/pubsub-gcp/pom.xml
+++ b/pubsub/pubsub-gcp/pom.xml
@@ -13,6 +13,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.pubsub.gcp.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.salesforce.multicloudj</groupId>
@@ -93,6 +100,11 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>

--- a/registry/registry-aws/pom.xml
+++ b/registry/registry-aws/pom.xml
@@ -14,6 +14,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.registry.aws.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.salesforce.multicloudj</groupId>
@@ -113,6 +120,11 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/registry/registry-client/pom.xml
+++ b/registry/registry-client/pom.xml
@@ -13,6 +13,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- benchmarks-classifier-jar execution inherited from the root pluginManagement -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/registry/registry-client/pom.xml
+++ b/registry/registry-client/pom.xml
@@ -97,7 +97,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/registry/registry-gcp/pom.xml
+++ b/registry/registry-gcp/pom.xml
@@ -14,6 +14,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.registry.gcp.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.salesforce.multicloudj</groupId>
@@ -105,6 +112,11 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/sts/sts-aws/pom.xml
+++ b/sts/sts-aws/pom.xml
@@ -13,6 +13,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.sts.aws.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.wiremock</groupId>
@@ -619,64 +626,10 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
-                <executions>
-                    <!-- benchmark-only artifact: benchmark classes + JMH-generated classes + JMH metadata (BenchmarkList, CompilerHints), no test infra -->
-                    <execution>
-                        <id>benchmarks-classifier-jar</id>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                        <configuration>
-                            <classifier>benchmarks</classifier>
-                            <includes>
-                                <include>**/*Benchmark*.class</include>
-                                <include>**/jmh_generated/**</include>
-                                <include>META-INF/BenchmarkList</include>
-                                <include>META-INF/CompilerHints</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- guard the benchmarks jar: fail the build (and any publish) if it carries no discoverable benchmarks -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>verify-benchmarks-jar</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <loadresource property="benchmarkList" quiet="true">
-                                    <zipentry zipfile="${project.build.directory}/${project.build.finalName}-benchmarks.jar"
-                                              name="META-INF/BenchmarkList"/>
-                                </loadresource>
-                                <fail message="benchmarks jar has a missing or empty BenchmarkList - zero benchmarks">
-                                    <condition>
-                                        <not><isset property="benchmarkList"/></not>
-                                    </condition>
-                                </fail>
-                                <fail message="benchmarks jar is missing com.salesforce.multicloudj.sts.aws benchmarks">
-                                    <condition>
-                                        <not>
-                                            <contains string="${benchmarkList}"
-                                                      substring="com.salesforce.multicloudj.sts.aws."/>
-                                        </not>
-                                    </condition>
-                                </fail>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>

--- a/sts/sts-client/pom.xml
+++ b/sts/sts-client/pom.xml
@@ -13,6 +13,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar (abstract benchmark base classes); no guard on the client module -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -146,22 +151,7 @@
                             <goal>test-jar</goal>
                         </goals>
                     </execution>
-                    <!-- benchmark-only artifact: benchmark classes + JMH-generated classes + JMH metadata (BenchmarkList, CompilerHints), no test infra -->
-                    <execution>
-                        <id>benchmarks-classifier-jar</id>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                        <configuration>
-                            <classifier>benchmarks</classifier>
-                            <includes>
-                                <include>**/*Benchmark*.class</include>
-                                <include>**/jmh_generated/**</include>
-                                <include>META-INF/BenchmarkList</include>
-                                <include>META-INF/CompilerHints</include>
-                            </includes>
-                        </configuration>
-                    </execution>
+                    <!-- benchmarks-classifier-jar execution inherited from the root pluginManagement -->
                 </executions>
             </plugin>
 

--- a/sts/sts-client/pom.xml
+++ b/sts/sts-client/pom.xml
@@ -144,7 +144,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/sts/sts-gcp/pom.xml
+++ b/sts/sts-gcp/pom.xml
@@ -14,6 +14,13 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <!-- opt in to the centralized benchmarks jar + guard (config in the root pluginManagement) -->
+        <benchmarks.jar.phase>package</benchmarks.jar.phase>
+        <!-- provider package the benchmark-jar guard asserts is present in META-INF/BenchmarkList -->
+        <benchmarks.expected.package>com.salesforce.multicloudj.sts.gcp.</benchmarks.expected.package>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.wiremock</groupId>
@@ -325,6 +332,11 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- opt in to the centralized benchmarks jar (guard runs automatically because benchmarks.expected.package is set) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>


### PR DESCRIPTION
## What

Follow-up to #604. #604 added the benchmarks-classifier jar plus a build-time guard inline to the blob and sts provider modules. This PR lifts that config into the root `pom.xml` (`pluginManagement` + `build`) so any module opts in through properties instead of copied XML, and rolls it out to **every** benchmark-bearing module.

- Providers (runnable benchmarks): set `benchmarks.jar.phase=package` + `benchmarks.expected.package=com.salesforce.multicloudj.<service>.<cloud>.` and declare a bare `maven-jar-plugin`.
- Clients (abstract benchmark base classes): set only `benchmarks.jar.phase=package`.
- Everything else: unset, so the phase stays `none` and no benchmarks jar is produced.

Coverage: 14 providers + 7 clients across blob, docstore, sts, pubsub, iam, registry, dbbackuprestore. No single service is left half-covered (both the AWS and GCP providers of each service opt in).

## Plugin version

The benchmarks classifier is produced by the same `maven-jar-plugin` as the main jar — one plugin, one version per module, so the two can't be pinned independently. This PR pins that shared plugin to `3.5.0` in `pluginManagement` (the version `main` already resolves by default), deliberately dropping the inline `3.4.2` from #604 — which, once lifted to the root, would have re-pinned the plugin repo-wide and downgraded the main and `-tests` jars from `3.5.0` to `3.4.2`. The pin is a no-op on the resolved version (it equals today's default), but it's load-bearing: each provider opts in with a bare `<plugin>maven-jar-plugin</plugin>` to pull the shared benchmarks execution, and a bare declaration with no managed version makes Maven emit `'plugin.version' is missing` on every provider. Pinning in `pluginManagement` supplies that version and keeps the build warning-free. No behavior change to the existing main/`-tests` jars.

## The guard (runs for every module at `verify`)

Lives once in the root `build/plugins`. For a provider it fails the build if:
- no **fresh** benchmarks jar was built (phase not `package`, or the bare `maven-jar-plugin` was not declared) — freshness is checked against the compiled test-classes so a stale jar from an earlier build does not satisfy it;
- the jar's `META-INF/BenchmarkList` is missing or empty;
- the BenchmarkList does not contain the provider's package.

It also fails **any** module that ships a jar of runnable benchmarks without declaring `benchmarks.expected.package`, so a new provider cannot accidentally publish an unverified benchmarks jar. It is a safe no-op on clients (empty BenchmarkList) and on modules that build no jar.

The guard also enforces a content allowlist: it fails the build if the benchmarks jar carries any entry outside `com/salesforce/multicloudj/**` or `META-INF/**`. This mechanizes the "benchmark classes + JMH metadata only, no test infrastructure" invariant that #604 verified by hand — a future module that leaks a WireMock/Netty/etc. class into the jar now fails the build instead of publishing to Central silently. The whole guard no-ops under `-Dmaven.test.skip=true`, where no test classes (and thus no benchmarks jar) are built.

## Testing

- `mvn clean install -DskipTests`: BUILD SUCCESS; exactly 21 benchmarks jars — 14 providers with non-empty BenchmarkLists (e.g. blob 66, docstore 32, pubsub-aws 52), 7 clients with empty lists, zero leaks elsewhere.
- All four guard failure paths verified to fail the build with the right message: no fresh jar, wrong package, empty BenchmarkList, and runnable-benchmarks-without-expected-package.
- Guard confirmed a no-op on clients and on non-benchmark modules, and confirmed to execute on every reactor module at `verify` (not silently skipped).

## Publishing scope (benchmarks jars publish to Maven Central — deliberate)

`mvn deploy -Prelease` attaches and signs the `-benchmarks` classifier like any other artifact, so these jars publish to Maven Central (via `central-publishing-maven-plugin`, immutable) alongside the SDK. This is deliberate and consistent with existing behavior: the repo already publishes `-tests.jar` classifier artifacts to Central on every release (e.g. `blob-client-0.4.4-tests.jar` is live today), and the `benchmarks` classifier is a strict subset of that — benchmark classes + JMH metadata only, no test infrastructure. Classifier jars are non-transitive, so no consumer resolves them unless they explicitly request `<classifier>benchmarks</classifier>`. Publishing to Central makes the classifier resolvable through the same channels as the existing `-tests` classifier, which downstream consumers already pull today. Wiring the benchmark runner to consume the published classifier (instead of building from vendored source) is follow-up work, tracked separately.

## Note on stacking (why this is a draft)

Stacked on #604 (still open); the Files-changed diff is already the net change. Once #604 merges I will rebase so only this centralization commit remains, then mark ready for review.
