### PR TITLE
sts: add optional circuit breaker and GCP STS token cache

### DIFF
--- a/documentation/guides/sts-guide.md
+++ b/documentation/guides/sts-guide.md
@@ -32,6 +32,7 @@ The `StsClient` is built on top of provider-specific implementations of `Abstrac
 |---------------|-----|-----|-----|----------|
 | **Region Support** | ✅ Supported | ✅ Supported | ✅ Supported | All providers support region-specific operations |
 | **Endpoint Override** | ✅ Supported | ✅ Supported | ✅ Supported | Custom endpoint configuration |
+| **Circuit Breaker** | ✅ Supported | ✅ Supported | ✅ Supported | Optional, provider-agnostic; disabled by default (see [Circuit Breaker](#circuit-breaker-optional)) |
 
 ### Provider-Specific Notes
 
@@ -109,3 +110,54 @@ try {
     e.printStackTrace();
 }
 ```
+
+---
+
+## Circuit Breaker (optional)
+
+`StsClient` can guard every provider call with a circuit breaker. It is **disabled by default** — if you never call `withCircuitBreakerConfig(...)`, the client behaves exactly as before. When enabled, the breaker protects your application from hammering an unhealthy token service: after enough failures it "opens" and rejects calls immediately for a cool-down window, then probes for recovery before closing again.
+
+Only **retryable** failures (those signalling an unhealthy dependency, e.g. throttling or timeouts) count toward opening the breaker. Caller errors such as an invalid argument are non-retryable and never trip it.
+
+```java
+CircuitBreakerConfig breakerConfig = CircuitBreakerConfig.builder()
+    .failureRateThreshold(30f)                                 // open at ≥30% failures
+    .slowCallRateThreshold(10f)                                // open at ≥10% slow calls
+    .slowCallDurationThreshold(Duration.ofSeconds(120))        // a call ≥120s counts as slow
+    .minimumNumberOfCalls(100)                                 // evaluate only after 100 calls
+    .slidingWindowSize(600)                                    // 600-second time-based window
+    .waitDurationInOpenState(Duration.ofSeconds(1))            // stay open 1s before probing
+    .permittedNumberOfCallsInHalfOpenState(200)                // trial calls while half-open
+    .build();
+
+StsClient stsClient = StsClient.builder("aws")
+    .withRegion("us-west-2")
+    .withCircuitBreakerConfig(breakerConfig)
+    .build();
+```
+
+When the breaker is open, calls fail fast with a non-retryable `CircuitBreakerOpenException`:
+
+```java
+try {
+    CallerIdentity identity = stsClient.getCallerIdentity();
+} catch (CircuitBreakerOpenException e) {
+    // Breaker is open — back off and retry only after the wait duration elapses.
+} catch (SubstrateSdkException e) {
+    // Other provider errors.
+}
+```
+
+### Configuration reference
+
+The values shown above are **recommended starting points for a high-throughput workload**, not the defaults. Tune them to your own call volume and latency profile.
+
+| Option | Meaning |
+|--------|---------|
+| `failureRateThreshold` | Percentage (0–100) of recorded failures at or above which the breaker opens. |
+| `slowCallRateThreshold` | Percentage (0–100) of slow calls at or above which the breaker opens. |
+| `slowCallDurationThreshold` | A call taking at least this long is counted as slow. |
+| `slidingWindowSize` | Size of the time-based sliding window, in seconds. |
+| `minimumNumberOfCalls` | Minimum recorded calls before the failure/slow rate is evaluated. |
+| `waitDurationInOpenState` | How long the breaker stays open before transitioning to half-open. |
+| `permittedNumberOfCallsInHalfOpenState` | Number of trial calls permitted while half-open. |

--- a/documentation/guides/sts-guide.md
+++ b/documentation/guides/sts-guide.md
@@ -121,13 +121,13 @@ Only **retryable** failures (those signalling an unhealthy dependency, e.g. thro
 
 ```java
 CircuitBreakerConfig breakerConfig = CircuitBreakerConfig.builder()
-    .failureRateThreshold(30f)                                 // open at ≥30% failures
-    .slowCallRateThreshold(10f)                                // open at ≥10% slow calls
-    .slowCallDurationThreshold(Duration.ofSeconds(120))        // a call ≥120s counts as slow
-    .minimumNumberOfCalls(100)                                 // evaluate only after 100 calls
-    .slidingWindowSize(600)                                    // 600-second time-based window
-    .waitDurationInOpenState(Duration.ofSeconds(1))            // stay open 1s before probing
-    .permittedNumberOfCallsInHalfOpenState(200)                // trial calls while half-open
+    .withFailureRateThreshold(30f)                             // open at ≥30% failures
+    .withSlowCallRateThreshold(10f)                            // open at ≥10% slow calls
+    .withSlowCallDurationThreshold(Duration.ofSeconds(120))    // a call ≥120s counts as slow
+    .withMinimumNumberOfCalls(100)                             // evaluate only after 100 calls
+    .withSlidingWindowSize(600)                                // 600-second time-based window
+    .withWaitDurationInOpenState(Duration.ofSeconds(1))        // stay open 1s before probing
+    .withPermittedNumberOfCallsInHalfOpenState(200)            // trial calls while half-open
     .build();
 
 StsClient stsClient = StsClient.builder("aws")
@@ -154,10 +154,10 @@ The values shown above are **recommended starting points for a high-throughput w
 
 | Option | Meaning |
 |--------|---------|
-| `failureRateThreshold` | Percentage (0–100) of recorded failures at or above which the breaker opens. |
-| `slowCallRateThreshold` | Percentage (0–100) of slow calls at or above which the breaker opens. |
-| `slowCallDurationThreshold` | A call taking at least this long is counted as slow. |
-| `slidingWindowSize` | Size of the time-based sliding window, in seconds. |
-| `minimumNumberOfCalls` | Minimum recorded calls before the failure/slow rate is evaluated. |
-| `waitDurationInOpenState` | How long the breaker stays open before transitioning to half-open. |
-| `permittedNumberOfCallsInHalfOpenState` | Number of trial calls permitted while half-open. |
+| `withFailureRateThreshold` | Percentage (0–100) of recorded failures at or above which the breaker opens. |
+| `withSlowCallRateThreshold` | Percentage (0–100) of slow calls at or above which the breaker opens. |
+| `withSlowCallDurationThreshold` | A call taking at least this long is counted as slow. |
+| `withSlidingWindowSize` | Size of the time-based sliding window, in seconds. |
+| `withMinimumNumberOfCalls` | Minimum recorded calls before the failure/slow rate is evaluated. |
+| `withWaitDurationInOpenState` | How long the breaker stays open before transitioning to half-open. |
+| `withPermittedNumberOfCallsInHalfOpenState` | Number of trial calls permitted while half-open. |

--- a/documentation/guides/sts-guide.md
+++ b/documentation/guides/sts-guide.md
@@ -38,6 +38,25 @@ The `StsClient` is built on top of provider-specific implementations of `Abstrac
 
 **GCP (Google Cloud Platform)**
 - Uses Google's OAuth 2.0 access tokens for credentials and ID tokens for Caller Identity
+- Caches minted tokens in-process to avoid redundant token fetches (see [GCP token caching](#gcp-token-caching))
+
+---
+
+## GCP token caching
+
+The GCP provider keeps an in-process, expiry-aware cache of the tokens it mints, so repeated calls that would produce the same token are served without a fresh network fetch. This is a **GCP-only** optimization: the AWS and Alibaba providers do not cache.
+
+Caching lives inside the GCP provider rather than at the portable `StsClient` seam because the portable `StsCredentials` type carries no expiry — only the provider can observe the native token lifetime (an `AccessToken` expiration, a caller-identity JWT `exp`, or a token-exchange `expires_in`) and honor it.
+
+Key properties:
+
+- **Behavior-neutral.** A cache hit returns the same token a fresh fetch would, and a token is never served within a safety skew (60s) of its expiry.
+- **Correctly scoped.** Each of the four GCP paths — assume-role/impersonation (keyed on target principal, requested lifetime and a hash of any access boundary), get-access-token (keyed on scope), caller-identity (keyed on audience), and web-identity token exchange (keyed on audience and a hash of the subject token) — has its own key, so a request never receives a token minted for a different scope. Secret material (the subject token) is hashed, never stored in the key.
+- **Single-flight.** Concurrent misses for the same key collapse to one network fetch.
+- **Failures are not cached.** If a fetch fails, the exception propagates and nothing is stored.
+- **Enabled by default.** There is no public configuration surface. As an operational escape hatch it can be disabled entirely with the system property `-Dmulticloudj.gcp.sts.cache.enabled=false`.
+
+Because the cache is transparent, application code does not change whether it is on or off.
 
 ---
 
@@ -113,6 +132,35 @@ try {
 
 ---
 
+## Releasing resources
+
+`StsClient` implements `AutoCloseable`. Closing it releases resources held by the underlying provider client (for example, a provider that builds its own HTTP transport for proxy support will shut down that transport's connection pool). Prefer a try-with-resources block so the client is always closed:
+
+```java
+try (StsClient stsClient = StsClient.builder("gcp")
+        .withRegion("us-west-2")
+        .build()) {
+    CallerIdentity identity = stsClient.getCallerIdentity();
+    // ... use the client ...
+}
+// stsClient is closed automatically here
+```
+
+If you cannot use try-with-resources (for example, the client is a long-lived field), call `close()` explicitly when you are done with it:
+
+```java
+StsClient stsClient = StsClient.builder("gcp").withRegion("us-west-2").build();
+try {
+    // ... use the client ...
+} finally {
+    stsClient.close();
+}
+```
+
+`StsClient` instances are meant to be long-lived and reused across requests; create one per provider/configuration and close it only during application shutdown.
+
+---
+
 ## Circuit Breaker (optional)
 
 `StsClient` can guard every provider call with a circuit breaker. It is **disabled by default** — if you never call `withCircuitBreakerConfig(...)`, the client behaves exactly as before. When enabled, the breaker protects your application from hammering an unhealthy token service: after enough failures it "opens" and rejects calls immediately for a cool-down window, then probes for recovery before closing again.
@@ -154,6 +202,7 @@ The values shown above are **recommended starting points for a high-throughput w
 
 | Option | Meaning |
 |--------|---------|
+| `withName` | Name identifying the breaker in logs and metrics. Optional; a null or blank value is ignored and the default name (`"circuit-breaker"`) is kept. |
 | `withFailureRateThreshold` | Percentage (0–100) of recorded failures at or above which the breaker opens. |
 | `withSlowCallRateThreshold` | Percentage (0–100) of slow calls at or above which the breaker opens. |
 | `withSlowCallDurationThreshold` | A call taking at least this long is counted as slow. |

--- a/multicloudj-common/pom.xml
+++ b/multicloudj-common/pom.xml
@@ -25,6 +25,13 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- Source: https://mvnrepository.com/artifact/io.github.resilience4j/resilience4j-circuitbreaker -->
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-circuitbreaker</artifactId>
+            <version>2.4.0</version>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>

--- a/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/circuitbreaker/CircuitBreakerConfig.java
+++ b/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/circuitbreaker/CircuitBreakerConfig.java
@@ -1,0 +1,129 @@
+package com.salesforce.multicloudj.common.circuitbreaker;
+
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
+import java.time.Clock;
+import java.time.Duration;
+
+/**
+ * Substrate-agnostic configuration for a {@link CircuitBreakerExecutor}. This is the only
+ * circuit-breaker type a caller ever constructs; the underlying resilience4j configuration is an
+ * implementation detail produced by {@link #toResilience4jConfig(Clock)}.
+ *
+ * <p>The breaker uses a time-based sliding window and counts only <em>retryable</em>
+ * {@link SubstrateSdkException}s as failures: a retryable failure signals the dependency itself is
+ * unhealthy, whereas a non-retryable failure (e.g. an invalid argument) is a caller error that must
+ * not trip the breaker.
+ *
+ * <p>The defaults mirror resilience4j's own defaults adapted to a time-based window and are
+ * deliberately conservative. Recommended production values for a high-throughput STS workload — for
+ * reference, not defaults — are roughly: {@code failureRateThreshold=30}, {@code
+ * slowCallRateThreshold=10}, {@code slowCallDurationThreshold=120s}, {@code
+ * minimumNumberOfCalls=100}, {@code slidingWindowSize=600s}, {@code waitDurationInOpenState=1s},
+ * {@code permittedNumberOfCallsInHalfOpenState=200}. Tune these to your call volume and latency
+ * profile.
+ */
+public class CircuitBreakerConfig {
+
+  private final float failureRateThreshold;
+  private final float slowCallRateThreshold;
+  private final Duration slowCallDurationThreshold;
+  private final int slidingWindowSize;
+  private final int minimumNumberOfCalls;
+  private final Duration waitDurationInOpenState;
+  private final int permittedNumberOfCallsInHalfOpenState;
+
+  private CircuitBreakerConfig(Builder builder) {
+    this.failureRateThreshold = builder.failureRateThreshold;
+    this.slowCallRateThreshold = builder.slowCallRateThreshold;
+    this.slowCallDurationThreshold = builder.slowCallDurationThreshold;
+    this.slidingWindowSize = builder.slidingWindowSize;
+    this.minimumNumberOfCalls = builder.minimumNumberOfCalls;
+    this.waitDurationInOpenState = builder.waitDurationInOpenState;
+    this.permittedNumberOfCallsInHalfOpenState = builder.permittedNumberOfCallsInHalfOpenState;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Translates this configuration into a resilience4j {@code CircuitBreakerConfig}. The supplied
+   * {@link Clock} drives the time-based sliding window and open-state timing, so tests can inject a
+   * controllable clock. Package-private: only {@link CircuitBreakerExecutor} needs it.
+   */
+  io.github.resilience4j.circuitbreaker.CircuitBreakerConfig toResilience4jConfig(Clock clock) {
+    return io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.custom()
+        .failureRateThreshold(failureRateThreshold)
+        .slowCallRateThreshold(slowCallRateThreshold)
+        .slowCallDurationThreshold(slowCallDurationThreshold)
+        .slidingWindow(slidingWindowSize, minimumNumberOfCalls, SlidingWindowType.TIME_BASED)
+        .waitDurationInOpenState(waitDurationInOpenState)
+        .permittedNumberOfCallsInHalfOpenState(permittedNumberOfCallsInHalfOpenState)
+        // Only retryable failures (unhealthy dependency) count toward opening the breaker; caller
+        // errors are treated as successful calls so they never trip it.
+        .recordException(
+            t ->
+                t instanceof SubstrateSdkException && ((SubstrateSdkException) t).isRetryable())
+        .clock(clock)
+        .build();
+  }
+
+  /** Builder for {@link CircuitBreakerConfig}. */
+  public static class Builder {
+    private float failureRateThreshold = 50f;
+    private float slowCallRateThreshold = 100f;
+    private Duration slowCallDurationThreshold = Duration.ofSeconds(60);
+    private int slidingWindowSize = 60;
+    private int minimumNumberOfCalls = 100;
+    private Duration waitDurationInOpenState = Duration.ofSeconds(60);
+    private int permittedNumberOfCallsInHalfOpenState = 10;
+
+    /** Percentage (0–100) of recorded failures at or above which the breaker opens. */
+    public Builder failureRateThreshold(float failureRateThreshold) {
+      this.failureRateThreshold = failureRateThreshold;
+      return this;
+    }
+
+    /** Percentage (0–100) of slow calls at or above which the breaker opens. */
+    public Builder slowCallRateThreshold(float slowCallRateThreshold) {
+      this.slowCallRateThreshold = slowCallRateThreshold;
+      return this;
+    }
+
+    /** A call taking at least this long is counted as slow. */
+    public Builder slowCallDurationThreshold(Duration slowCallDurationThreshold) {
+      this.slowCallDurationThreshold = slowCallDurationThreshold;
+      return this;
+    }
+
+    /** Size of the time-based sliding window, in seconds. */
+    public Builder slidingWindowSize(int slidingWindowSize) {
+      this.slidingWindowSize = slidingWindowSize;
+      return this;
+    }
+
+    /** Minimum number of recorded calls before the failure/slow rate is evaluated. */
+    public Builder minimumNumberOfCalls(int minimumNumberOfCalls) {
+      this.minimumNumberOfCalls = minimumNumberOfCalls;
+      return this;
+    }
+
+    /** How long the breaker stays open before transitioning to half-open. */
+    public Builder waitDurationInOpenState(Duration waitDurationInOpenState) {
+      this.waitDurationInOpenState = waitDurationInOpenState;
+      return this;
+    }
+
+    /** Number of trial calls permitted while the breaker is half-open. */
+    public Builder permittedNumberOfCallsInHalfOpenState(
+        int permittedNumberOfCallsInHalfOpenState) {
+      this.permittedNumberOfCallsInHalfOpenState = permittedNumberOfCallsInHalfOpenState;
+      return this;
+    }
+
+    public CircuitBreakerConfig build() {
+      return new CircuitBreakerConfig(this);
+    }
+  }
+}

--- a/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/circuitbreaker/CircuitBreakerConfig.java
+++ b/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/circuitbreaker/CircuitBreakerConfig.java
@@ -80,43 +80,43 @@ public class CircuitBreakerConfig {
     private int permittedNumberOfCallsInHalfOpenState = 10;
 
     /** Percentage (0–100) of recorded failures at or above which the breaker opens. */
-    public Builder failureRateThreshold(float failureRateThreshold) {
+    public Builder withFailureRateThreshold(float failureRateThreshold) {
       this.failureRateThreshold = failureRateThreshold;
       return this;
     }
 
     /** Percentage (0–100) of slow calls at or above which the breaker opens. */
-    public Builder slowCallRateThreshold(float slowCallRateThreshold) {
+    public Builder withSlowCallRateThreshold(float slowCallRateThreshold) {
       this.slowCallRateThreshold = slowCallRateThreshold;
       return this;
     }
 
     /** A call taking at least this long is counted as slow. */
-    public Builder slowCallDurationThreshold(Duration slowCallDurationThreshold) {
+    public Builder withSlowCallDurationThreshold(Duration slowCallDurationThreshold) {
       this.slowCallDurationThreshold = slowCallDurationThreshold;
       return this;
     }
 
     /** Size of the time-based sliding window, in seconds. */
-    public Builder slidingWindowSize(int slidingWindowSize) {
+    public Builder withSlidingWindowSize(int slidingWindowSize) {
       this.slidingWindowSize = slidingWindowSize;
       return this;
     }
 
     /** Minimum number of recorded calls before the failure/slow rate is evaluated. */
-    public Builder minimumNumberOfCalls(int minimumNumberOfCalls) {
+    public Builder withMinimumNumberOfCalls(int minimumNumberOfCalls) {
       this.minimumNumberOfCalls = minimumNumberOfCalls;
       return this;
     }
 
     /** How long the breaker stays open before transitioning to half-open. */
-    public Builder waitDurationInOpenState(Duration waitDurationInOpenState) {
+    public Builder withWaitDurationInOpenState(Duration waitDurationInOpenState) {
       this.waitDurationInOpenState = waitDurationInOpenState;
       return this;
     }
 
     /** Number of trial calls permitted while the breaker is half-open. */
-    public Builder permittedNumberOfCallsInHalfOpenState(
+    public Builder withPermittedNumberOfCallsInHalfOpenState(
         int permittedNumberOfCallsInHalfOpenState) {
       this.permittedNumberOfCallsInHalfOpenState = permittedNumberOfCallsInHalfOpenState;
       return this;

--- a/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/circuitbreaker/CircuitBreakerConfig.java
+++ b/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/circuitbreaker/CircuitBreakerConfig.java
@@ -25,6 +25,10 @@ import java.time.Duration;
  */
 public class CircuitBreakerConfig {
 
+  /** Name applied to the breaker when a caller does not supply one. */
+  public static final String DEFAULT_NAME = "circuit-breaker";
+
+  private final String name;
   private final float failureRateThreshold;
   private final float slowCallRateThreshold;
   private final Duration slowCallDurationThreshold;
@@ -34,6 +38,7 @@ public class CircuitBreakerConfig {
   private final int permittedNumberOfCallsInHalfOpenState;
 
   private CircuitBreakerConfig(Builder builder) {
+    this.name = builder.name;
     this.failureRateThreshold = builder.failureRateThreshold;
     this.slowCallRateThreshold = builder.slowCallRateThreshold;
     this.slowCallDurationThreshold = builder.slowCallDurationThreshold;
@@ -45,6 +50,11 @@ public class CircuitBreakerConfig {
 
   public static Builder builder() {
     return new Builder();
+  }
+
+  /** The breaker's name, used to identify it (e.g. in logs and metrics). */
+  public String getName() {
+    return name;
   }
 
   /**
@@ -71,6 +81,7 @@ public class CircuitBreakerConfig {
 
   /** Builder for {@link CircuitBreakerConfig}. */
   public static class Builder {
+    private String name = DEFAULT_NAME;
     private float failureRateThreshold = 50f;
     private float slowCallRateThreshold = 100f;
     private Duration slowCallDurationThreshold = Duration.ofSeconds(60);
@@ -78,6 +89,17 @@ public class CircuitBreakerConfig {
     private int minimumNumberOfCalls = 100;
     private Duration waitDurationInOpenState = Duration.ofSeconds(60);
     private int permittedNumberOfCallsInHalfOpenState = 10;
+
+    /**
+     * Name identifying the breaker (e.g. in logs and metrics). Defaults to
+     * {@link #DEFAULT_NAME}. A null or blank value is ignored and the default is kept.
+     */
+    public Builder withName(String name) {
+      if (name != null && !name.isBlank()) {
+        this.name = name;
+      }
+      return this;
+    }
 
     /** Percentage (0–100) of recorded failures at or above which the breaker opens. */
     public Builder withFailureRateThreshold(float failureRateThreshold) {

--- a/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/circuitbreaker/CircuitBreakerExecutor.java
+++ b/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/circuitbreaker/CircuitBreakerExecutor.java
@@ -1,0 +1,60 @@
+package com.salesforce.multicloudj.common.circuitbreaker;
+
+import com.salesforce.multicloudj.common.exceptions.CircuitBreakerOpenException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.time.Clock;
+import java.util.function.Supplier;
+
+/**
+ * Wraps a single standalone resilience4j {@link CircuitBreaker} and runs operations through it.
+ * There is no shared registry: each executor owns exactly one breaker, so its state is isolated to
+ * the client instance that created it.
+ *
+ * <p>When the breaker is open, resilience4j rejects the call with a
+ * {@link CallNotPermittedException} which is translated to the substrate-agnostic
+ * {@link CircuitBreakerOpenException}. Any exception
+ * the operation itself throws propagates unchanged; the breaker records it as a failure only when
+ * the configured predicate matches (see {@link CircuitBreakerConfig}).
+ */
+public class CircuitBreakerExecutor {
+
+  private final CircuitBreaker circuitBreaker;
+
+  /**
+   * Creates an executor backed by a new breaker built from {@code config}, timed by the system UTC
+   * clock.
+   *
+   * @param name the breaker's name, used in resilience4j events and diagnostics
+   * @param config the substrate-agnostic breaker configuration
+   */
+  public CircuitBreakerExecutor(String name, CircuitBreakerConfig config) {
+    this(name, config, Clock.systemUTC());
+  }
+
+  /**
+   * Creates an executor backed by a new breaker built from {@code config}, timed by the supplied
+   * {@link Clock}. Tests inject a controllable clock to drive the sliding window and open-state
+   * timing deterministically.
+   */
+  public CircuitBreakerExecutor(String name, CircuitBreakerConfig config, Clock clock) {
+    this.circuitBreaker = CircuitBreaker.of(name, config.toResilience4jConfig(clock));
+  }
+
+  /**
+   * Runs {@code operation} through the breaker.
+   *
+   * @param operation the operation to execute
+   * @param <T> the operation's result type
+   * @return the operation's result
+   * @throws CircuitBreakerOpenException if the breaker is open and the call was rejected
+   */
+  public <T> T execute(Supplier<T> operation) {
+    try {
+      return circuitBreaker.executeSupplier(operation);
+    } catch (CallNotPermittedException e) {
+      throw new CircuitBreakerOpenException(
+          "Circuit breaker '" + circuitBreaker.getName() + "' is open; call not permitted", e);
+    }
+  }
+}

--- a/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/exceptions/CircuitBreakerOpenException.java
+++ b/multicloudj-common/src/main/java/com/salesforce/multicloudj/common/exceptions/CircuitBreakerOpenException.java
@@ -1,0 +1,29 @@
+package com.salesforce.multicloudj.common.exceptions;
+
+/**
+ * Thrown when a call is short-circuited because the circuit breaker is open. The failing dependency
+ * is being given time to recover, so the call was rejected without being attempted.
+ *
+ * <p>This exception is non-retryable: an open breaker means an immediate retry would also be
+ * rejected. Callers should back off and retry only after the breaker's wait duration has elapsed.
+ */
+public class CircuitBreakerOpenException extends SubstrateSdkException {
+
+  private static final boolean DEFAULT_RETRYABLE = false;
+
+  public CircuitBreakerOpenException() {
+    super(DEFAULT_RETRYABLE);
+  }
+
+  public CircuitBreakerOpenException(String message, Throwable cause) {
+    super(message, cause, DEFAULT_RETRYABLE);
+  }
+
+  public CircuitBreakerOpenException(String message) {
+    super(message, DEFAULT_RETRYABLE);
+  }
+
+  public CircuitBreakerOpenException(Throwable cause) {
+    super(cause, DEFAULT_RETRYABLE);
+  }
+}

--- a/multicloudj-common/src/test/java/com/salesforce/multicloudj/common/circuitbreaker/CircuitBreakerExecutorTest.java
+++ b/multicloudj-common/src/test/java/com/salesforce/multicloudj/common/circuitbreaker/CircuitBreakerExecutorTest.java
@@ -1,0 +1,216 @@
+package com.salesforce.multicloudj.common.circuitbreaker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.salesforce.multicloudj.common.exceptions.CircuitBreakerOpenException;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.ResourceExhaustedException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives the breaker through its full lifecycle using an injected {@link Clock}, so every
+ * open/half-open/close transition is deterministic and there are no sleeps.
+ */
+class CircuitBreakerExecutorTest {
+
+  /** Retryable failure — the only kind the breaker is configured to count. */
+  private static RuntimeException retryable() {
+    return new ResourceExhaustedException("dependency unhealthy");
+  }
+
+  /** Non-retryable caller error — must never trip the breaker. */
+  private static RuntimeException nonRetryable() {
+    return new InvalidArgumentException("bad input");
+  }
+
+  /**
+   * Small, deterministic config: 5 calls minimum, opens at a 50% failure rate, a 60s window keeps
+   * every call in the same time bucket, 10s open duration, 3 trial calls while half-open.
+   */
+  private static CircuitBreakerConfig config() {
+    return CircuitBreakerConfig.builder()
+        .failureRateThreshold(50f)
+        .slowCallRateThreshold(100f)
+        .slowCallDurationThreshold(Duration.ofHours(1))
+        .slidingWindowSize(60)
+        .minimumNumberOfCalls(5)
+        .waitDurationInOpenState(Duration.ofSeconds(10))
+        .permittedNumberOfCallsInHalfOpenState(3)
+        .build();
+  }
+
+  private static void driveFailures(CircuitBreakerExecutor executor, int count, Supplier<?> op) {
+    for (int i = 0; i < count; i++) {
+      assertThrows(RuntimeException.class, () -> executor.execute(op));
+    }
+  }
+
+  @Test
+  void closedBreaker_returnsOperationResult() {
+    CircuitBreakerExecutor executor = new CircuitBreakerExecutor("t", config(), new MutableClock());
+    assertEquals("ok", executor.execute(() -> "ok"));
+  }
+
+  @Test
+  void retryableFailures_openTheBreaker() {
+    CircuitBreakerExecutor executor = new CircuitBreakerExecutor("t", config(), new MutableClock());
+
+    driveFailures(
+        executor,
+        5,
+        () -> {
+          throw retryable();
+        });
+
+    // Breaker is now open: the next call is rejected without being attempted.
+    assertThrows(
+        CircuitBreakerOpenException.class,
+        () -> executor.execute(() -> "should not run"));
+  }
+
+  @Test
+  void openBreaker_doesNotInvokeOperation() {
+    CircuitBreakerExecutor executor = new CircuitBreakerExecutor("t", config(), new MutableClock());
+    AtomicInteger invocations = new AtomicInteger();
+
+    driveFailures(
+        executor,
+        5,
+        () -> {
+          invocations.incrementAndGet();
+          throw retryable();
+        });
+    assertEquals(5, invocations.get());
+
+    assertThrows(
+        CircuitBreakerOpenException.class,
+        () -> executor.execute(() -> invocations.incrementAndGet()));
+    // Still 5: the guarded supplier never ran while the breaker was open.
+    assertEquals(5, invocations.get());
+  }
+
+  @Test
+  void nonRetryableFailures_doNotOpenBreaker() {
+    CircuitBreakerExecutor executor = new CircuitBreakerExecutor("t", config(), new MutableClock());
+    AtomicInteger invocations = new AtomicInteger();
+
+    // Far more than minimumNumberOfCalls, all non-retryable: the breaker treats them as successful
+    // calls and stays closed, so every call reaches the operation and the original exception
+    // propagates unchanged.
+    for (int i = 0; i < 20; i++) {
+      InvalidArgumentException thrown =
+          assertThrows(
+              InvalidArgumentException.class,
+              () ->
+                  executor.execute(
+                      () -> {
+                        invocations.incrementAndGet();
+                        throw nonRetryable();
+                      }));
+      assertFalse(thrown.isRetryable());
+    }
+    assertEquals(20, invocations.get());
+  }
+
+  @Test
+  void openException_isNonRetryable() {
+    CircuitBreakerExecutor executor = new CircuitBreakerExecutor("t", config(), new MutableClock());
+    driveFailures(
+        executor,
+        5,
+        () -> {
+          throw retryable();
+        });
+
+    CircuitBreakerOpenException open =
+        assertThrows(
+            CircuitBreakerOpenException.class, () -> executor.execute(() -> "should not run"));
+    assertFalse(open.isRetryable());
+  }
+
+  @Test
+  void halfOpen_recoversAndClosesAfterSuccesses() {
+    MutableClock clock = new MutableClock();
+    CircuitBreakerExecutor executor = new CircuitBreakerExecutor("t", config(), clock);
+    driveFailures(
+        executor,
+        5,
+        () -> {
+          throw retryable();
+        });
+
+    // Wait past the open duration; the next calls are permitted as half-open trials.
+    clock.advance(Duration.ofSeconds(11));
+
+    // permittedNumberOfCallsInHalfOpenState = 3 successes close the breaker.
+    for (int i = 0; i < 3; i++) {
+      assertEquals("ok", executor.execute(() -> "ok"));
+    }
+
+    // Closed again: normal calls flow through.
+    assertEquals("recovered", executor.execute(() -> "recovered"));
+  }
+
+  @Test
+  void halfOpen_reopensOnFailure() {
+    MutableClock clock = new MutableClock();
+    CircuitBreakerExecutor executor = new CircuitBreakerExecutor("t", config(), clock);
+    driveFailures(
+        executor,
+        5,
+        () -> {
+          throw retryable();
+        });
+
+    clock.advance(Duration.ofSeconds(11));
+
+    // Three half-open trial calls, all failing → 100% failure rate reopens the breaker.
+    driveFailures(
+        executor,
+        3,
+        () -> {
+          throw retryable();
+        });
+
+    assertThrows(
+        CircuitBreakerOpenException.class, () -> executor.execute(() -> "should not run"));
+  }
+
+  /** A {@link Clock} whose instant only moves when the test advances it. */
+  private static final class MutableClock extends Clock {
+    private Instant instant = Instant.parse("2024-01-01T00:00:00Z");
+
+    void advance(Duration duration) {
+      this.instant = this.instant.plus(duration);
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+
+    @Override
+    public long millis() {
+      return instant.toEpochMilli();
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+  }
+}

--- a/multicloudj-common/src/test/java/com/salesforce/multicloudj/common/circuitbreaker/CircuitBreakerExecutorTest.java
+++ b/multicloudj-common/src/test/java/com/salesforce/multicloudj/common/circuitbreaker/CircuitBreakerExecutorTest.java
@@ -38,13 +38,13 @@ class CircuitBreakerExecutorTest {
    */
   private static CircuitBreakerConfig config() {
     return CircuitBreakerConfig.builder()
-        .failureRateThreshold(50f)
-        .slowCallRateThreshold(100f)
-        .slowCallDurationThreshold(Duration.ofHours(1))
-        .slidingWindowSize(60)
-        .minimumNumberOfCalls(5)
-        .waitDurationInOpenState(Duration.ofSeconds(10))
-        .permittedNumberOfCallsInHalfOpenState(3)
+        .withFailureRateThreshold(50f)
+        .withSlowCallRateThreshold(100f)
+        .withSlowCallDurationThreshold(Duration.ofHours(1))
+        .withSlidingWindowSize(60)
+        .withMinimumNumberOfCalls(5)
+        .withWaitDurationInOpenState(Duration.ofSeconds(10))
+        .withPermittedNumberOfCallsInHalfOpenState(3)
         .build();
   }
 

--- a/multicloudj-common/src/test/java/com/salesforce/multicloudj/common/exceptions/CircuitBreakerOpenExceptionTest.java
+++ b/multicloudj-common/src/test/java/com/salesforce/multicloudj/common/exceptions/CircuitBreakerOpenExceptionTest.java
@@ -1,0 +1,46 @@
+package com.salesforce.multicloudj.common.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+public class CircuitBreakerOpenExceptionTest {
+
+  @Test
+  public void testDefaultConstructor() {
+    CircuitBreakerOpenException exception = new CircuitBreakerOpenException();
+    assertNull(exception.getMessage());
+    assertNull(exception.getCause());
+    assertFalse(exception.isRetryable());
+  }
+
+  @Test
+  public void testConstructorWithMessage() {
+    String message = "Circuit breaker is open";
+    CircuitBreakerOpenException exception = new CircuitBreakerOpenException(message);
+    assertEquals(message, exception.getMessage());
+    assertNull(exception.getCause());
+    assertFalse(exception.isRetryable());
+  }
+
+  @Test
+  public void testConstructorWithCause() {
+    Throwable cause = new Throwable("Cause");
+    CircuitBreakerOpenException exception = new CircuitBreakerOpenException(cause);
+    assertEquals(cause, exception.getCause());
+    assertEquals("java.lang.Throwable: Cause", exception.getMessage());
+    assertFalse(exception.isRetryable());
+  }
+
+  @Test
+  public void testConstructorWithMessageAndCause() {
+    String message = "Circuit breaker is open";
+    Throwable cause = new Throwable("Cause");
+    CircuitBreakerOpenException exception = new CircuitBreakerOpenException(message, cause);
+    assertEquals(message, exception.getMessage());
+    assertEquals(cause, exception.getCause());
+    assertFalse(exception.isRetryable());
+  }
+}

--- a/sts/sts-aws/src/main/java/com/salesforce/multicloudj/sts/aws/AwsSts.java
+++ b/sts/sts-aws/src/main/java/com/salesforce/multicloudj/sts/aws/AwsSts.java
@@ -77,6 +77,14 @@ public class AwsSts extends AbstractSts {
     return new Builder();
   }
 
+  /** Closes the underlying AWS SDK STS client, releasing its HTTP connection pool and threads. */
+  @Override
+  public void close() {
+    if (stsClient != null) {
+      stsClient.close();
+    }
+  }
+
   @Override
   protected StsCredentials getSTSCredentialsWithAssumeRole(AssumedRoleRequest request) {
     AssumeRoleRequest.Builder roleRequestBuilder =

--- a/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsCircuitBreakerIT.java
+++ b/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsCircuitBreakerIT.java
@@ -1,0 +1,127 @@
+package com.salesforce.multicloudj.sts.aws;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+
+import com.salesforce.multicloudj.common.circuitbreaker.CircuitBreakerConfig;
+import com.salesforce.multicloudj.common.exceptions.CircuitBreakerOpenException;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import com.salesforce.multicloudj.common.util.common.TestsUtil;
+import com.salesforce.multicloudj.sts.client.StsClient;
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * Fault-injection integration test for the STS circuit breaker on AWS. Unlike the record/replay
+ * conformance suite ({@link AwsStsIT}), this drives a real {@link StsClient} — the layer that owns
+ * the breaker — against a hand-written WireMock stub that always returns a retryable HTTP 503, so
+ * the breaker's open transition is observed end-to-end without touching a live AWS endpoint.
+ *
+ * <p>The AWS SDK STS client is pointed straight at WireMock's plain-HTTP port via the client's
+ * public {@code withEndpoint(...)} builder — no forward proxy or TLS interception is needed because
+ * AWS honours an endpoint override directly. Dummy credentials are supplied through JVM system
+ * properties so the default credential chain resolves and the request actually reaches the stub.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AwsStsCircuitBreakerIT {
+
+  private static final int PORT = ThreadLocalRandom.current().nextInt(20000, 40000);
+  private static final int HTTP_PORT = PORT + 1;
+
+  // A well-formed STS error body so the AWS SDK surfaces a 503 AwsServiceException (retryable).
+  private static final String SERVICE_UNAVAILABLE_BODY =
+      "<ErrorResponse xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\">"
+          + "<Error><Type>Server</Type><Code>ServiceUnavailable</Code>"
+          + "<Message>slow down</Message></Error>"
+          + "<RequestId>fault-injection</RequestId></ErrorResponse>";
+
+  private String priorAccessKey;
+  private String priorSecretKey;
+
+  @BeforeAll
+  public void setUp() {
+    // Dummy credentials for the default provider chain — never leave the JVM as anything real.
+    priorAccessKey = System.setProperty("aws.accessKeyId", "FAKE_ACCESS_KEY");
+    priorSecretKey = System.setProperty("aws.secretAccessKey", "FAKE_SECRET_ACCESS_KEY");
+
+    TestsUtil.startWireMockServer("src/test/resources", PORT);
+    configureFor(TestsUtil.WIREMOCK_HOST, HTTP_PORT);
+    // Every STS action (a POST to "/") fails with a transient 503.
+    stubFor(
+        any(anyUrl())
+            .willReturn(
+                aResponse()
+                    .withStatus(503)
+                    .withHeader("Content-Type", "text/xml")
+                    .withBody(SERVICE_UNAVAILABLE_BODY)));
+  }
+
+  @AfterAll
+  public void tearDown() {
+    TestsUtil.stopWireMockServer();
+    restoreProperty("aws.accessKeyId", priorAccessKey);
+    restoreProperty("aws.secretAccessKey", priorSecretKey);
+  }
+
+  private static void restoreProperty(String key, String prior) {
+    if (prior == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, prior);
+    }
+  }
+
+  @Test
+  public void breakerOpensAfterRepeatedRetryableFailures() {
+    CircuitBreakerConfig config =
+        CircuitBreakerConfig.builder()
+            .withFailureRateThreshold(50f)
+            .withMinimumNumberOfCalls(3)
+            .withSlidingWindowSize(60)
+            .withSlowCallRateThreshold(100f) // never trip on slowness, only on failures
+            .withWaitDurationInOpenState(Duration.ofSeconds(30))
+            .withPermittedNumberOfCallsInHalfOpenState(1)
+            .build();
+
+    StsClient client =
+        StsClient.builder("aws")
+            .withRegion("us-west-2")
+            .withEndpoint(URI.create("http://" + TestsUtil.WIREMOCK_HOST + ":" + HTTP_PORT))
+            .withCircuitBreakerConfig(config)
+            .build();
+
+    int retryableFailures = 0;
+    boolean breakerOpened = false;
+
+    // Once the minimum number of failing calls has been recorded, the next call must fast-fail.
+    for (int i = 0; i < 10 && !breakerOpened; i++) {
+      try {
+        client.getCallerIdentity();
+        Assertions.fail("Expected the stubbed 503 to surface as an exception");
+      } catch (CircuitBreakerOpenException open) {
+        breakerOpened = true;
+        Assertions.assertFalse(
+            open.isRetryable(), "CircuitBreakerOpenException must be non-retryable");
+      } catch (SubstrateSdkException e) {
+        // The provider failure that feeds the breaker must itself be retryable, or it would never
+        // count toward opening.
+        Assertions.assertTrue(
+            e.isRetryable(), "A 503 ServiceUnavailable must map to a retryable exception");
+        retryableFailures++;
+      }
+    }
+
+    Assertions.assertTrue(
+        retryableFailures >= 3, "expected at least the minimum number of recorded failures");
+    Assertions.assertTrue(breakerOpened, "circuit breaker never opened after repeated 503s");
+  }
+}

--- a/sts/sts-client/pom.xml
+++ b/sts/sts-client/pom.xml
@@ -39,6 +39,14 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- SLF4J binding for tests: the circuit breaker (resilience4j) logs via SLF4J, which needs
+             a provider on the test classpath to initialize. -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.19</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.salesforce.multicloudj</groupId>
             <artifactId>multicloudj-common</artifactId>

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/client/StsClient.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/client/StsClient.java
@@ -1,6 +1,9 @@
 package com.salesforce.multicloudj.sts.client;
 
 import com.google.common.collect.ImmutableSet;
+import com.salesforce.multicloudj.common.circuitbreaker.CircuitBreakerConfig;
+import com.salesforce.multicloudj.common.circuitbreaker.CircuitBreakerExecutor;
+import com.salesforce.multicloudj.common.exceptions.CircuitBreakerOpenException;
 import com.salesforce.multicloudj.common.exceptions.ExceptionHandler;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.sts.driver.AbstractSts;
@@ -12,13 +15,21 @@ import com.salesforce.multicloudj.sts.model.GetCallerIdentityRequest;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
 import java.net.URI;
 import java.util.ServiceLoader;
+import java.util.function.Supplier;
 
 /**
  * StsClient class in the Portable Client for interacting with Security Token Service (STS) in a
  * substrate agnostic way.
  */
-public class StsClient {
+public class StsClient implements AutoCloseable {
   protected AbstractSts sts;
+
+  /**
+   * Optional circuit breaker guarding every provider call. Null unless a circuit-breaker
+   * configuration was supplied to the builder, in which case behavior is byte-for-byte identical to
+   * a client without a breaker.
+   */
+  private final CircuitBreakerExecutor circuitBreakerExecutor;
 
   /**
    * Constructor for StsClient with StsBuilder.
@@ -26,7 +37,44 @@ public class StsClient {
    * @param sts The abstract used to back this client for implementation.
    */
   protected StsClient(AbstractSts sts) {
+    this(sts, null);
+  }
+
+  /**
+   * Constructor for StsClient with an optional circuit breaker.
+   *
+   * @param sts The abstract used to back this client for implementation.
+   * @param circuitBreakerExecutor The circuit breaker to guard provider calls, or null to disable.
+   */
+  protected StsClient(AbstractSts sts, CircuitBreakerExecutor circuitBreakerExecutor) {
     this.sts = sts;
+    this.circuitBreakerExecutor = circuitBreakerExecutor;
+  }
+
+  /**
+   * Single seam through which every provider operation runs. The provider call and its exception
+   * mapping ({@link AbstractSts#mapException(Throwable)}) happen inside the guarded supplier, so
+   * the breaker observes the mapped {@link SubstrateSdkException} and its retryability. When no
+   * breaker is configured, the supplier is invoked directly — behavior is identical to the
+   * pre-breaker client.
+   *
+   * @param operation the raw provider call
+   * @param <T> the operation's result type
+   * @return the operation's result
+   */
+  private <T> T call(Supplier<T> operation) {
+    Supplier<T> mapped =
+        () -> {
+          try {
+            return operation.get();
+          } catch (Throwable t) {
+            throw this.sts.mapException(t);
+          }
+        };
+    if (circuitBreakerExecutor == null) {
+      return mapped.get();
+    }
+    return circuitBreakerExecutor.execute(mapped);
   }
 
   /**
@@ -93,11 +141,7 @@ public class StsClient {
    * @return The StsCredentials for the assumed role.
    */
   public StsCredentials getAssumeRoleCredentials(AssumedRoleRequest request) {
-    try {
-      return this.sts.assumeRole(request);
-    } catch (Throwable t) {
-      throw this.sts.mapException(t);
-    }
+    return call(() -> this.sts.assumeRole(request));
   }
 
   /**
@@ -106,11 +150,7 @@ public class StsClient {
    * @return The CallerIdentity.
    */
   public CallerIdentity getCallerIdentity() {
-    try {
-      return getCallerIdentity(GetCallerIdentityRequest.builder().build());
-    } catch (Throwable t) {
-      throw this.sts.mapException(t);
-    }
+    return getCallerIdentity(GetCallerIdentityRequest.builder().build());
   }
 
   /**
@@ -119,11 +159,7 @@ public class StsClient {
    * @return The CallerIdentity.
    */
   public CallerIdentity getCallerIdentity(GetCallerIdentityRequest request) {
-    try {
-      return this.sts.getCallerIdentity(request);
-    } catch (Throwable t) {
-      throw this.sts.mapException(t);
-    }
+    return call(() -> this.sts.getCallerIdentity(request));
   }
 
   /**
@@ -133,11 +169,7 @@ public class StsClient {
    * @return The StsCredentials containing the access token.
    */
   public StsCredentials getAccessToken(GetAccessTokenRequest request) {
-    try {
-      return this.sts.getAccessToken(request);
-    } catch (Throwable t) {
-      throw this.sts.mapException(t);
-    }
+    return call(() -> this.sts.getAccessToken(request));
   }
 
   /**
@@ -148,10 +180,14 @@ public class StsClient {
    */
   public StsCredentials getAssumeRoleWithWebIdentityCredentials(
       AssumeRoleWebIdentityRequest request) {
-    try {
-      return this.sts.assumeRoleWithWebIdentity(request);
-    } catch (Throwable t) {
-      throw this.sts.mapException(t);
+    return call(() -> this.sts.assumeRoleWithWebIdentity(request));
+  }
+
+  /** Closes the underlying STS provider client and releases any resources it holds. */
+  @Override
+  public void close() throws Exception {
+    if (this.sts != null) {
+      this.sts.close();
     }
   }
 
@@ -161,6 +197,7 @@ public class StsClient {
     protected URI endpoint;
     protected AbstractSts sts;
     protected AbstractSts.Builder<?, ?> stsBuilder;
+    protected CircuitBreakerConfig circuitBreakerConfig;
 
     /**
      * Constructor for StsBuilder.
@@ -232,13 +269,35 @@ public class StsClient {
     }
 
     /**
+     * Enables a circuit breaker that guards every provider call made by the built client. When this
+     * is not called (or is passed null), the client behaves exactly as before — no breaker is
+     * created and calls run straight through.
+     *
+     * <p>The breaker counts only retryable {@link SubstrateSdkException}s as failures, so caller
+     * errors (e.g. invalid arguments) never trip it. Once open, calls are rejected with a
+     * non-retryable {@link CircuitBreakerOpenException} until the breaker's wait duration elapses.
+     * See {@link CircuitBreakerConfig} for tuning guidance.
+     *
+     * @param circuitBreakerConfig the breaker configuration, or null to leave the breaker disabled
+     * @return This StsBuilder instance.
+     */
+    public StsBuilder withCircuitBreakerConfig(CircuitBreakerConfig circuitBreakerConfig) {
+      this.circuitBreakerConfig = circuitBreakerConfig;
+      return this;
+    }
+
+    /**
      * Builds and returns an StsClient instance.
      *
      * @return A new StsClient instance.
      */
     public StsClient build() {
       this.sts = this.stsBuilder.build();
-      return new StsClient(this.sts);
+      CircuitBreakerExecutor executor =
+          circuitBreakerConfig == null
+              ? null
+              : new CircuitBreakerExecutor("sts", circuitBreakerConfig);
+      return new StsClient(this.sts, executor);
     }
   }
 }

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/client/StsClient.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/client/StsClient.java
@@ -296,7 +296,7 @@ public class StsClient implements AutoCloseable {
       CircuitBreakerExecutor executor =
           circuitBreakerConfig == null
               ? null
-              : new CircuitBreakerExecutor("sts", circuitBreakerConfig);
+              : new CircuitBreakerExecutor(circuitBreakerConfig.getName(), circuitBreakerConfig);
       return new StsClient(this.sts, executor);
     }
   }

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/driver/AbstractSts.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/driver/AbstractSts.java
@@ -15,7 +15,7 @@ import lombok.Getter;
  * Abstract base class for Security Token Service (STS) implementations. This class is internal for
  * SDK and all the providers for STS implementations are supposed to implement it.
  */
-public abstract class AbstractSts implements Provider {
+public abstract class AbstractSts implements Provider, AutoCloseable {
   protected final String providerId;
   protected final String region;
 
@@ -127,6 +127,20 @@ public abstract class AbstractSts implements Provider {
    */
   public StsCredentials assumeRoleWithWebIdentity(AssumeRoleWebIdentityRequest request) {
     return getSTSCredentialsWithAssumeRoleWebIdentity(request);
+  }
+
+  /**
+   * Releases any resources (e.g. HTTP connection pools) held by the underlying provider client.
+   *
+   * <p>The default implementation is a no-op: a provider that holds no closeable resource does not
+   * need to override this. Providers that own a long-lived SDK client or HTTP transport override
+   * {@code close()} to release it.
+   *
+   * @throws Exception if the underlying provider resource fails to close
+   */
+  @Override
+  public void close() throws Exception {
+    // No-op by default; providers holding closeable resources override this.
   }
 
   /**

--- a/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/StsClientTest.java
+++ b/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/StsClientTest.java
@@ -1,12 +1,20 @@
 package com.salesforce.multicloudj.sts.client;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.salesforce.multicloudj.common.circuitbreaker.CircuitBreakerConfig;
+import com.salesforce.multicloudj.common.circuitbreaker.CircuitBreakerExecutor;
+import com.salesforce.multicloudj.common.exceptions.CircuitBreakerOpenException;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.ResourceExhaustedException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.driver.AbstractSts;
@@ -15,9 +23,11 @@ import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.GetCallerIdentityRequest;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
@@ -26,6 +36,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class StsClientTest {
+
+  /**
+   * resilience4j initializes an SLF4J logger in a static initializer, and SLF4J discovers its
+   * provider through {@link ServiceLoader}. Several tests below mock {@code ServiceLoader}
+   * statically; if the breaker's classes are first touched inside such a block, SLF4J's own
+   * lookup returns the mock and fails to initialize. Force both static initializations here — once,
+   * before any mock is installed — so the real provider is cached for the whole JVM.
+   */
+  @BeforeAll
+  static void warmUpBreakerAndLoggingBeforeServiceLoaderMocking() {
+    new CircuitBreakerExecutor("warmup", breakerConfig());
+  }
+
   @Test
   public void testStsClient() {
     AbstractSts mockProvider = mock(AbstractSts.class);
@@ -216,6 +239,131 @@ public class StsClientTest {
       assertThrows(
           SubstrateSdkException.class,
           () -> client.getAssumeRoleWithWebIdentityCredentials(request));
+    }
+  }
+
+  /**
+   * Deterministic breaker config: opens once five recorded calls hit a 50% retryable-failure rate.
+   * The 60s window keeps every call in one bucket, so no clock manipulation is needed to observe
+   * the open transition.
+   */
+  private static CircuitBreakerConfig breakerConfig() {
+    return CircuitBreakerConfig.builder()
+        .failureRateThreshold(50f)
+        .slowCallRateThreshold(100f)
+        .slowCallDurationThreshold(Duration.ofHours(1))
+        .slidingWindowSize(60)
+        .minimumNumberOfCalls(5)
+        .waitDurationInOpenState(Duration.ofSeconds(10))
+        .permittedNumberOfCallsInHalfOpenState(3)
+        .build();
+  }
+
+  private static AbstractSts newMockProvider() {
+    AbstractSts mockProvider = mock(AbstractSts.class);
+    AbstractSts.Builder mockBuilder = mock(AbstractSts.Builder.class);
+    when(mockProvider.getProviderId()).thenReturn("mockProviderId");
+    when(mockProvider.builder()).thenReturn(mockBuilder);
+    when(mockBuilder.build()).thenReturn(mockProvider);
+    return mockProvider;
+  }
+
+  private static ServiceLoader<?> serviceLoaderFor(AbstractSts provider) {
+    ServiceLoader serviceLoader = mock(ServiceLoader.class);
+    Iterator<? extends AbstractSts> providerIterator = List.of(provider).iterator();
+    when(serviceLoader.iterator()).thenReturn(providerIterator);
+    return serviceLoader;
+  }
+
+  @Test
+  public void circuitBreakerOpensAfterRetryableFailures() {
+    AbstractSts mockProvider = newMockProvider();
+    when(mockProvider.getCallerIdentity(any(GetCallerIdentityRequest.class)))
+        .thenThrow(new RuntimeException("boom"));
+    // The seam maps the raw failure to a retryable SubstrateSdkException, which the breaker counts.
+    when(mockProvider.mapException(any(Throwable.class)))
+        .thenAnswer(inv -> new ResourceExhaustedException((Throwable) inv.getArgument(0)));
+
+    try (MockedStatic<ServiceLoader> serviceLoaderStatic =
+        Mockito.mockStatic(ServiceLoader.class)) {
+      ServiceLoader<?> serviceLoader = serviceLoaderFor(mockProvider);
+
+      serviceLoaderStatic
+          .when(() -> ServiceLoader.load(AbstractSts.class))
+          .thenReturn(serviceLoader);
+
+      StsClient client =
+          StsClient.builder("mockProviderId").withCircuitBreakerConfig(breakerConfig()).build();
+      GetCallerIdentityRequest request = GetCallerIdentityRequest.builder().build();
+
+      // Five retryable failures reach the provider and trip the breaker.
+      for (int i = 0; i < 5; i++) {
+        assertThrows(ResourceExhaustedException.class, () -> client.getCallerIdentity(request));
+      }
+
+      // Breaker is now open: the call is short-circuited without touching the provider.
+      assertThrows(CircuitBreakerOpenException.class, () -> client.getCallerIdentity(request));
+      verify(mockProvider, times(5)).getCallerIdentity(any(GetCallerIdentityRequest.class));
+    }
+  }
+
+  @Test
+  public void nonRetryableFailuresDoNotOpenBreaker() {
+    AbstractSts mockProvider = newMockProvider();
+    when(mockProvider.getCallerIdentity(any(GetCallerIdentityRequest.class)))
+        .thenThrow(new RuntimeException("bad input"));
+    // Caller errors map to a non-retryable exception; the breaker treats them as successful calls.
+    when(mockProvider.mapException(any(Throwable.class)))
+        .thenAnswer(inv -> new InvalidArgumentException((Throwable) inv.getArgument(0)));
+
+    try (MockedStatic<ServiceLoader> serviceLoaderStatic =
+        Mockito.mockStatic(ServiceLoader.class)) {
+      ServiceLoader<?> serviceLoader = serviceLoaderFor(mockProvider);
+
+      serviceLoaderStatic
+          .when(() -> ServiceLoader.load(AbstractSts.class))
+          .thenReturn(serviceLoader);
+
+      StsClient client =
+          StsClient.builder("mockProviderId").withCircuitBreakerConfig(breakerConfig()).build();
+      GetCallerIdentityRequest request = GetCallerIdentityRequest.builder().build();
+
+      // Far more than the minimum call count: the breaker never opens on non-retryable failures.
+      for (int i = 0; i < 20; i++) {
+        InvalidArgumentException thrown =
+            assertThrows(
+                InvalidArgumentException.class, () -> client.getCallerIdentity(request));
+        assertFalse(thrown.isRetryable());
+      }
+      verify(mockProvider, times(20)).getCallerIdentity(any(GetCallerIdentityRequest.class));
+    }
+  }
+
+  @Test
+  public void withoutBreaker_retryableFailuresNeverShortCircuit() {
+    AbstractSts mockProvider = newMockProvider();
+    when(mockProvider.getCallerIdentity(any(GetCallerIdentityRequest.class)))
+        .thenThrow(new RuntimeException("boom"));
+    when(mockProvider.mapException(any(Throwable.class)))
+        .thenAnswer(inv -> new ResourceExhaustedException((Throwable) inv.getArgument(0)));
+
+    try (MockedStatic<ServiceLoader> serviceLoaderStatic =
+        Mockito.mockStatic(ServiceLoader.class)) {
+      ServiceLoader<?> serviceLoader = serviceLoaderFor(mockProvider);
+
+      serviceLoaderStatic
+          .when(() -> ServiceLoader.load(AbstractSts.class))
+          .thenReturn(serviceLoader);
+
+      // No breaker configured: behavior is identical to the pre-breaker client — every call reaches
+      // the provider and the mapped exception propagates, never a CircuitBreakerOpenException.
+      StsClient client = StsClient.builder("mockProviderId").build();
+      GetCallerIdentityRequest request = GetCallerIdentityRequest.builder().build();
+
+      for (int i = 0; i < 20; i++) {
+        assertThrows(ResourceExhaustedException.class, () -> client.getCallerIdentity(request));
+      }
+      verify(mockProvider, times(20)).getCallerIdentity(any(GetCallerIdentityRequest.class));
     }
   }
 

--- a/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/StsClientTest.java
+++ b/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/StsClientTest.java
@@ -249,13 +249,13 @@ public class StsClientTest {
    */
   private static CircuitBreakerConfig breakerConfig() {
     return CircuitBreakerConfig.builder()
-        .failureRateThreshold(50f)
-        .slowCallRateThreshold(100f)
-        .slowCallDurationThreshold(Duration.ofHours(1))
-        .slidingWindowSize(60)
-        .minimumNumberOfCalls(5)
-        .waitDurationInOpenState(Duration.ofSeconds(10))
-        .permittedNumberOfCallsInHalfOpenState(3)
+        .withFailureRateThreshold(50f)
+        .withSlowCallRateThreshold(100f)
+        .withSlowCallDurationThreshold(Duration.ofHours(1))
+        .withSlidingWindowSize(60)
+        .withMinimumNumberOfCalls(5)
+        .withWaitDurationInOpenState(Duration.ofSeconds(10))
+        .withPermittedNumberOfCallsInHalfOpenState(3)
         .build();
   }
 

--- a/sts/sts-gcp/pom.xml
+++ b/sts/sts-gcp/pom.xml
@@ -123,6 +123,20 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Provider-local, expiry-aware token cache (GcpStsTokenCache). Compile-only transitives
+             (checker-qual, error_prone_annotations) are already declared below, so excluding all
+             transitives here is safe. -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- The transitives of the dependencies above -->
         <dependency>

--- a/sts/sts-gcp/pom.xml
+++ b/sts/sts-gcp/pom.xml
@@ -23,6 +23,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/CachedToken.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/CachedToken.java
@@ -1,0 +1,33 @@
+package com.salesforce.multicloudj.sts.gcp;
+
+import java.time.Instant;
+
+/**
+ * Immutable value held by {@link GcpStsTokenCache}: a token string paired with the instant it
+ * expires. The expiry drives the cache's per-entry eviction so a token is never served past its
+ * lifetime. A {@code null} {@link #getExpiresAt()} means the expiry could not be determined; the
+ * cache treats such an entry as immediately expired (returned to the current caller, never reused).
+ */
+public final class CachedToken {
+  private final String tokenValue;
+  private final Instant expiresAt;
+
+  /**
+   * Creates a cached token.
+   *
+   * @param tokenValue the token string to return to callers
+   * @param expiresAt the instant the token expires, or {@code null} if unknown
+   */
+  public CachedToken(String tokenValue, Instant expiresAt) {
+    this.tokenValue = tokenValue;
+    this.expiresAt = expiresAt;
+  }
+
+  public String getTokenValue() {
+    return tokenValue;
+  }
+
+  public Instant getExpiresAt() {
+    return expiresAt;
+  }
+}

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/CachedToken.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/CachedToken.java
@@ -1,6 +1,8 @@
 package com.salesforce.multicloudj.sts.gcp;
 
 import java.time.Instant;
+import lombok.ToString;
+import lombok.Value;
 
 /**
  * Immutable value held by {@link GcpStsTokenCache}: a token string paired with the instant it
@@ -8,26 +10,16 @@ import java.time.Instant;
  * lifetime. A {@code null} {@link #getExpiresAt()} means the expiry could not be determined; the
  * cache treats such an entry as immediately expired (returned to the current caller, never reused).
  */
-public final class CachedToken {
-  private final String tokenValue;
-  private final Instant expiresAt;
+@Value
+public class CachedToken {
 
   /**
-   * Creates a cached token.
-   *
-   * @param tokenValue the token string to return to callers
-   * @param expiresAt the instant the token expires, or {@code null} if unknown
+   * The token string to return to callers. Excluded from {@code toString} because it is a secret
+   * credential that must never be rendered into logs or diagnostics.
    */
-  public CachedToken(String tokenValue, Instant expiresAt) {
-    this.tokenValue = tokenValue;
-    this.expiresAt = expiresAt;
-  }
+  @ToString.Exclude
+  String tokenValue;
 
-  public String getTokenValue() {
-    return tokenValue;
-  }
-
-  public Instant getExpiresAt() {
-    return expiresAt;
-  }
+  /** The instant the token expires, or {@code null} if unknown. */
+  Instant expiresAt;
 }

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpSts.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpSts.java
@@ -3,6 +3,7 @@ package com.salesforce.multicloudj.sts.gcp;
 import com.google.api.client.http.ByteArrayContent;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.apache.v2.ApacheHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
@@ -338,7 +339,7 @@ public class GcpSts extends AbstractSts {
               });
       return new StsCredentials(StringUtils.EMPTY, StringUtils.EMPTY, tokenValue);
     } catch (IOException e) {
-      throw new SubstrateSdkException("Failed to create credentials", e);
+      throw mapIoException("Failed to create credentials", e);
     }
   }
 
@@ -367,7 +368,7 @@ public class GcpSts extends AbstractSts {
 
       return new CallerIdentity(StringUtils.EMPTY, idToken, StringUtils.EMPTY);
     } catch (IOException e) {
-      throw new SubstrateSdkException("Could not create credentials in given environment", e);
+      throw mapIoException("Could not create credentials in given environment", e);
     }
   }
 
@@ -390,7 +391,7 @@ public class GcpSts extends AbstractSts {
               });
       return new StsCredentials(StringUtils.EMPTY, StringUtils.EMPTY, tokenValue);
     } catch (IOException e) {
-      throw new SubstrateSdkException("Could not create credentials in given environment", e);
+      throw mapIoException("Could not create credentials in given environment", e);
     }
   }
 
@@ -453,8 +454,31 @@ public class GcpSts extends AbstractSts {
 
       return new StsCredentials(StringUtils.EMPTY, StringUtils.EMPTY, accessToken);
     } catch (IOException e) {
-      throw new SubstrateSdkException("Failed to exchange OIDC token for GCP access token", e);
+      throw mapIoException("Failed to exchange OIDC token for GCP access token", e);
     }
+  }
+
+  /**
+   * Translates an {@link IOException} raised while calling a GCP STS/token endpoint into the
+   * appropriate {@link SubstrateSdkException}. Transient failures — HTTP 408/429 and 5xx, and
+   * transport-level errors with no HTTP status (connection resets, read/connect timeouts) — are
+   * classified <em>retryable</em> so that a persistently unhealthy token endpoint trips the circuit
+   * breaker. Any other 4xx response is a caller error (bad request, unauthorized, not found) and
+   * stays non-retryable.
+   */
+  private static SubstrateSdkException mapIoException(String message, IOException e) {
+    if (e instanceof HttpResponseException) {
+      int status = ((HttpResponseException) e).getStatusCode();
+      if (status == 429) {
+        return new ResourceExhaustedException(message, e);
+      }
+      if (status == 408 || status >= 500) {
+        return new UnknownException(message, e);
+      }
+      return new SubstrateSdkException(message, e);
+    }
+    // No HTTP status: a transport-level failure against the token endpoint — treat as transient.
+    return new UnknownException(message, e);
   }
 
   @Override

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpSts.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpSts.java
@@ -43,7 +43,13 @@ import com.salesforce.multicloudj.sts.model.GetAccessTokenRequest;
 import com.salesforce.multicloudj.sts.model.GetCallerIdentityRequest;
 import com.salesforce.multicloudj.sts.model.StsCredentials;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +71,20 @@ public class GcpSts extends AbstractSts {
 
   private GoogleCredentials googleCredentials;
   private HttpTransportFactory httpTransportFactory;
+
+  /**
+   * The HTTP transport this instance built and therefore owns. Non-null only when a proxy
+   * configuration caused us to construct our own Apache-backed transport; a caller-injected
+   * transport is never assigned here and is never closed by us.
+   */
+  private HttpTransport ownedHttpTransport;
+
+  /**
+   * Provider-local, expiry-aware token cache. Behavior-neutral: a hit returns the same token a
+   * fresh fetch would, and never within the cache's skew of the token's expiry. Enabled by default;
+   * disable with the {@code multicloudj.gcp.sts.cache.enabled=false} system property.
+   */
+  private final GcpStsTokenCache tokenCache = new GcpStsTokenCache();
 
   public GcpSts(Builder builder) {
     super(builder);
@@ -103,7 +123,24 @@ public class GcpSts extends AbstractSts {
     if (builder.getProxyEndpoint() != null
         || builder.getUseSystemPropertyProxyValues() != null
         || builder.getUseEnvironmentVariableProxyValues() != null) {
-      this.httpTransportFactory = buildHttpTransportFactory(builder);
+      CloseableHttpClient httpClient = buildHttpClient(builder);
+      ApacheHttpTransport transport = new ApacheHttpTransport(httpClient);
+      this.ownedHttpTransport = transport;
+      this.httpTransportFactory = () -> transport;
+    }
+  }
+
+  /**
+   * Shuts down the Apache-backed HTTP transport this instance created, releasing its connection
+   * pool. A no-op when no proxy transport was built or when the transport was supplied by the
+   * caller.
+   *
+   * @throws IOException if the underlying transport fails to shut down
+   */
+  @Override
+  public void close() throws IOException {
+    if (ownedHttpTransport != null) {
+      ownedHttpTransport.shutdown();
     }
   }
 
@@ -239,53 +276,67 @@ public class GcpSts extends AbstractSts {
   @Override
   protected StsCredentials getSTSCredentialsWithAssumeRole(AssumedRoleRequest request) {
     try {
-      // Create credentials for the service account
-      GoogleCredentials sourceCredentials = getCredentials();
+      // Key on the inputs that fully qualify the minted token: target principal, requested
+      // lifetime, and a hash of the access boundary. The scope is a constant.
+      int expiration = request.getExpiration();
+      TokenCacheKey key =
+          TokenCacheKey.forAssumeRole(
+              request.getRole(), expiration, credentialScopeHash(request.getCredentialScope()));
 
-      // If service account impersonation is needed, use ImpersonatedCredentials
-      if (request.getRole() != null && !request.getRole().isEmpty()) {
-        ImpersonatedCredentials.Builder impersonatedBuilder =
-            ImpersonatedCredentials.newBuilder()
-                .setSourceCredentials(sourceCredentials)
-                .setTargetPrincipal(request.getRole())
-                .setScopes(List.of(SCOPE));
+      String tokenValue =
+          tokenCache.getToken(
+              key,
+              () -> {
+                // Create credentials for the service account
+                GoogleCredentials sourceCredentials = getCredentials();
 
-        if (request.getExpiration() > 0) {
-          impersonatedBuilder.setLifetime(request.getExpiration());
-        }
+                // If service account impersonation is needed, use ImpersonatedCredentials
+                if (request.getRole() != null && !request.getRole().isEmpty()) {
+                  ImpersonatedCredentials.Builder impersonatedBuilder =
+                      ImpersonatedCredentials.newBuilder()
+                          .setSourceCredentials(sourceCredentials)
+                          .setTargetPrincipal(request.getRole())
+                          .setScopes(List.of(SCOPE));
 
-        // Set custom HTTP transport if available
-        if (httpTransportFactory != null) {
-          impersonatedBuilder.setHttpTransportFactory(httpTransportFactory);
-        }
+                  if (expiration > 0) {
+                    impersonatedBuilder.setLifetime(expiration);
+                  }
 
-        sourceCredentials = impersonatedBuilder.build();
-      }
+                  // Set custom HTTP transport if available
+                  if (httpTransportFactory != null) {
+                    impersonatedBuilder.setHttpTransportFactory(httpTransportFactory);
+                  }
 
-      // If credential scope is provided, apply downscoping
-      if (request.getCredentialScope() != null) {
-        // Convert cloud-agnostic CredentialScope to GCP CredentialAccessBoundary
-        CredentialAccessBoundary gcpAccessBoundary =
-            convertToGcpAccessBoundary(request.getCredentialScope());
+                  sourceCredentials = impersonatedBuilder.build();
+                }
 
-        // Create downscoped credentials with the access boundary
-        DownscopedCredentials.Builder downscopedBuilder =
-            DownscopedCredentials.newBuilder()
-                .setSourceCredential(sourceCredentials)
-                .setCredentialAccessBoundary(gcpAccessBoundary);
-        DownscopedCredentials downscopedCredentials = downscopedBuilder.build();
+                // If credential scope is provided, apply downscoping
+                if (request.getCredentialScope() != null) {
+                  // Convert cloud-agnostic CredentialScope to GCP CredentialAccessBoundary
+                  CredentialAccessBoundary gcpAccessBoundary =
+                      convertToGcpAccessBoundary(request.getCredentialScope());
 
-        // Get the downscoped access token
-        downscopedCredentials.refreshIfExpired();
-        AccessToken accessToken = downscopedCredentials.getAccessToken();
-        return new StsCredentials(
-            StringUtils.EMPTY, StringUtils.EMPTY, accessToken.getTokenValue());
-      }
+                  // Create downscoped credentials with the access boundary
+                  DownscopedCredentials downscopedCredentials =
+                      DownscopedCredentials.newBuilder()
+                          .setSourceCredential(sourceCredentials)
+                          .setCredentialAccessBoundary(gcpAccessBoundary)
+                          .build();
 
-      // No downscoping - refresh and return the credentials
-      sourceCredentials.refreshIfExpired();
-      AccessToken accessToken = sourceCredentials.getAccessToken();
-      return new StsCredentials(StringUtils.EMPTY, StringUtils.EMPTY, accessToken.getTokenValue());
+                  // Get the downscoped access token
+                  downscopedCredentials.refreshIfExpired();
+                  AccessToken accessToken = downscopedCredentials.getAccessToken();
+                  return new CachedToken(
+                      accessToken.getTokenValue(), toInstant(accessToken.getExpirationTime()));
+                }
+
+                // No downscoping - refresh and return the credentials
+                sourceCredentials.refreshIfExpired();
+                AccessToken accessToken = sourceCredentials.getAccessToken();
+                return new CachedToken(
+                    accessToken.getTokenValue(), toInstant(accessToken.getExpirationTime()));
+              });
+      return new StsCredentials(StringUtils.EMPTY, StringUtils.EMPTY, tokenValue);
     } catch (IOException e) {
       throw new SubstrateSdkException("Failed to create credentials", e);
     }
@@ -294,15 +345,25 @@ public class GcpSts extends AbstractSts {
   @Override
   protected CallerIdentity getCallerIdentityFromProvider(GetCallerIdentityRequest request) {
     try {
-      GoogleCredentials credentials = getCredentials();
-      credentials.refreshIfExpired();
-      IdTokenCredentials idTokenCredentials =
-          IdTokenCredentials.newBuilder()
-              .setIdTokenProvider((IdTokenProvider) credentials)
-              .setTargetAudience(
-                  request.getAud() != null ? request.getAud().toLowerCase() : "multicloudj")
-              .build();
-      String idToken = idTokenCredentials.refreshAccessToken().getTokenValue();
+      String aud = request.getAud() != null ? request.getAud().toLowerCase() : "multicloudj";
+      TokenCacheKey key = TokenCacheKey.forCallerIdentity(aud);
+
+      String idToken =
+          tokenCache.getToken(
+              key,
+              () -> {
+                GoogleCredentials credentials = getCredentials();
+                credentials.refreshIfExpired();
+                IdTokenCredentials idTokenCredentials =
+                    IdTokenCredentials.newBuilder()
+                        .setIdTokenProvider((IdTokenProvider) credentials)
+                        .setTargetAudience(aud)
+                        .build();
+                // The id token's expiry is the JWT exp claim, which IdTokenCredentials surfaces on
+                // the returned AccessToken.
+                AccessToken token = idTokenCredentials.refreshAccessToken();
+                return new CachedToken(token.getTokenValue(), toInstant(token.getExpirationTime()));
+              });
 
       return new CallerIdentity(StringUtils.EMPTY, idToken, StringUtils.EMPTY);
     } catch (IOException e) {
@@ -313,10 +374,21 @@ public class GcpSts extends AbstractSts {
   @Override
   protected StsCredentials getAccessTokenFromProvider(GetAccessTokenRequest request) {
     try {
-      GoogleCredentials credentials = getCredentials();
-      credentials.refreshIfExpired();
-      return new StsCredentials(
-          StringUtils.EMPTY, StringUtils.EMPTY, credentials.getAccessToken().getTokenValue());
+      // The returned token is minted from the application-default credentials for the constant
+      // cloud-platform scope, so the scope fully qualifies it.
+      TokenCacheKey key = TokenCacheKey.forAccessToken(SCOPE);
+
+      String tokenValue =
+          tokenCache.getToken(
+              key,
+              () -> {
+                GoogleCredentials credentials = getCredentials();
+                credentials.refreshIfExpired();
+                AccessToken accessToken = credentials.getAccessToken();
+                return new CachedToken(
+                    accessToken.getTokenValue(), toInstant(accessToken.getExpirationTime()));
+              });
+      return new StsCredentials(StringUtils.EMPTY, StringUtils.EMPTY, tokenValue);
     } catch (IOException e) {
       throw new SubstrateSdkException("Could not create credentials in given environment", e);
     }
@@ -337,30 +409,47 @@ public class GcpSts extends AbstractSts {
     }
 
     try {
-      // Build token exchange request
-      GenericJson tokenRequest = new GenericJson();
-      tokenRequest.set("audience", request.getRole());
-      tokenRequest.set("grantType", "urn:ietf:params:oauth:grant-type:token-exchange");
-      tokenRequest.set("requestedTokenType", "urn:ietf:params:oauth:token-type:access_token");
-      tokenRequest.set("subjectToken", request.getWebIdentityToken());
-      tokenRequest.set("subjectTokenType", "urn:ietf:params:oauth:token-type:jwt");
-      tokenRequest.set("scope", SCOPE);
+      // Key on the audience and a hash of the subject token being exchanged; the raw subject token
+      // is never stored in the key.
+      TokenCacheKey key =
+          TokenCacheKey.forWebIdentity(request.getRole(), sha256Hex(request.getWebIdentityToken()));
 
-      // Execute token exchange
-      HttpTransport transport =
-          httpTransportFactory != null ? httpTransportFactory.create() : new NetHttpTransport();
-      JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
-      HttpRequest httpRequest =
-          transport
-              .createRequestFactory()
-              .buildPostRequest(
-                  new GenericUrl(STS_ENDPOINT),
-                  new ByteArrayContent("application/json", jsonFactory.toByteArray(tokenRequest)));
-      com.google.api.client.http.HttpResponse response = httpRequest.execute();
-      GenericJson responseData =
-          jsonFactory.fromInputStream(
-              response.getContent(), response.getContentCharset(), GenericJson.class);
-      String accessToken = String.valueOf(responseData.get("access_token"));
+      String accessToken =
+          tokenCache.getToken(
+              key,
+              () -> {
+                // Build token exchange request
+                GenericJson tokenRequest = new GenericJson();
+                tokenRequest.set("audience", request.getRole());
+                tokenRequest.set("grantType", "urn:ietf:params:oauth:grant-type:token-exchange");
+                tokenRequest.set(
+                    "requestedTokenType", "urn:ietf:params:oauth:token-type:access_token");
+                tokenRequest.set("subjectToken", request.getWebIdentityToken());
+                tokenRequest.set("subjectTokenType", "urn:ietf:params:oauth:token-type:jwt");
+                tokenRequest.set("scope", SCOPE);
+
+                // Execute token exchange
+                HttpTransport transport =
+                    httpTransportFactory != null
+                        ? httpTransportFactory.create()
+                        : new NetHttpTransport();
+                JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
+                HttpRequest httpRequest =
+                    transport
+                        .createRequestFactory()
+                        .buildPostRequest(
+                            new GenericUrl(STS_ENDPOINT),
+                            new ByteArrayContent(
+                                "application/json", jsonFactory.toByteArray(tokenRequest)));
+                com.google.api.client.http.HttpResponse response = httpRequest.execute();
+                GenericJson responseData =
+                    jsonFactory.fromInputStream(
+                        response.getContent(), response.getContentCharset(), GenericJson.class);
+                String tokenValue = String.valueOf(responseData.get("access_token"));
+                // The token-exchange response carries a relative lifetime in expires_in seconds.
+                Instant expiry = parseExpiresIn(responseData.get("expires_in"));
+                return new CachedToken(tokenValue, expiry);
+              });
 
       return new StsCredentials(StringUtils.EMPTY, StringUtils.EMPTY, accessToken);
     } catch (IOException e) {
@@ -388,6 +477,71 @@ public class GcpSts extends AbstractSts {
       return adc;
     } catch (IOException e) {
       throw new SubstrateSdkException("Could not create credentials in given environment", e);
+    }
+  }
+
+  /** Converts a native token expiry {@link Date} to an {@link Instant}, preserving {@code null}. */
+  private static Instant toInstant(Date expirationTime) {
+    return expirationTime == null ? null : expirationTime.toInstant();
+  }
+
+  /** Lowercase hex SHA-256 of {@code value}; used to keep secrets out of cache keys. */
+  private static String sha256Hex(String value) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+      StringBuilder sb = new StringBuilder(hash.length * 2);
+      for (byte b : hash) {
+        sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+        sb.append(Character.forDigit(b & 0xF, 16));
+      }
+      return sb.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new SubstrateSdkException("SHA-256 algorithm not available", e);
+    }
+  }
+
+  /**
+   * Produces a stable hash over the fields of a {@link CredentialScope} so two requests with the
+   * same access boundary share a cache entry and requests with different boundaries never do.
+   * Returns an empty string when no scope is set (no downscoping).
+   */
+  private static String credentialScopeHash(CredentialScope scope) {
+    if (scope == null) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (CredentialScope.ScopeRule rule : scope.getRules()) {
+      sb.append("res=").append(rule.getAvailableResource()).append(';');
+      sb.append("perms=").append(rule.getAvailablePermissions()).append(';');
+      CredentialScope.AvailabilityCondition condition = rule.getAvailabilityCondition();
+      if (condition != null) {
+        sb.append("prefix=").append(condition.getResourcePrefix()).append(';');
+        sb.append("title=").append(condition.getTitle()).append(';');
+        sb.append("desc=").append(condition.getDescription()).append(';');
+      }
+      sb.append('|');
+    }
+    return sha256Hex(sb.toString());
+  }
+
+  /**
+   * Converts a token-exchange {@code expires_in} value (relative seconds) to an absolute expiry
+   * instant using the cache's clock. Returns {@code null} when the value is absent, unparseable, or
+   * non-positive, so the token is returned once but never reused.
+   */
+  private Instant parseExpiresIn(Object expiresIn) {
+    if (expiresIn == null) {
+      return null;
+    }
+    try {
+      long seconds = new BigDecimal(String.valueOf(expiresIn)).longValue();
+      if (seconds <= 0) {
+        return null;
+      }
+      return tokenCache.now().plusSeconds(seconds);
+    } catch (NumberFormatException e) {
+      return null;
     }
   }
 
@@ -423,18 +577,6 @@ public class GcpSts extends AbstractSts {
     ERROR_MAPPING.put(StatusCode.Code.UNAVAILABLE, UnknownException.class);
     ERROR_MAPPING.put(StatusCode.Code.DATA_LOSS, UnknownException.class);
     ERROR_MAPPING.put(StatusCode.Code.UNAUTHENTICATED, UnAuthorizedException.class);
-  }
-
-  /**
-   * Builds an HttpTransportFactory with proxy configuration.
-   *
-   * @param builder The builder containing proxy configuration
-   * @return Configured HttpTransportFactory
-   */
-  private static HttpTransportFactory buildHttpTransportFactory(Builder builder) {
-    CloseableHttpClient httpClient = buildHttpClient(builder);
-    ApacheHttpTransport transport = new ApacheHttpTransport(httpClient);
-    return () -> transport;
   }
 
   /**

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpSts.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpSts.java
@@ -500,7 +500,7 @@ public class GcpSts extends AbstractSts {
       }
       return adc;
     } catch (IOException e) {
-      throw new SubstrateSdkException("Could not create credentials in given environment", e);
+      throw mapIoException("Could not create credentials in given environment", e);
     }
   }
 

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsTokenCache.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsTokenCache.java
@@ -1,0 +1,147 @@
+package com.salesforce.multicloudj.sts.gcp;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import com.github.benmanes.caffeine.cache.Ticker;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Provider-local, expiry-aware cache for the tokens produced by the GCP STS paths. It exists
+ * because {@code StsCredentials} carries no expiry, so caching cannot live at the portable seam;
+ * only here can the native token expiry ({@code AccessToken.getExpirationTime()}, a JWT
+ * {@code exp}, or a token-exchange {@code expires_in}) be observed and honored.
+ *
+ * <p>The cache is a behavior-neutral optimization: a hit is indistinguishable from a fresh fetch,
+ * and a token is never served within {@code expirySkew} of its expiry. Concurrent misses for the
+ * same key collapse to a single network fetch (single-flight). Failed loads are not cached —
+ * exceptions propagate and nothing is stored.
+ *
+ * <p>Enabled by default with bounded, safe internal defaults; there is no public configuration
+ * surface. The hidden system property {@code multicloudj.gcp.sts.cache.enabled=false} disables it
+ * as an operational escape hatch.
+ */
+public class GcpStsTokenCache {
+
+  /** System property to disable the cache entirely (operational escape hatch). */
+  static final String ENABLED_PROPERTY = "multicloudj.gcp.sts.cache.enabled";
+
+  private static final long DEFAULT_MAX_SIZE = 1000L;
+  private static final Duration DEFAULT_EXPIRY_SKEW = Duration.ofSeconds(60);
+
+  private final Clock clock;
+  private final Cache<TokenCacheKey, CachedToken> cache;
+
+  /** Loads a fresh token when the cache misses. */
+  @FunctionalInterface
+  public interface TokenLoader {
+    CachedToken load() throws IOException;
+  }
+
+  /** Production constructor: enabled unless disabled by system property, with default sizing. */
+  public GcpStsTokenCache() {
+    this(isEnabledByProperty(), DEFAULT_MAX_SIZE, DEFAULT_EXPIRY_SKEW, Clock.systemUTC(),
+        Ticker.systemTicker());
+  }
+
+  /**
+   * Test/internal constructor allowing an injected {@link Clock} and {@link Ticker} so expiry is
+   * deterministic without real waits.
+   */
+  GcpStsTokenCache(boolean enabled, long maximumSize, Duration expirySkew, Clock clock,
+      Ticker ticker) {
+    this.clock = clock;
+    if (enabled) {
+      this.cache =
+          Caffeine.newBuilder()
+              .maximumSize(maximumSize)
+              .ticker(ticker)
+              .expireAfter(new TokenExpiry(clock, expirySkew))
+              .build();
+    } else {
+      this.cache = null;
+    }
+  }
+
+  private static boolean isEnabledByProperty() {
+    String value = System.getProperty(ENABLED_PROPERTY);
+    return value == null || !value.equalsIgnoreCase("false");
+  }
+
+  /**
+   * Returns a valid token for {@code key}, loading and caching it on a miss. On a hit the loader is
+   * not invoked and no network I/O occurs. When the cache is disabled the loader is always invoked.
+   *
+   * @param key fully-qualifying cache key for the requested token
+   * @param loader supplier that performs the real (network) fetch on a miss
+   * @return the token string
+   * @throws IOException if the loader fails to fetch a token
+   */
+  public String getToken(TokenCacheKey key, TokenLoader loader) throws IOException {
+    if (cache == null) {
+      return loader.load().getTokenValue();
+    }
+    try {
+      CachedToken token =
+          cache.get(
+              key,
+              k -> {
+                try {
+                  return loader.load();
+                } catch (IOException e) {
+                  throw new UncheckedIOException(e);
+                }
+              });
+      return token.getTokenValue();
+    } catch (UncheckedIOException e) {
+      throw e.getCause();
+    }
+  }
+
+  /** Current wall-clock instant from the injected clock; used to convert relative expiries. */
+  public Instant now() {
+    return clock.instant();
+  }
+
+  /**
+   * Per-entry expiry: a relative TTL of {@code (expiresAt - skew) - now}, aged by Caffeine's
+   * ticker. A relative TTL (rather than an absolute ticker deadline) avoids mixing the monotonic
+   * ticker with wall-clock expiries. A {@code null} expiry yields TTL 0 — the value is returned to
+   * the current caller but is never reused.
+   */
+  private static final class TokenExpiry implements Expiry<TokenCacheKey, CachedToken> {
+    private final Clock clock;
+    private final Duration skew;
+
+    TokenExpiry(Clock clock, Duration skew) {
+      this.clock = clock;
+      this.skew = skew;
+    }
+
+    @Override
+    public long expireAfterCreate(TokenCacheKey key, CachedToken value, long currentTime) {
+      Instant expiresAt = value.getExpiresAt();
+      if (expiresAt == null) {
+        return 0L;
+      }
+      long ttlNanos = Duration.between(clock.instant(), expiresAt.minus(skew)).toNanos();
+      return Math.max(0L, ttlNanos);
+    }
+
+    @Override
+    public long expireAfterUpdate(
+        TokenCacheKey key, CachedToken value, long currentTime, long currentDuration) {
+      return currentDuration;
+    }
+
+    @Override
+    public long expireAfterRead(
+        TokenCacheKey key, CachedToken value, long currentTime, long currentDuration) {
+      return currentDuration;
+    }
+  }
+}

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/TokenCacheKey.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/TokenCacheKey.java
@@ -1,0 +1,108 @@
+package com.salesforce.multicloudj.sts.gcp;
+
+import java.util.Objects;
+
+/**
+ * Immutable cache key for {@link GcpStsTokenCache}. Each of the GCP STS token paths keys on the
+ * bounded set of inputs that fully qualify the token it produces, so a cached entry is never
+ * returned for a request that would have produced a different token (different identity, scope,
+ * access boundary, audience, or subject token).
+ *
+ * <p>Secret-bearing inputs (the access boundary, the web-identity subject token) are represented in
+ * the key by a hash supplied by the caller — never the raw value.
+ */
+public final class TokenCacheKey {
+
+  /** The GCP STS path a key belongs to; part of equality so keys never collide across paths. */
+  public enum Path {
+    ASSUME_ROLE,
+    ACCESS_TOKEN,
+    CALLER_IDENTITY,
+    WEB_IDENTITY
+  }
+
+  private final Path path;
+  private final String primary;
+  private final String secondary;
+  private final long numeric;
+
+  private TokenCacheKey(Path path, String primary, String secondary, long numeric) {
+    this.path = path;
+    this.primary = primary;
+    this.secondary = secondary;
+    this.numeric = numeric;
+  }
+
+  /**
+   * Key for the impersonation / downscoping path.
+   *
+   * @param role target principal (empty when no impersonation)
+   * @param expiration requested lifetime in seconds (0 when unset)
+   * @param credentialScopeHash hash of the serialized access boundary (empty when no downscoping)
+   */
+  public static TokenCacheKey forAssumeRole(
+      String role, long expiration, String credentialScopeHash) {
+    return new TokenCacheKey(Path.ASSUME_ROLE, nullToEmpty(role), nullToEmpty(credentialScopeHash),
+        expiration);
+  }
+
+  /**
+   * Key for the plain access-token path.
+   *
+   * @param scope the OAuth scope the token is minted for
+   */
+  public static TokenCacheKey forAccessToken(String scope) {
+    return new TokenCacheKey(Path.ACCESS_TOKEN, nullToEmpty(scope), "", 0L);
+  }
+
+  /**
+   * Key for the caller-identity (id-token) path.
+   *
+   * @param aud the target audience the id token is minted for
+   */
+  public static TokenCacheKey forCallerIdentity(String aud) {
+    return new TokenCacheKey(Path.CALLER_IDENTITY, nullToEmpty(aud), "", 0L);
+  }
+
+  /**
+   * Key for the web-identity token-exchange path.
+   *
+   * @param audience the identity-pool provider audience
+   * @param webIdentityTokenHash hash of the subject token being exchanged
+   */
+  public static TokenCacheKey forWebIdentity(String audience, String webIdentityTokenHash) {
+    return new TokenCacheKey(Path.WEB_IDENTITY, nullToEmpty(audience),
+        nullToEmpty(webIdentityTokenHash), 0L);
+  }
+
+  private static String nullToEmpty(String value) {
+    return value == null ? "" : value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TokenCacheKey)) {
+      return false;
+    }
+    TokenCacheKey that = (TokenCacheKey) o;
+    return numeric == that.numeric
+        && path == that.path
+        && primary.equals(that.primary)
+        && secondary.equals(that.secondary);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(path, primary, secondary, numeric);
+  }
+
+  @Override
+  public String toString() {
+    // primary/secondary are non-secret identifiers or hashes; safe to render.
+    return "TokenCacheKey{path=" + path + ", primary=" + primary + ", secondary=" + secondary
+        + ", numeric=" + numeric + '}';
+  }
+}

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/TokenCacheKey.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/TokenCacheKey.java
@@ -1,6 +1,6 @@
 package com.salesforce.multicloudj.sts.gcp;
 
-import java.util.Objects;
+import lombok.Value;
 
 /**
  * Immutable cache key for {@link GcpStsTokenCache}. Each of the GCP STS token paths keys on the
@@ -9,9 +9,12 @@ import java.util.Objects;
  * access boundary, audience, or subject token).
  *
  * <p>Secret-bearing inputs (the access boundary, the web-identity subject token) are represented in
- * the key by a hash supplied by the caller — never the raw value.
+ * the key by a hash supplied by the caller — never the raw value. {@code toString} renders only
+ * {@code path}/{@code primary}/{@code secondary}/{@code numeric}, which are non-secret identifiers,
+ * hashes, or lifetimes; it never exposes a raw secret.
  */
-public final class TokenCacheKey {
+@Value
+public class TokenCacheKey {
 
   /** The GCP STS path a key belongs to; part of equality so keys never collide across paths. */
   public enum Path {
@@ -21,17 +24,17 @@ public final class TokenCacheKey {
     WEB_IDENTITY
   }
 
-  private final Path path;
-  private final String primary;
-  private final String secondary;
-  private final long numeric;
+  /** The GCP STS path this key belongs to; part of equality so keys never collide. */
+  Path path;
 
-  private TokenCacheKey(Path path, String primary, String secondary, long numeric) {
-    this.path = path;
-    this.primary = primary;
-    this.secondary = secondary;
-    this.numeric = numeric;
-  }
+  /** The primary identity/scope/audience discriminator for the path. */
+  String primary;
+
+  /** The secondary discriminator (a hash for secret-bearing inputs), or empty. */
+  String secondary;
+
+  /** The numeric discriminator (e.g. requested lifetime in seconds), or 0 when unset. */
+  long numeric;
 
   /**
    * Key for the impersonation / downscoping path.
@@ -77,32 +80,5 @@ public final class TokenCacheKey {
 
   private static String nullToEmpty(String value) {
     return value == null ? "" : value;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof TokenCacheKey)) {
-      return false;
-    }
-    TokenCacheKey that = (TokenCacheKey) o;
-    return numeric == that.numeric
-        && path == that.path
-        && primary.equals(that.primary)
-        && secondary.equals(that.secondary);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(path, primary, secondary, numeric);
-  }
-
-  @Override
-  public String toString() {
-    // primary/secondary are non-secret identifiers or hashes; safe to render.
-    return "TokenCacheKey{path=" + path + ", primary=" + primary + ", secondary=" + secondary
-        + ", numeric=" + numeric + '}';
   }
 }

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/client/GcpStsCircuitBreakerIT.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/client/GcpStsCircuitBreakerIT.java
@@ -1,0 +1,123 @@
+package com.salesforce.multicloudj.sts.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.auth.http.HttpTransportFactory;
+import com.salesforce.multicloudj.common.circuitbreaker.CircuitBreakerConfig;
+import com.salesforce.multicloudj.common.circuitbreaker.CircuitBreakerExecutor;
+import com.salesforce.multicloudj.common.exceptions.CircuitBreakerOpenException;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import com.salesforce.multicloudj.common.gcp.util.MockGoogleCredentialsFactory;
+import com.salesforce.multicloudj.common.gcp.util.TestsUtilGcp;
+import com.salesforce.multicloudj.common.util.common.TestsUtil;
+import com.salesforce.multicloudj.sts.gcp.GcpSts;
+import com.salesforce.multicloudj.sts.model.AssumeRoleWebIdentityRequest;
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * Fault-injection integration test for the STS circuit breaker on GCP. It drives a real
+ * {@link StsClient} — the layer that owns the breaker — against a hand-written WireMock stub that
+ * always returns a retryable HTTP 503 from the GCP STS token-exchange endpoint, so the breaker's
+ * open transition is observed end-to-end without touching a live GCP endpoint.
+ *
+ * <p>GCP's token endpoint URL is fixed in the driver, so the request is redirected by injecting a
+ * transport that proxies through WireMock (the same trust-all forward proxy the conformance suite
+ * uses); a stub then intercepts the proxied {@code POST /v1/token}. The breaker-carrying client is
+ * assembled through the package-visible {@link StsClient} constructor (this test deliberately lives
+ * in the {@code sts.client} package) because the public builder cannot inject a test transport.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class GcpStsCircuitBreakerIT {
+
+  private static final int PORT = ThreadLocalRandom.current().nextInt(20000, 40000);
+  private static final int HTTP_PORT = PORT + 1;
+
+  private static final String WEB_IDENTITY_ROLE =
+      "//iam.googleapis.com/projects/test-project/locations/global"
+          + "/workloadIdentityPools/test-pool/providers/test-provider";
+
+  @BeforeAll
+  public void setUp() {
+    TestsUtil.startWireMockServer("src/test/resources", PORT);
+    configureFor(TestsUtil.WIREMOCK_HOST, HTTP_PORT);
+    // The token-exchange endpoint always responds 503 — a transient failure the breaker must count.
+    stubFor(
+        post(urlPathEqualTo("/v1/token"))
+            .willReturn(
+                aResponse()
+                    .withStatus(503)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"error\":\"unavailable\"}")));
+  }
+
+  @AfterAll
+  public void tearDown() {
+    TestsUtil.stopWireMockServer();
+  }
+
+  private static StsClient breakerClient() {
+    HttpTransport transport = TestsUtilGcp.getHttpTransport(PORT);
+    HttpTransportFactory factory = () -> transport;
+    GcpSts gcpSts =
+        new GcpSts().builder().build(MockGoogleCredentialsFactory.createMockCredentials(), factory);
+
+    CircuitBreakerConfig config =
+        CircuitBreakerConfig.builder()
+            .withFailureRateThreshold(50f)
+            .withMinimumNumberOfCalls(3)
+            .withSlidingWindowSize(60)
+            .withSlowCallRateThreshold(100f) // never trip on slowness, only on failures
+            .withWaitDurationInOpenState(Duration.ofSeconds(30))
+            .withPermittedNumberOfCallsInHalfOpenState(1)
+            .build();
+
+    return new StsClient(gcpSts, new CircuitBreakerExecutor("sts-it", config));
+  }
+
+  @Test
+  public void breakerOpensAfterRepeatedRetryableFailures() {
+    StsClient client = breakerClient();
+
+    int retryableFailures = 0;
+    boolean breakerOpened = false;
+
+    for (int i = 0; i < 10 && !breakerOpened; i++) {
+      // A distinct subject token per call keeps every request a cache miss that hits the endpoint.
+      AssumeRoleWebIdentityRequest request =
+          AssumeRoleWebIdentityRequest.builder()
+              .role(WEB_IDENTITY_ROLE)
+              .webIdentityToken("oidc-token-" + i)
+              .sessionName("fault-injection")
+              .build();
+      try {
+        client.getAssumeRoleWithWebIdentityCredentials(request);
+        Assertions.fail("Expected the stubbed 503 to surface as an exception");
+      } catch (CircuitBreakerOpenException open) {
+        breakerOpened = true;
+        Assertions.assertFalse(
+            open.isRetryable(), "CircuitBreakerOpenException must be non-retryable");
+      } catch (SubstrateSdkException e) {
+        // The provider failure that feeds the breaker must itself be retryable, or it would never
+        // count toward opening.
+        Assertions.assertTrue(
+            e.isRetryable(), "A 503 from the token endpoint must map to a retryable exception");
+        retryableFailures++;
+      }
+    }
+
+    Assertions.assertTrue(
+        retryableFailures >= 3, "expected at least the minimum number of recorded failures");
+    Assertions.assertTrue(breakerOpened, "circuit breaker never opened after repeated 503s");
+  }
+}

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/client/GcpStsCircuitBreakerIT.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/client/GcpStsCircuitBreakerIT.java
@@ -1,6 +1,8 @@
 package com.salesforce.multicloudj.sts.client;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -54,11 +56,18 @@ public class GcpStsCircuitBreakerIT {
     // The token-exchange endpoint always responds 503 — a transient failure the breaker must count.
     stubFor(
         post(urlPathEqualTo("/v1/token"))
+            .atPriority(1)
             .willReturn(
                 aResponse()
                     .withStatus(503)
                     .withHeader("Content-Type", "application/json")
                     .withBody("{\"error\":\"unavailable\"}")));
+    // Browser proxying is on, so an unexpected request would otherwise be forwarded to the real
+    // endpoint and hang in a no-egress environment. This catch-all keeps every request local.
+    stubFor(
+        any(anyUrl())
+            .atPriority(10)
+            .willReturn(aResponse().withStatus(503).withBody("{\"error\":\"unavailable\"}")));
   }
 
   @AfterAll

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsTest.java
@@ -322,6 +322,107 @@ public class GcpStsTest {
     Assertions.assertEquals("test-access-token", credentials.getSecurityToken());
   }
 
+  /**
+   * Builds a {@link GcpSts} whose token-exchange endpoint returns the given HTTP status, so the
+   * web-identity path exercises the real {@code mapIoException} translation of an
+   * {@link com.google.api.client.http.HttpResponseException}.
+   */
+  private static GcpSts stsReturningStatus(int statusCode) {
+    MockHttpTransport transport =
+        new MockHttpTransport() {
+          @Override
+          public MockLowLevelHttpRequest buildRequest(String method, String url) {
+            return new MockLowLevelHttpRequest() {
+              @Override
+              public MockLowLevelHttpResponse execute() {
+                MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+                response.setStatusCode(statusCode);
+                response.setContentType("application/json");
+                response.setContent("{\"error\":\"simulated\"}");
+                return response;
+              }
+            };
+          }
+        };
+    return new GcpSts().builder().build((HttpTransportFactory) () -> transport);
+  }
+
+  private static AssumeRoleWebIdentityRequest webIdentityRequest() {
+    return AssumeRoleWebIdentityRequest.builder()
+        .role(
+            "//iam.googleapis.com/projects/test-project/locations/global"
+            + "/workloadIdentityPools/test-pool/providers/test-provider")
+        .webIdentityToken("test-oidc-token")
+        .sessionName("test-session")
+        .build();
+  }
+
+  @Test
+  public void testWebIdentityTooManyRequestsMapsToRetryableResourceExhausted() {
+    GcpSts sts = stsReturningStatus(429);
+    AssumeRoleWebIdentityRequest req = webIdentityRequest();
+    ResourceExhaustedException e =
+        Assertions.assertThrows(
+            ResourceExhaustedException.class, () -> sts.assumeRoleWithWebIdentity(req));
+    Assertions.assertTrue(e.isRetryable());
+  }
+
+  @Test
+  public void testWebIdentityServerErrorMapsToRetryableUnknown() {
+    GcpSts sts = stsReturningStatus(503);
+    AssumeRoleWebIdentityRequest req = webIdentityRequest();
+    UnknownException e =
+        Assertions.assertThrows(
+            UnknownException.class, () -> sts.assumeRoleWithWebIdentity(req));
+    Assertions.assertTrue(e.isRetryable());
+  }
+
+  @Test
+  public void testWebIdentityRequestTimeoutMapsToRetryableUnknown() {
+    GcpSts sts = stsReturningStatus(408);
+    AssumeRoleWebIdentityRequest req = webIdentityRequest();
+    UnknownException e =
+        Assertions.assertThrows(
+            UnknownException.class, () -> sts.assumeRoleWithWebIdentity(req));
+    Assertions.assertTrue(e.isRetryable());
+  }
+
+  @Test
+  public void testWebIdentityClientErrorMapsToNonRetryableException() {
+    GcpSts sts = stsReturningStatus(400);
+    AssumeRoleWebIdentityRequest req = webIdentityRequest();
+    SubstrateSdkException e =
+        Assertions.assertThrows(
+            SubstrateSdkException.class, () -> sts.assumeRoleWithWebIdentity(req));
+    // A plain 4xx (bad request, unauthorized, not found) is a caller error; never trips breaker.
+    Assertions.assertFalse(e.isRetryable());
+    // Guard against a retryable subclass slipping through: it must be the base type.
+    Assertions.assertEquals(SubstrateSdkException.class, e.getClass());
+  }
+
+  @Test
+  public void testWebIdentityTransportFailureMapsToRetryableUnknown() {
+    // No HTTP status at all — a connection reset / timeout surfaces as a bare IOException.
+    MockHttpTransport transport =
+        new MockHttpTransport() {
+          @Override
+          public MockLowLevelHttpRequest buildRequest(String method, String url) {
+            return new MockLowLevelHttpRequest() {
+              @Override
+              public MockLowLevelHttpResponse execute() throws IOException {
+                throw new IOException("connection reset");
+              }
+            };
+          }
+        };
+    GcpSts sts = new GcpSts().builder().build((HttpTransportFactory) () -> transport);
+    AssumeRoleWebIdentityRequest req = webIdentityRequest();
+    UnknownException e =
+        Assertions.assertThrows(
+            UnknownException.class, () -> sts.assumeRoleWithWebIdentity(req));
+    Assertions.assertTrue(e.isRetryable());
+  }
+
   @Test
   public void testAssumedRoleStsWithCredentialScopeConversion() throws Exception {
     GcpSts sts = new GcpSts().builder().build(mockGoogleCredentials);

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsTest.java
@@ -1,5 +1,7 @@
 package com.salesforce.multicloudj.sts.gcp;
 
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
@@ -32,14 +34,24 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 public class GcpStsTest {
+
+  /** A mock id-token JWT whose {@code exp} claim (9999999999) is far in the future. */
+  private static final String MOCK_JWT =
+      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9"
+          + ".eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiJtb2NrLXVzZ"
+          + "XIiLCJhdWQiOiJtdWx0aWNsb3VkaiIsImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxMjM0NTY3ODkwfQ"
+          + ".mock-signature";
 
   private static GoogleCredentials mockGoogleCredentials;
   private static GoogleCredentials mockGoogleCredentialsWithIdToken;
@@ -56,12 +68,7 @@ public class GcpStsTest {
     AccessToken mockAccessToken = Mockito.mock(AccessToken.class);
 
     // Create a real IdToken instead of mocking it
-    String mockJwt =
-        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9"
-            + ".eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiJtb2NrLXVzZ"
-            + "XIiLCJhdWQiOiJtdWx0aWNsb3VkaiIsImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxMjM0NTY3ODkwfQ"
-            + ".mock-signature";
-    IdToken mockIdToken = IdToken.create(mockJwt);
+    IdToken mockIdToken = IdToken.create(MOCK_JWT);
 
     Mockito.when(mockGoogleCredentials.createScoped(Mockito.any(Collection.class)))
         .thenReturn(mockGoogleCredentials);
@@ -421,6 +428,139 @@ public class GcpStsTest {
         Assertions.assertThrows(
             UnknownException.class, () -> sts.assumeRoleWithWebIdentity(req));
     Assertions.assertTrue(e.isRetryable());
+  }
+
+  @Test
+  public void testAccessTokenTooManyRequestsMapsToRetryableResourceExhausted() throws IOException {
+    // A 429 raised on a non-web-identity path (the credential refresh) must map the same way the
+    // web-identity path does: a retryable ResourceExhaustedException that can trip the breaker.
+    GoogleCredentials creds = Mockito.mock(GoogleCredentials.class);
+    Mockito.doThrow(
+            new HttpResponseException.Builder(429, "Too Many Requests", new HttpHeaders()).build())
+        .when(creds)
+        .refreshIfExpired();
+
+    GcpSts sts = new GcpSts().builder().build(creds);
+    ResourceExhaustedException e =
+        Assertions.assertThrows(
+            ResourceExhaustedException.class,
+            () ->
+                sts.getAccessToken(
+                    GetAccessTokenRequest.newBuilder().withDurationSeconds(60).build()));
+    Assertions.assertTrue(e.isRetryable());
+  }
+
+  @Test
+  public void testAdcFailureMapsToRetryableUnknown() {
+    // Off Compute Engine the driver resolves application-default credentials; a transport-level
+    // failure there must surface as a retryable UnknownException (no HTTP status → transient), not
+    // a bare non-retryable SubstrateSdkException. On K8s the code takes the ComputeEngine branch
+    // instead, so this assertion only holds off-cluster.
+    Assumptions.assumeTrue(System.getenv("KUBERNETES_SERVICE_HOST") == null);
+    try (MockedStatic<GoogleCredentials> mockedGoogleCreds =
+        Mockito.mockStatic(GoogleCredentials.class)) {
+      mockedGoogleCreds
+          .when(GoogleCredentials::getApplicationDefault)
+          .thenThrow(new IOException("no application default credentials"));
+
+      GcpSts sts = new GcpSts().builder().build();
+      UnknownException e =
+          Assertions.assertThrows(
+              UnknownException.class,
+              () ->
+                  sts.getAccessToken(
+                      GetAccessTokenRequest.newBuilder().withDurationSeconds(60).build()));
+      Assertions.assertTrue(
+          e.isRetryable(),
+          "A transport-level ADC failure must be retryable so a persistently unhealthy"
+              + " environment can trip the breaker");
+    }
+  }
+
+  @Test
+  public void testAssumeRoleCachesTokenAcrossCalls() throws IOException {
+    // Two identical assume-role requests must collapse to a single credential fetch: the second
+    // call is served from the cache, so the underlying token retrieval runs exactly once.
+    GoogleCredentials creds = Mockito.mock(GoogleCredentials.class);
+    Mockito.doNothing().when(creds).refreshIfExpired();
+    Mockito.when(creds.getAccessToken()).thenReturn(new AccessToken("assume-tok", futureDate()));
+
+    GcpSts sts = new GcpSts().builder().build(creds);
+    AssumedRoleRequest request =
+        AssumedRoleRequest.newBuilder().withSessionName("testSession").build();
+
+    Assertions.assertEquals("assume-tok", sts.assumeRole(request).getSecurityToken());
+    Assertions.assertEquals("assume-tok", sts.assumeRole(request).getSecurityToken());
+    Mockito.verify(creds, Mockito.times(1)).getAccessToken();
+  }
+
+  @Test
+  public void testGetAccessTokenCachesTokenAcrossCalls() throws IOException {
+    GoogleCredentials creds = Mockito.mock(GoogleCredentials.class);
+    Mockito.doNothing().when(creds).refreshIfExpired();
+    Mockito.when(creds.getAccessToken()).thenReturn(new AccessToken("access-tok", futureDate()));
+
+    GcpSts sts = new GcpSts().builder().build(creds);
+    GetAccessTokenRequest request =
+        GetAccessTokenRequest.newBuilder().withDurationSeconds(60).build();
+
+    Assertions.assertEquals("access-tok", sts.getAccessToken(request).getSecurityToken());
+    Assertions.assertEquals("access-tok", sts.getAccessToken(request).getSecurityToken());
+    Mockito.verify(creds, Mockito.times(1)).getAccessToken();
+  }
+
+  @Test
+  public void testCallerIdentityCachesTokenAcrossCalls() throws IOException {
+    GoogleCredentials creds =
+        Mockito.mock(
+            GoogleCredentials.class, Mockito.withSettings().extraInterfaces(IdTokenProvider.class));
+    Mockito.doNothing().when(creds).refreshIfExpired();
+    Mockito.when(
+            ((IdTokenProvider) creds).idTokenWithAudience(Mockito.anyString(), Mockito.any()))
+        .thenReturn(IdToken.create(MOCK_JWT));
+
+    GcpSts sts = new GcpSts().builder().build(creds);
+    GetCallerIdentityRequest request = GetCallerIdentityRequest.builder().build();
+
+    sts.getCallerIdentity(request);
+    sts.getCallerIdentity(request);
+    Mockito.verify((IdTokenProvider) creds, Mockito.times(1))
+        .idTokenWithAudience(Mockito.anyString(), Mockito.any());
+  }
+
+  @Test
+  public void testWebIdentityCachesTokenAcrossCalls() {
+    // The token-exchange endpoint must be hit once for two identical requests; the second is a hit.
+    AtomicInteger exchangeCalls = new AtomicInteger();
+    MockHttpTransport transport =
+        new MockHttpTransport() {
+          @Override
+          public MockLowLevelHttpRequest buildRequest(String method, String url) {
+            return new MockLowLevelHttpRequest() {
+              @Override
+              public MockLowLevelHttpResponse execute() {
+                exchangeCalls.incrementAndGet();
+                MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+                response.setStatusCode(200);
+                response.setContentType("application/json");
+                response.setContent("{\"access_token\":\"web-tok\",\"expires_in\":3600}");
+                return response;
+              }
+            };
+          }
+        };
+
+    GcpSts sts = new GcpSts().builder().build((HttpTransportFactory) () -> transport);
+    AssumeRoleWebIdentityRequest request = webIdentityRequest();
+
+    Assertions.assertEquals("web-tok", sts.assumeRoleWithWebIdentity(request).getSecurityToken());
+    Assertions.assertEquals("web-tok", sts.assumeRoleWithWebIdentity(request).getSecurityToken());
+    Assertions.assertEquals(1, exchangeCalls.get());
+  }
+
+  /** A token expiry an hour out, so the cache keeps the entry rather than evicting it at once. */
+  private static Date futureDate() {
+    return new Date(System.currentTimeMillis() + 3_600_000L);
   }
 
   @Test

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsTokenCacheTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsTokenCacheTest.java
@@ -1,0 +1,259 @@
+package com.salesforce.multicloudj.sts.gcp;
+
+import com.github.benmanes.caffeine.cache.Ticker;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link GcpStsTokenCache}. Time is driven by a manual {@link Clock} and
+ * {@link Ticker} that advance in lockstep, so expiry is deterministic without real waits.
+ */
+class GcpStsTokenCacheTest {
+
+  private static final Duration SKEW = Duration.ofSeconds(60);
+  private static final long MAX_SIZE = 1000L;
+
+  /** A clock and ticker backed by a single mutable nanosecond counter, advanced by tests. */
+  private static final class ManualTime {
+    private final Instant base = Instant.parse("2026-01-01T00:00:00Z");
+    private long elapsedNanos = 0L;
+
+    Clock clock() {
+      return new Clock() {
+        @Override
+        public Instant instant() {
+          return base.plusNanos(elapsedNanos);
+        }
+
+        @Override
+        public ZoneId getZone() {
+          return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+          return this;
+        }
+      };
+    }
+
+    Ticker ticker() {
+      return () -> elapsedNanos;
+    }
+
+    void advance(Duration duration) {
+      elapsedNanos += duration.toNanos();
+    }
+  }
+
+  private GcpStsTokenCache newCache(boolean enabled, ManualTime time) {
+    return new GcpStsTokenCache(enabled, MAX_SIZE, SKEW, time.clock(), time.ticker());
+  }
+
+  @Test
+  void hitWithinTtl_loadsOnce() throws IOException {
+    ManualTime time = new ManualTime();
+    GcpStsTokenCache cache = newCache(true, time);
+    AtomicInteger loads = new AtomicInteger();
+    TokenCacheKey key = TokenCacheKey.forAccessToken("scope");
+    GcpStsTokenCache.TokenLoader loader =
+        () -> {
+          loads.incrementAndGet();
+          return new CachedToken("token", time.clock().instant().plus(Duration.ofMinutes(10)));
+        };
+
+    String first = cache.getToken(key, loader);
+    time.advance(Duration.ofMinutes(5));
+    String second = cache.getToken(key, loader);
+
+    Assertions.assertEquals("token", first);
+    Assertions.assertEquals("token", second);
+    Assertions.assertEquals(1, loads.get(), "second call within TTL must not reload");
+  }
+
+  @Test
+  void expiresAfterLifetimeMinusSkew() throws IOException {
+    ManualTime time = new ManualTime();
+    GcpStsTokenCache cache = newCache(true, time);
+    AtomicInteger loads = new AtomicInteger();
+    TokenCacheKey key = TokenCacheKey.forAccessToken("scope");
+    // 5-minute lifetime, 60s skew => effective TTL of 4 minutes.
+    GcpStsTokenCache.TokenLoader loader =
+        () ->
+            new CachedToken(
+                "token-" + loads.incrementAndGet(),
+                time.clock().instant().plus(Duration.ofMinutes(5)));
+
+    Assertions.assertEquals("token-1", cache.getToken(key, loader));
+
+    // Just before the skew-adjusted deadline: still cached.
+    time.advance(Duration.ofSeconds(239));
+    Assertions.assertEquals("token-1", cache.getToken(key, loader));
+    Assertions.assertEquals(1, loads.get());
+
+    // Past the skew-adjusted deadline: reloaded.
+    time.advance(Duration.ofSeconds(2));
+    Assertions.assertEquals("token-2", cache.getToken(key, loader));
+    Assertions.assertEquals(2, loads.get());
+  }
+
+  @Test
+  void keysAreIsolatedAcrossPaths() throws IOException {
+    ManualTime time = new ManualTime();
+    GcpStsTokenCache cache = newCache(true, time);
+    AtomicInteger loads = new AtomicInteger();
+    GcpStsTokenCache.TokenLoader loader =
+        () ->
+            new CachedToken(
+                "token-" + loads.incrementAndGet(),
+                time.clock().instant().plus(Duration.ofMinutes(10)));
+
+    List<TokenCacheKey> keys =
+        List.of(
+            TokenCacheKey.forAssumeRole("role", 3600, "scopeHash"),
+            TokenCacheKey.forAccessToken("scope"),
+            TokenCacheKey.forCallerIdentity("aud"),
+            TokenCacheKey.forWebIdentity("audience", "tokenHash"));
+
+    for (TokenCacheKey key : keys) {
+      cache.getToken(key, loader);
+    }
+    // Re-fetching each key must hit the cache, not reload.
+    for (TokenCacheKey key : keys) {
+      cache.getToken(key, loader);
+    }
+
+    Assertions.assertEquals(4, loads.get(), "each distinct path key loads exactly once");
+  }
+
+  @Test
+  void distinctKeyInputsDoNotCollide() throws IOException {
+    ManualTime time = new ManualTime();
+    GcpStsTokenCache cache = newCache(true, time);
+    AtomicInteger loads = new AtomicInteger();
+    GcpStsTokenCache.TokenLoader loader =
+        () ->
+            new CachedToken(
+                "token-" + loads.incrementAndGet(),
+                time.clock().instant().plus(Duration.ofMinutes(10)));
+
+    cache.getToken(TokenCacheKey.forAssumeRole("roleA", 3600, "hash"), loader);
+    cache.getToken(TokenCacheKey.forAssumeRole("roleB", 3600, "hash"), loader);
+    cache.getToken(TokenCacheKey.forAssumeRole("roleA", 7200, "hash"), loader);
+    cache.getToken(TokenCacheKey.forAssumeRole("roleA", 3600, "otherHash"), loader);
+
+    Assertions.assertEquals(4, loads.get(), "role, lifetime, and boundary each vary the key");
+  }
+
+  @Test
+  void concurrentMissesCollapseToSingleLoad() throws Exception {
+    ManualTime time = new ManualTime();
+    GcpStsTokenCache cache = newCache(true, time);
+    AtomicInteger loads = new AtomicInteger();
+    TokenCacheKey key = TokenCacheKey.forAccessToken("scope");
+    CountDownLatch release = new CountDownLatch(1);
+    GcpStsTokenCache.TokenLoader loader =
+        () -> {
+          loads.incrementAndGet();
+          try {
+            release.await(5, TimeUnit.SECONDS);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          return new CachedToken("token", time.clock().instant().plus(Duration.ofMinutes(10)));
+        };
+
+    int threads = 8;
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    try {
+      List<Future<String>> futures = new ArrayList<>();
+      for (int i = 0; i < threads; i++) {
+        futures.add(pool.submit(() -> cache.getToken(key, loader)));
+      }
+      release.countDown();
+      for (Future<String> future : futures) {
+        Assertions.assertEquals("token", future.get(5, TimeUnit.SECONDS));
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+
+    Assertions.assertEquals(1, loads.get(), "concurrent identical misses must load once");
+  }
+
+  @Test
+  void failedLoadsAreNotCached() throws IOException {
+    ManualTime time = new ManualTime();
+    GcpStsTokenCache cache = newCache(true, time);
+    TokenCacheKey key = TokenCacheKey.forAccessToken("scope");
+
+    GcpStsTokenCache.TokenLoader failing =
+        () -> {
+          throw new IOException("boom");
+        };
+    Assertions.assertThrows(IOException.class, () -> cache.getToken(key, failing));
+
+    // A subsequent successful load for the same key must proceed (nothing was cached).
+    String value =
+        cache.getToken(
+            key,
+            () -> new CachedToken("token", time.clock().instant().plus(Duration.ofMinutes(10))));
+    Assertions.assertEquals("token", value);
+  }
+
+  @Test
+  void unknownExpiryIsNotReused() throws IOException {
+    ManualTime time = new ManualTime();
+    GcpStsTokenCache cache = newCache(true, time);
+    AtomicInteger loads = new AtomicInteger();
+    TokenCacheKey key = TokenCacheKey.forWebIdentity("audience", "tokenHash");
+    GcpStsTokenCache.TokenLoader loader =
+        () -> new CachedToken("token-" + loads.incrementAndGet(), null);
+
+    Assertions.assertEquals("token-1", cache.getToken(key, loader));
+    // null expiry => TTL 0 => the entry is never reused.
+    Assertions.assertEquals("token-2", cache.getToken(key, loader));
+    Assertions.assertEquals(2, loads.get());
+  }
+
+  @Test
+  void disabledCacheAlwaysInvokesLoader() throws IOException {
+    ManualTime time = new ManualTime();
+    GcpStsTokenCache cache = newCache(false, time);
+    AtomicInteger loads = new AtomicInteger();
+    TokenCacheKey key = TokenCacheKey.forAccessToken("scope");
+    GcpStsTokenCache.TokenLoader loader =
+        () ->
+            new CachedToken(
+                "token-" + loads.incrementAndGet(),
+                time.clock().instant().plus(Duration.ofMinutes(10)));
+
+    cache.getToken(key, loader);
+    cache.getToken(key, loader);
+
+    Assertions.assertEquals(2, loads.get(), "disabled cache never caches");
+  }
+
+  @Test
+  void nowReflectsInjectedClock() {
+    ManualTime time = new ManualTime();
+    GcpStsTokenCache cache = newCache(true, time);
+    Instant before = cache.now();
+    time.advance(Duration.ofSeconds(30));
+    Assertions.assertEquals(before.plusSeconds(30), cache.now());
+  }
+}

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/TokenCacheKeyTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/TokenCacheKeyTest.java
@@ -1,0 +1,84 @@
+package com.salesforce.multicloudj.sts.gcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the equality contract of {@link TokenCacheKey}: keys are equal iff every qualifying
+ * input matches, are never equal across paths, and treat a {@code null} input the same as an empty
+ * string so a cached entry is only ever returned for an identical request.
+ */
+class TokenCacheKeyTest {
+
+  @Test
+  void sameInputs_areEqualAndShareHashCode() {
+    TokenCacheKey a = TokenCacheKey.forAssumeRole("role", 3600L, "scopeHash");
+    TokenCacheKey b = TokenCacheKey.forAssumeRole("role", 3600L, "scopeHash");
+
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  void sameKey_isEqualToItself() {
+    TokenCacheKey key = TokenCacheKey.forAccessToken("scope");
+    assertEquals(key, key);
+  }
+
+  @Test
+  void differentType_isNotEqual() {
+    TokenCacheKey key = TokenCacheKey.forAccessToken("scope");
+    assertNotEquals(key, "scope");
+    assertNotEquals(key, null);
+  }
+
+  @Test
+  void keysAreNeverEqualAcrossPaths() {
+    // Same primary value, different path: must not collide.
+    TokenCacheKey accessToken = TokenCacheKey.forAccessToken("value");
+    TokenCacheKey callerIdentity = TokenCacheKey.forCallerIdentity("value");
+
+    assertNotEquals(accessToken, callerIdentity);
+  }
+
+  @Test
+  void assumeRole_distinguishesEveryInput() {
+    TokenCacheKey base = TokenCacheKey.forAssumeRole("role", 3600L, "scopeHash");
+
+    assertNotEquals(base, TokenCacheKey.forAssumeRole("other-role", 3600L, "scopeHash"));
+    assertNotEquals(base, TokenCacheKey.forAssumeRole("role", 7200L, "scopeHash"));
+    assertNotEquals(base, TokenCacheKey.forAssumeRole("role", 3600L, "other-scopeHash"));
+  }
+
+  @Test
+  void webIdentity_distinguishesAudienceAndTokenHash() {
+    TokenCacheKey base = TokenCacheKey.forWebIdentity("aud", "tokenHash");
+
+    assertNotEquals(base, TokenCacheKey.forWebIdentity("other-aud", "tokenHash"));
+    assertNotEquals(base, TokenCacheKey.forWebIdentity("aud", "other-tokenHash"));
+  }
+
+  @Test
+  void nullInputsAreTreatedAsEmpty() {
+    // A null and an empty string for the same field produce the same key.
+    assertEquals(TokenCacheKey.forAccessToken(null), TokenCacheKey.forAccessToken(""));
+    assertEquals(TokenCacheKey.forCallerIdentity(null), TokenCacheKey.forCallerIdentity(""));
+    assertEquals(
+        TokenCacheKey.forAssumeRole(null, 0L, null), TokenCacheKey.forAssumeRole("", 0L, ""));
+    assertEquals(
+        TokenCacheKey.forWebIdentity(null, null), TokenCacheKey.forWebIdentity("", ""));
+  }
+
+  @Test
+  void toString_rendersPathAndInputs() {
+    String rendered = TokenCacheKey.forAssumeRole("role", 3600L, "scopeHash").toString();
+
+    assertTrue(rendered.contains("ASSUME_ROLE"));
+    assertTrue(rendered.contains("role"));
+    assertTrue(rendered.contains("scopeHash"));
+    assertTrue(rendered.contains("3600"));
+  }
+}


### PR DESCRIPTION
## Summary
Adds an **optional, opt-in circuit breaker** guarding every STS provider call, plus a **provider-local, expiry-aware token cache for GCP STS**. Both are additive: when no circuit-breaker config is supplied the client behaves byte-for-byte as before, and the GCP cache is transparent to callers.


## Changes

### Circuit breaker (cloud-agnostic)
- New `multicloudj-common` circuit-breaker package built on resilience4j 2.4.0 (compile scope):
  - `CircuitBreakerConfig` — substrate-agnostic builder (failure-rate / slow-call / sliding-window / wait-duration / half-open knobs); maps to a resilience4j config with an injectable `java.time.Clock` and a `recordException` predicate that counts **only retryable `SubstrateSdkException`s** as failures.
  - `CircuitBreakerExecutor` — wraps a single standalone `CircuitBreaker.of(...)` (no shared registry); translates resilience4j's `CallNotPermittedException` into a non-retryable `CircuitBreakerOpenException`.
  - `CircuitBreakerOpenException extends SubstrateSdkException` (non-retryable).
- `sts-client`: `StsClient.StsBuilder.withCircuitBreakerConfig(...)`; a single private `call(Supplier)` seam runs the provider call **and** its exception mapping inside the guarded supplier, so the breaker observes the mapped `SubstrateSdkException`. `executor == null` ⇒ direct invocation (no behavior change). `StsClient`/`AbstractSts` now `AutoCloseable`.

### GCP STS token cache
- Provider-local, expiry-aware token cache covering the GcpSts paths (impersonation/downscoping, `getAccessToken`/compute, caller-identity id-token, web-identity token-exchange), keyed by request identity/target principal/scopes/lifetime so a request never receives a token minted for a different scope. GCP-only — no AWS/Ali cache.

## Testing
- `multicloudj-common`: `CircuitBreakerExecutorTest` — 7 deterministic lifecycle tests via an injected `Clock` (closed → open → half-open recovery/reopen; open short-circuits without invoking the op; non-retryable failures never open; open exception is non-retryable).
- `sts-client`: `StsClientTest` — added breaker-through-the-client tests (opens after retryable failures, non-retryable failures never open, and without-breaker parity).
- Full reactor `mvn clean install`: **BUILD SUCCESS**, all modules green, checkstyle clean.

## Cross-Cloud Compatibility
- **AWS**: no production change — participates via the shared cloud-agnostic breaker at the `StsClient` level.
- **GCP**: circuit breaker (shared) + provider-local token cache.
- **Alibaba**: no production change — participates via the shared cloud-agnostic breaker.
