### PR TITLE
sts: add STS verifier for AWS, GCP, and Alibaba

### DIFF
--- a/examples/src/main/java/com/salesforce/multicloudj/sts/CloudNativeAuth.java
+++ b/examples/src/main/java/com/salesforce/multicloudj/sts/CloudNativeAuth.java
@@ -35,7 +35,7 @@ import java.util.Map;
  */
 public class CloudNativeAuth {
 
-  private static final String PROVIDER = "aws";
+  private static final String PROVIDER = "gcp";
   private static final String REGION = "us-east-2";
 
   public static void main(String[] args) {
@@ -44,8 +44,7 @@ public class CloudNativeAuth {
     customHeaders.put("x-request-source", "cloud-native-auth-example");
     customHeaders.put("x-tenant-id", "tenant-42");
 
-    // ── Sign (client side) ──────────────────────────────────────────────
-    //
+    // Sign (client side)
     // StsUtilities produces a portable signedIdentity from the caller's own cloud credentials.
     StsUtilities signer = StsUtilities.builder(PROVIDER).withRegion(REGION).build();
 
@@ -58,8 +57,7 @@ public class CloudNativeAuth {
     System.out.println("Signed auth request created successfully");
     System.out.println("  SignedIdentity: " + preview(signedIdentity));
 
-    // ── Validate (server side) ──────────────────────────────────────────
-    //
+    // Validate (server side)
     // StsVerifier proves the signedIdentity and returns who the caller is.
     StsVerifier verifier = StsVerifier.builder(PROVIDER).withRegion(REGION).build();
 

--- a/examples/src/main/java/com/salesforce/multicloudj/sts/CloudNativeAuth.java
+++ b/examples/src/main/java/com/salesforce/multicloudj/sts/CloudNativeAuth.java
@@ -1,0 +1,85 @@
+package com.salesforce.multicloudj.sts;
+
+import com.salesforce.multicloudj.sts.client.StsUtilities;
+import com.salesforce.multicloudj.sts.client.StsVerifier;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.SignOptions;
+import com.salesforce.multicloudj.sts.model.SignedAuthRequest;
+import com.salesforce.multicloudj.sts.model.ValidateOptions;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * End-to-end Cloud Native Auth (CNA) example.
+ *
+ * <p>CNA lets a workload prove <em>its own</em> cloud identity to another service without any
+ * shared secret. The flow has two halves:
+ *
+ * <ol>
+ *   <li><b>Sign</b> (client side): {@link StsUtilities} signs the caller's cloud credentials into a
+ *       portable, self-contained {@code signedIdentity} string. The client sends this string to the
+ *       server as its proof of identity.
+ *   <li><b>Validate</b> (server side): {@link StsVerifier} takes the {@code signedIdentity},
+ *       proves it against the substrate, and returns the verified {@link CallerIdentity} — the
+ *       caller's cloud resource name, user id, and account.
+ * </ol>
+ *
+ * <p>Optional custom headers are signed by the client and asserted by the verifier, so the server
+ * can bind additional context (a request source, a tenant id, a federation target, ...) into the
+ * signed proof and reject anything that does not match.
+ *
+ * <p>Run this against real credentials for {@code PROVIDER}/{@code REGION}. For {@code aws} the
+ * verifier replays the presigned {@code GetCallerIdentity} request against AWS STS; the default
+ * credential chain must resolve. Custom header names are lowercase because AWS SigV4 signs
+ * canonical (lowercase) header names.
+ */
+public class CloudNativeAuth {
+
+  private static final String PROVIDER = "aws";
+  private static final String REGION = "us-east-2";
+
+  public static void main(String[] args) {
+    // Custom headers the client signs into its identity and the server asserts on validation.
+    Map<String, String> customHeaders = new LinkedHashMap<>();
+    customHeaders.put("x-request-source", "cloud-native-auth-example");
+    customHeaders.put("x-tenant-id", "tenant-42");
+
+    // ── Sign (client side) ──────────────────────────────────────────────
+    //
+    // StsUtilities produces a portable signedIdentity from the caller's own cloud credentials.
+    StsUtilities signer = StsUtilities.builder(PROVIDER).withRegion(REGION).build();
+
+    SignOptions signOptions = SignOptions.builder().withCustomHeaders(customHeaders).build();
+
+    // No service request to hash here, so a bare identity assertion is signed.
+    SignedAuthRequest signed = signer.newCloudNativeAuthSignedRequest(null, signOptions);
+    String signedIdentity = signed.getSignedIdentity();
+
+    System.out.println("Signed auth request created successfully");
+    System.out.println("  SignedIdentity: " + preview(signedIdentity));
+
+    // ── Validate (server side) ──────────────────────────────────────────
+    //
+    // StsVerifier proves the signedIdentity and returns who the caller is.
+    StsVerifier verifier = StsVerifier.builder(PROVIDER).withRegion(REGION).build();
+
+    ValidateOptions validateOptions =
+        ValidateOptions.builder().withExpectedCustomHeaders(customHeaders).build();
+
+    CallerIdentity identity = verifier.validateSignedAuthRequest(signedIdentity, validateOptions);
+
+    System.out.println();
+    System.out.println("Validation succeeded");
+    System.out.println("  CloudResourceName: " + identity.getCloudResourceName());
+    System.out.println("  UserId           : " + identity.getUserId());
+    System.out.println("  Account          : " + identity.getAccountId());
+  }
+
+  /** Shortens the signed identity for display; the full string can be several hundred bytes. */
+  private static String preview(String value) {
+    if (value == null) {
+      return "(none)";
+    }
+    return value.length() <= 50 ? value : value.substring(0, 50) + "...";
+  }
+}

--- a/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliStsUtilities.java
+++ b/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliStsUtilities.java
@@ -108,12 +108,18 @@ public class AliStsUtilities extends AbstractStsUtilities<AliStsUtilities> {
     }
 
     HttpRequest signed = builder.build();
+
+    // The signed request URL carries the action, version, every signed query parameter, and the
+    // computed signature, so it is a self-contained, replayable representation of the identity.
+    String signedIdentity = signedRequest.getSysUrl();
+
     return new SignedAuthRequest(
         signed,
         new StsCredentials(
             credentials.getAccessKeyId(),
             credentials.getAccessKeySecret(),
-            credentials.getSessionToken()));
+            credentials.getSessionToken()),
+        signedIdentity);
   }
 
   public static class Builder extends AbstractStsUtilities.Builder<AliStsUtilities> {

--- a/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliStsVerifier.java
+++ b/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliStsVerifier.java
@@ -1,0 +1,183 @@
+package com.salesforce.multicloudj.sts.ali;
+
+import com.google.auto.service.AutoService;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.salesforce.multicloudj.common.exceptions.ExceptionHandler;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.common.exceptions.UnknownException;
+import com.salesforce.multicloudj.sts.driver.AbstractStsVerifier;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.ValidateOptions;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Alibaba Cloud implementation of the STS verifier. It validates a signed identity by replaying the
+ * presigned {@code GetCallerIdentity} request against Alibaba Cloud STS and returning the caller
+ * identity parsed from the STS response.
+ *
+ * <p>The signed identity is a fully signed STS URL whose query string carries the action, version,
+ * every signed parameter, and the RPC signature. Alibaba Cloud RPC signatures cover the HTTP
+ * method, so the request is replayed with the same GET method used to sign it; STS then validates
+ * the signature and returns the identity of the credentials that produced it.
+ */
+@AutoService(AbstractStsVerifier.class)
+public class AliStsVerifier extends AbstractStsVerifier {
+  private final HttpClient httpClient;
+
+  public AliStsVerifier() {
+    this(new Builder());
+  }
+
+  public AliStsVerifier(Builder builder) {
+    super(builder);
+    this.httpClient = buildHttpClient(builder);
+  }
+
+  /** Constructor that accepts a preconfigured HTTP client, used by tests. */
+  public AliStsVerifier(Builder builder, HttpClient httpClient) {
+    super(builder);
+    this.httpClient = httpClient;
+  }
+
+  @Override
+  public Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  protected CallerIdentity validateSignedAuthRequest(
+      String signedIdentity, ValidateOptions options) {
+    if (signedIdentity == null || signedIdentity.isEmpty()) {
+      throw new InvalidArgumentException("signedIdentity cannot be empty");
+    }
+
+    URI identityUri = URI.create(signedIdentity);
+    Map<String, String> params = parseQuery(identityUri.getRawQuery());
+    verifyExpectedCustomHeaders(params, options);
+
+    HttpRequest request =
+        HttpRequest.newBuilder(identityUri).GET().build();
+    HttpResponse<String> response;
+    try {
+      response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    } catch (IOException e) {
+      throw new UnknownException("failed to replay STS request", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UnknownException("interrupted while replaying STS request", e);
+    }
+
+    if (response.statusCode() != 200) {
+      throw new UnAuthorizedException(
+          "STS returned HTTP " + response.statusCode() + ": " + response.body());
+    }
+
+    return parseCallerIdentity(response.body());
+  }
+
+  private static void verifyExpectedCustomHeaders(
+      Map<String, String> params, ValidateOptions options) {
+    if (options == null) {
+      return;
+    }
+    for (Map.Entry<String, String> expected : options.getExpectedCustomHeaders().entrySet()) {
+      String actual = params.get(expected.getKey());
+      if (actual == null) {
+        throw new InvalidArgumentException(
+            "expected custom header \"" + expected.getKey() + "\" not found in signed request");
+      }
+      if (!actual.equals(expected.getValue())) {
+        throw new InvalidArgumentException(
+            "custom header \"" + expected.getKey() + "\" has an unexpected value");
+      }
+    }
+  }
+
+  private static CallerIdentity parseCallerIdentity(String responseBody) {
+    try {
+      JsonObject json = JsonParser.parseString(responseBody).getAsJsonObject();
+      String accountId = optString(json, "AccountId");
+      String arn = optString(json, "Arn");
+      String userId = optString(json, "UserId");
+      if (accountId == null && arn == null && userId == null) {
+        throw new UnknownException("STS response did not contain a caller identity");
+      }
+      return new CallerIdentity(userId, arn, accountId);
+    } catch (SubstrateSdkException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new UnknownException("failed to parse STS response", e);
+    }
+  }
+
+  private static String optString(JsonObject json, String field) {
+    return json.has(field) && !json.get(field).isJsonNull() ? json.get(field).getAsString() : null;
+  }
+
+  private static Map<String, String> parseQuery(String rawQuery) {
+    Map<String, String> params = new LinkedHashMap<>();
+    if (rawQuery == null || rawQuery.isEmpty()) {
+      return params;
+    }
+    for (String pair : rawQuery.split("&")) {
+      int idx = pair.indexOf('=');
+      if (idx < 0) {
+        params.put(URLDecoder.decode(pair, StandardCharsets.UTF_8), "");
+        continue;
+      }
+      String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
+      String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
+      params.put(key, value);
+    }
+    return params;
+  }
+
+  private static HttpClient buildHttpClient(Builder builder) {
+    HttpClient.Builder clientBuilder = HttpClient.newBuilder();
+    if (builder.getProxyEndpoint() != null) {
+      URI proxy = builder.getProxyEndpoint();
+      clientBuilder.proxy(
+          ProxySelector.of(new InetSocketAddress(proxy.getHost(), proxy.getPort())));
+    }
+    return clientBuilder.build();
+  }
+
+  @Override
+  public SubstrateSdkException mapException(Throwable t) {
+    return ExceptionHandler.build(UnknownException.class, t);
+  }
+
+  public static class Builder extends AbstractStsVerifier.Builder<AliStsVerifier, Builder> {
+    protected Builder() {
+      providerId("ali");
+    }
+
+    @Override
+    public Builder self() {
+      return this;
+    }
+
+    /** Builds a verifier backed by the supplied HTTP client, used by tests. */
+    public AliStsVerifier build(HttpClient httpClient) {
+      return new AliStsVerifier(this, httpClient);
+    }
+
+    @Override
+    public AliStsVerifier build() {
+      return new AliStsVerifier(this);
+    }
+  }
+}

--- a/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliStsVerifier.java
+++ b/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliStsVerifier.java
@@ -12,8 +12,6 @@ import com.salesforce.multicloudj.sts.driver.AbstractStsVerifier;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.http.HttpClient;
@@ -43,7 +41,7 @@ public class AliStsVerifier extends AbstractStsVerifier {
 
   public AliStsVerifier(Builder builder) {
     super(builder);
-    this.httpClient = buildHttpClient(builder);
+    this.httpClient = HttpClient.newHttpClient();
   }
 
   /** Constructor that accepts a preconfigured HTTP client, used by tests. */
@@ -143,16 +141,6 @@ public class AliStsVerifier extends AbstractStsVerifier {
       params.put(key, value);
     }
     return params;
-  }
-
-  private static HttpClient buildHttpClient(Builder builder) {
-    HttpClient.Builder clientBuilder = HttpClient.newBuilder();
-    if (builder.getProxyEndpoint() != null) {
-      URI proxy = builder.getProxyEndpoint();
-      clientBuilder.proxy(
-          ProxySelector.of(new InetSocketAddress(proxy.getHost(), proxy.getPort())));
-    }
-    return clientBuilder.build();
   }
 
   @Override

--- a/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsVerifierTest.java
+++ b/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsVerifierTest.java
@@ -1,0 +1,101 @@
+package com.salesforce.multicloudj.sts.ali;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.ValidateOptions;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AliStsVerifierTest {
+
+  private static final String IDENTITY =
+      "https://sts.cn-hangzhou.aliyuncs.com/?Action=GetCallerIdentity&Version=2015-04-01"
+          + "&Format=JSON&Signature=abc123&x-target-resource=my-service";
+
+  private static final String RESPONSE_JSON =
+      "{\"AccountId\":\"123456789012\","
+          + "\"UserId\":\"29417383920\","
+          + "\"Arn\":\"acs:ram::123456789012:user/Alice\","
+          + "\"RequestId\":\"req-1\"}";
+
+  @Test
+  void providerId() {
+    Assertions.assertEquals("ali", new AliStsVerifier().getProviderId());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void returnsCallerIdentityFromStsResponse() throws Exception {
+    HttpClient httpClient = okClient();
+
+    CallerIdentity identity =
+        new AliStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(IDENTITY);
+
+    Assertions.assertEquals("29417383920", identity.getUserId());
+    Assertions.assertEquals("acs:ram::123456789012:user/Alice", identity.getCloudResourceName());
+    Assertions.assertEquals("123456789012", identity.getAccountId());
+  }
+
+  @Test
+  void rejectsEmptySignedIdentity() {
+    AliStsVerifier verifier = new AliStsVerifier.Builder().build(mock(HttpClient.class));
+    Assertions.assertThrows(
+        InvalidArgumentException.class, () -> verifier.verifySignedAuthRequest(""));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void nonOkStatusThrowsUnauthorized() throws Exception {
+    HttpClient httpClient = mock(HttpClient.class);
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(400);
+    when(response.body()).thenReturn("{\"Code\":\"SignatureDoesNotMatch\"}");
+    when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+    AliStsVerifier verifier = new AliStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(IDENTITY));
+  }
+
+  @Test
+  void matchingExpectedCustomHeaderPasses() throws Exception {
+    HttpClient httpClient = okClient();
+    ValidateOptions options =
+        ValidateOptions.builder()
+            .withExpectedCustomHeader("x-target-resource", "my-service")
+            .build();
+
+    CallerIdentity identity =
+        new AliStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(IDENTITY, options);
+
+    Assertions.assertEquals("123456789012", identity.getAccountId());
+  }
+
+  @Test
+  void mismatchedExpectedCustomHeaderFails() {
+    AliStsVerifier verifier = new AliStsVerifier.Builder().build(mock(HttpClient.class));
+    ValidateOptions options =
+        ValidateOptions.builder().withExpectedCustomHeader("x-target-resource", "other").build();
+
+    Assertions.assertThrows(
+        InvalidArgumentException.class, () -> verifier.verifySignedAuthRequest(IDENTITY, options));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static HttpClient okClient() throws IOException, InterruptedException {
+    HttpClient httpClient = mock(HttpClient.class);
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(200);
+    when(response.body()).thenReturn(RESPONSE_JSON);
+    when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+    return httpClient;
+  }
+}

--- a/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsVerifierTest.java
+++ b/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsVerifierTest.java
@@ -5,10 +5,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
 import java.io.IOException;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import org.junit.jupiter.api.Assertions;
@@ -87,6 +90,64 @@ class AliStsVerifierTest {
 
     Assertions.assertThrows(
         InvalidArgumentException.class, () -> verifier.verifySignedAuthRequest(IDENTITY, options));
+  }
+
+  @Test
+  void buildWithProxyCreatesRealClient() {
+    AliStsVerifier verifier =
+        new AliStsVerifier.Builder()
+            .withRegion("cn-hangzhou")
+            .withProxyEndpoint(URI.create("http://localhost:8888"))
+            .build();
+    Assertions.assertEquals("ali", verifier.getProviderId());
+    Assertions.assertNotNull(verifier.builder());
+  }
+
+  @Test
+  void mapExceptionWrapsAsUnknown() {
+    SubstrateSdkException mapped =
+        new AliStsVerifier().mapException(new RuntimeException("boom"));
+    Assertions.assertInstanceOf(UnknownException.class, mapped);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void ioFailureWrappedAsUnknown() throws Exception {
+    HttpClient httpClient = mock(HttpClient.class);
+    when(httpClient.send(any(), any(HttpResponse.BodyHandler.class)))
+        .thenThrow(new IOException("connection reset"));
+
+    AliStsVerifier verifier = new AliStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnknownException.class, () -> verifier.verifySignedAuthRequest(IDENTITY));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void responseWithoutIdentityThrowsUnknown() throws Exception {
+    HttpClient httpClient = mock(HttpClient.class);
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(200);
+    when(response.body()).thenReturn("{\"RequestId\":\"req-1\"}");
+    when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+    AliStsVerifier verifier = new AliStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnknownException.class, () -> verifier.verifySignedAuthRequest(IDENTITY));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void malformedJsonThrowsUnknown() throws Exception {
+    HttpClient httpClient = mock(HttpClient.class);
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(200);
+    when(response.body()).thenReturn("not json at all");
+    when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+    AliStsVerifier verifier = new AliStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnknownException.class, () -> verifier.verifySignedAuthRequest(IDENTITY));
   }
 
   @SuppressWarnings("unchecked")

--- a/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsVerifierTest.java
+++ b/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsVerifierTest.java
@@ -11,7 +11,6 @@ import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
 import java.io.IOException;
-import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import org.junit.jupiter.api.Assertions;
@@ -93,12 +92,8 @@ class AliStsVerifierTest {
   }
 
   @Test
-  void buildWithProxyCreatesRealClient() {
-    AliStsVerifier verifier =
-        new AliStsVerifier.Builder()
-            .withRegion("cn-hangzhou")
-            .withProxyEndpoint(URI.create("http://localhost:8888"))
-            .build();
+  void buildCreatesRealClient() {
+    AliStsVerifier verifier = new AliStsVerifier.Builder().withRegion("cn-hangzhou").build();
     Assertions.assertEquals("ali", verifier.getProviderId());
     Assertions.assertNotNull(verifier.builder());
   }

--- a/sts/sts-aws/src/main/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifier.java
+++ b/sts/sts-aws/src/main/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifier.java
@@ -1,0 +1,231 @@
+package com.salesforce.multicloudj.sts.aws;
+
+import com.google.auto.service.AutoService;
+import com.salesforce.multicloudj.common.exceptions.ExceptionHandler;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.common.exceptions.UnknownException;
+import com.salesforce.multicloudj.sts.driver.AbstractStsVerifier;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.ValidateOptions;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * AWS implementation of the STS verifier. It validates a signed identity by replaying the presigned
+ * {@code GetCallerIdentity} request against AWS STS and returning the caller identity parsed from
+ * the STS response.
+ *
+ * <p>The signed identity is a URL rooted at the STS endpoint whose query string carries the STS
+ * action, version, and every signed request header. Replaying that request lets AWS STS validate
+ * the SigV4 signature and return the identity of the credentials that produced it.
+ */
+@AutoService(AbstractStsVerifier.class)
+public class AwsStsVerifier extends AbstractStsVerifier {
+  private static final String ACTION_PARAM = "Action";
+  private static final String VERSION_PARAM = "Version";
+  private static final String DEFAULT_API_ACTION_NAME = "GetCallerIdentity";
+  private static final String DEFAULT_API_VERSION = "2011-06-15";
+
+  private final HttpClient httpClient;
+  private final URI endpointOverride;
+
+  public AwsStsVerifier() {
+    this(new Builder());
+  }
+
+  public AwsStsVerifier(Builder builder) {
+    super(builder);
+    this.endpointOverride = builder.getEndpoint();
+    this.httpClient = buildHttpClient(builder);
+  }
+
+  /** Constructor that accepts a preconfigured HTTP client, used by tests. */
+  public AwsStsVerifier(Builder builder, HttpClient httpClient) {
+    super(builder);
+    this.endpointOverride = builder.getEndpoint();
+    this.httpClient = httpClient;
+  }
+
+  @Override
+  public Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  protected CallerIdentity validateSignedAuthRequest(
+      String signedIdentity, ValidateOptions options) {
+    if (signedIdentity == null || signedIdentity.isEmpty()) {
+      throw new InvalidArgumentException("signedIdentity cannot be empty");
+    }
+
+    URI identityUri = URI.create(signedIdentity);
+    Map<String, String> params = parseQuery(identityUri.getRawQuery());
+
+    // The signed request carries its headers as query parameters. Custom headers are validated
+    // against those signed values before the request is replayed.
+    verifyExpectedCustomHeaders(params, options);
+
+    // Action=GetCallerIdentity&Version=2011-06-15 is the AWS Query-form body that was signed. It is
+    // reconstructed here so the replayed POST matches what AWS STS expects.
+    String action = params.getOrDefault(ACTION_PARAM, DEFAULT_API_ACTION_NAME);
+    String version = params.getOrDefault(VERSION_PARAM, DEFAULT_API_VERSION);
+    String body = ACTION_PARAM + "=" + action + "&" + VERSION_PARAM + "=" + version;
+
+    URI replayTarget = endpointOverride != null ? endpointOverride : stripQuery(identityUri);
+    HttpRequest.Builder requestBuilder =
+        HttpRequest.newBuilder(replayTarget).POST(HttpRequest.BodyPublishers.ofString(body));
+    for (Map.Entry<String, String> param : params.entrySet()) {
+      if (ACTION_PARAM.equals(param.getKey()) || VERSION_PARAM.equals(param.getKey())) {
+        continue;
+      }
+      // The JDK HTTP client rejects restricted headers (host, content-length, ...). host was not
+      // signed into the identity, so any restricted name here is unexpected and simply skipped.
+      try {
+        requestBuilder.header(param.getKey(), param.getValue());
+      } catch (IllegalArgumentException restrictedHeader) {
+        // Skip headers the HTTP client refuses to set.
+      }
+    }
+
+    HttpResponse<String> response;
+    try {
+      response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+    } catch (IOException e) {
+      throw new UnknownException("failed to replay STS request", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UnknownException("interrupted while replaying STS request", e);
+    }
+
+    if (response.statusCode() != 200) {
+      throw new UnAuthorizedException(
+          "STS returned HTTP " + response.statusCode() + ": " + response.body());
+    }
+
+    return parseCallerIdentity(response.body());
+  }
+
+  private static void verifyExpectedCustomHeaders(
+      Map<String, String> params, ValidateOptions options) {
+    if (options == null) {
+      return;
+    }
+    for (Map.Entry<String, String> expected : options.getExpectedCustomHeaders().entrySet()) {
+      String actual = params.get(expected.getKey());
+      if (actual == null) {
+        throw new InvalidArgumentException(
+            "expected custom header \"" + expected.getKey() + "\" not found in signed request");
+      }
+      if (!actual.equals(expected.getValue())) {
+        throw new InvalidArgumentException(
+            "custom header \"" + expected.getKey() + "\" has an unexpected value");
+      }
+    }
+  }
+
+  private static CallerIdentity parseCallerIdentity(String responseBody) {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      // Harden the XML parser against external entity attacks; the STS response has no DTD.
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      factory.setXIncludeAware(false);
+      factory.setExpandEntityReferences(false);
+      Document document =
+          factory.newDocumentBuilder().parse(new InputSource(new StringReader(responseBody)));
+      String arn = elementText(document, "Arn");
+      String userId = elementText(document, "UserId");
+      String account = elementText(document, "Account");
+      if (arn == null && userId == null && account == null) {
+        throw new UnknownException("STS response did not contain a caller identity");
+      }
+      return new CallerIdentity(userId, arn, account);
+    } catch (SubstrateSdkException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new UnknownException("failed to parse STS response", e);
+    }
+  }
+
+  private static String elementText(Document document, String tagName) {
+    NodeList nodes = document.getElementsByTagName(tagName);
+    return nodes.getLength() > 0 ? nodes.item(0).getTextContent() : null;
+  }
+
+  private static URI stripQuery(URI uri) {
+    String base = uri.toString();
+    int queryIndex = base.indexOf('?');
+    return queryIndex >= 0 ? URI.create(base.substring(0, queryIndex)) : uri;
+  }
+
+  private static Map<String, String> parseQuery(String rawQuery) {
+    Map<String, String> params = new LinkedHashMap<>();
+    if (rawQuery == null || rawQuery.isEmpty()) {
+      return params;
+    }
+    for (String pair : rawQuery.split("&")) {
+      int idx = pair.indexOf('=');
+      if (idx < 0) {
+        params.put(URLDecoder.decode(pair, StandardCharsets.UTF_8), "");
+        continue;
+      }
+      String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
+      String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
+      params.put(key, value);
+    }
+    return params;
+  }
+
+  private static HttpClient buildHttpClient(Builder builder) {
+    HttpClient.Builder clientBuilder = HttpClient.newBuilder();
+    if (builder.getProxyEndpoint() != null) {
+      URI proxy = builder.getProxyEndpoint();
+      clientBuilder.proxy(
+          ProxySelector.of(new InetSocketAddress(proxy.getHost(), proxy.getPort())));
+    }
+    return clientBuilder.build();
+  }
+
+  @Override
+  public SubstrateSdkException mapException(Throwable t) {
+    return ExceptionHandler.build(UnknownException.class, t);
+  }
+
+  public static class Builder extends AbstractStsVerifier.Builder<AwsStsVerifier, Builder> {
+    protected Builder() {
+      providerId("aws");
+    }
+
+    @Override
+    public Builder self() {
+      return this;
+    }
+
+    /** Builds a verifier backed by the supplied HTTP client, used by tests. */
+    public AwsStsVerifier build(HttpClient httpClient) {
+      return new AwsStsVerifier(this, httpClient);
+    }
+
+    @Override
+    public AwsStsVerifier build() {
+      return new AwsStsVerifier(this);
+    }
+  }
+}

--- a/sts/sts-aws/src/main/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifier.java
+++ b/sts/sts-aws/src/main/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifier.java
@@ -41,7 +41,6 @@ public class AwsStsVerifier extends AbstractStsVerifier {
   private static final String DEFAULT_API_VERSION = "2011-06-15";
 
   private final HttpClient httpClient;
-  private final URI endpointOverride;
 
   public AwsStsVerifier() {
     this(new Builder());
@@ -49,14 +48,12 @@ public class AwsStsVerifier extends AbstractStsVerifier {
 
   public AwsStsVerifier(Builder builder) {
     super(builder);
-    this.endpointOverride = builder.getEndpoint();
     this.httpClient = HttpClient.newHttpClient();
   }
 
   /** Constructor that accepts a preconfigured HTTP client, used by tests. */
   public AwsStsVerifier(Builder builder, HttpClient httpClient) {
     super(builder);
-    this.endpointOverride = builder.getEndpoint();
     this.httpClient = httpClient;
   }
 
@@ -85,9 +82,11 @@ public class AwsStsVerifier extends AbstractStsVerifier {
     String version = params.getOrDefault(VERSION_PARAM, DEFAULT_API_VERSION);
     String body = ACTION_PARAM + "=" + action + "&" + VERSION_PARAM + "=" + version;
 
-    URI replayTarget = endpointOverride != null ? endpointOverride : stripQuery(identityUri);
+    // The replay target is the presigned URL from the signed identity with its query stripped; the
+    // signed parameters are re-added below as request headers.
     HttpRequest.Builder requestBuilder =
-        HttpRequest.newBuilder(replayTarget).POST(HttpRequest.BodyPublishers.ofString(body));
+        HttpRequest.newBuilder(stripQuery(identityUri))
+            .POST(HttpRequest.BodyPublishers.ofString(body));
     for (Map.Entry<String, String> param : params.entrySet()) {
       if (ACTION_PARAM.equals(param.getKey()) || VERSION_PARAM.equals(param.getKey())) {
         continue;

--- a/sts/sts-aws/src/main/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifier.java
+++ b/sts/sts-aws/src/main/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifier.java
@@ -11,8 +11,6 @@ import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
 import java.io.IOException;
 import java.io.StringReader;
-import java.net.InetSocketAddress;
-import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.http.HttpClient;
@@ -52,7 +50,7 @@ public class AwsStsVerifier extends AbstractStsVerifier {
   public AwsStsVerifier(Builder builder) {
     super(builder);
     this.endpointOverride = builder.getEndpoint();
-    this.httpClient = buildHttpClient(builder);
+    this.httpClient = HttpClient.newHttpClient();
   }
 
   /** Constructor that accepts a preconfigured HTTP client, used by tests. */
@@ -191,16 +189,6 @@ public class AwsStsVerifier extends AbstractStsVerifier {
       params.put(key, value);
     }
     return params;
-  }
-
-  private static HttpClient buildHttpClient(Builder builder) {
-    HttpClient.Builder clientBuilder = HttpClient.newBuilder();
-    if (builder.getProxyEndpoint() != null) {
-      URI proxy = builder.getProxyEndpoint();
-      clientBuilder.proxy(
-          ProxySelector.of(new InetSocketAddress(proxy.getHost(), proxy.getPort())));
-    }
-    return clientBuilder.build();
   }
 
   @Override

--- a/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifierTest.java
+++ b/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifierTest.java
@@ -1,0 +1,120 @@
+package com.salesforce.multicloudj.sts.aws;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.ValidateOptions;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AwsStsVerifierTest {
+
+  private static final String IDENTITY =
+      "https://sts.us-west-2.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15"
+          + "&x-amz-date=20250101T000000Z&authorization=AWS4-HMAC-SHA256%20Credential%3Dabc"
+          + "&x-target-resource=my-service";
+
+  private static final String RESPONSE_XML =
+      "<GetCallerIdentityResponse xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\">"
+          + "<GetCallerIdentityResult>"
+          + "<Arn>arn:aws:iam::123456789012:user/Alice</Arn>"
+          + "<UserId>AIDAEXAMPLE</UserId>"
+          + "<Account>123456789012</Account>"
+          + "</GetCallerIdentityResult>"
+          + "</GetCallerIdentityResponse>";
+
+  @Test
+  void providerId() {
+    Assertions.assertEquals("aws", new AwsStsVerifier().getProviderId());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void returnsCallerIdentityFromStsResponse() throws Exception {
+    HttpClient httpClient = mock(HttpClient.class);
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(200);
+    when(response.body()).thenReturn(RESPONSE_XML);
+    when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+    CallerIdentity identity =
+        new AwsStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(IDENTITY);
+
+    Assertions.assertEquals("AIDAEXAMPLE", identity.getUserId());
+    Assertions.assertEquals(
+        "arn:aws:iam::123456789012:user/Alice", identity.getCloudResourceName());
+    Assertions.assertEquals("123456789012", identity.getAccountId());
+  }
+
+  @Test
+  void rejectsEmptySignedIdentity() {
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(mock(HttpClient.class));
+    Assertions.assertThrows(
+        InvalidArgumentException.class, () -> verifier.verifySignedAuthRequest(""));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void nonOkStatusThrowsUnauthorized() throws Exception {
+    HttpClient httpClient = mock(HttpClient.class);
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(403);
+    when(response.body()).thenReturn("<Error><Code>AccessDenied</Code></Error>");
+    when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(IDENTITY));
+  }
+
+  @Test
+  void matchingExpectedCustomHeaderPasses() throws Exception {
+    HttpClient httpClient = okClient();
+    ValidateOptions options =
+        ValidateOptions.builder()
+            .withExpectedCustomHeader("x-target-resource", "my-service")
+            .build();
+
+    CallerIdentity identity =
+        new AwsStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(IDENTITY, options);
+
+    Assertions.assertEquals("123456789012", identity.getAccountId());
+  }
+
+  @Test
+  void mismatchedExpectedCustomHeaderFails() {
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(mock(HttpClient.class));
+    ValidateOptions options =
+        ValidateOptions.builder().withExpectedCustomHeader("x-target-resource", "other").build();
+
+    Assertions.assertThrows(
+        InvalidArgumentException.class, () -> verifier.verifySignedAuthRequest(IDENTITY, options));
+  }
+
+  @Test
+  void missingExpectedCustomHeaderFails() {
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(mock(HttpClient.class));
+    ValidateOptions options =
+        ValidateOptions.builder().withExpectedCustomHeader("x-absent", "value").build();
+
+    Assertions.assertThrows(
+        InvalidArgumentException.class, () -> verifier.verifySignedAuthRequest(IDENTITY, options));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static HttpClient okClient() throws IOException, InterruptedException {
+    HttpClient httpClient = mock(HttpClient.class);
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(200);
+    when(response.body()).thenReturn(RESPONSE_XML);
+    when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+    return httpClient;
+  }
+}

--- a/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifierTest.java
+++ b/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifierTest.java
@@ -5,10 +5,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
 import java.io.IOException;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import org.junit.jupiter.api.Assertions;
@@ -106,6 +109,81 @@ class AwsStsVerifierTest {
 
     Assertions.assertThrows(
         InvalidArgumentException.class, () -> verifier.verifySignedAuthRequest(IDENTITY, options));
+  }
+
+  @Test
+  void buildWithProxyCreatesRealClient() {
+    AwsStsVerifier verifier =
+        new AwsStsVerifier.Builder()
+            .withRegion("us-west-2")
+            .withProxyEndpoint(URI.create("http://localhost:8888"))
+            .build();
+    Assertions.assertEquals("aws", verifier.getProviderId());
+    Assertions.assertNotNull(verifier.builder());
+  }
+
+  @Test
+  void mapExceptionWrapsAsUnknown() {
+    SubstrateSdkException mapped =
+        new AwsStsVerifier().mapException(new RuntimeException("boom"));
+    Assertions.assertInstanceOf(UnknownException.class, mapped);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void ioFailureWrappedAsUnknown() throws Exception {
+    HttpClient httpClient = mock(HttpClient.class);
+    when(httpClient.send(any(), any(HttpResponse.BodyHandler.class)))
+        .thenThrow(new IOException("connection reset"));
+
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnknownException.class, () -> verifier.verifySignedAuthRequest(IDENTITY));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void responseWithoutIdentityThrowsUnknown() throws Exception {
+    HttpClient httpClient = mock(HttpClient.class);
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(200);
+    when(response.body())
+        .thenReturn(
+            "<GetCallerIdentityResponse><GetCallerIdentityResult/>"
+                + "</GetCallerIdentityResponse>");
+    when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnknownException.class, () -> verifier.verifySignedAuthRequest(IDENTITY));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void malformedXmlThrowsUnknown() throws Exception {
+    HttpClient httpClient = mock(HttpClient.class);
+    HttpResponse<String> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(200);
+    when(response.body()).thenReturn("this is not xml <<<");
+    when(httpClient.send(any(), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnknownException.class, () -> verifier.verifySignedAuthRequest(IDENTITY));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void restrictedHeaderInSignedRequestIsSkipped() throws Exception {
+    // host is a restricted header the JDK client refuses to set; it must be skipped, not fatal.
+    String identityWithHost =
+        "https://sts.us-west-2.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15"
+            + "&host=sts.us-west-2.amazonaws.com&x-amz-date=20250101T000000Z";
+    HttpClient httpClient = okClient();
+
+    CallerIdentity identity =
+        new AwsStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(identityWithHost);
+    Assertions.assertEquals("123456789012", identity.getAccountId());
   }
 
   @SuppressWarnings("unchecked")

--- a/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifierTest.java
+++ b/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifierTest.java
@@ -11,7 +11,6 @@ import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
 import java.io.IOException;
-import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import org.junit.jupiter.api.Assertions;
@@ -112,12 +111,8 @@ class AwsStsVerifierTest {
   }
 
   @Test
-  void buildWithProxyCreatesRealClient() {
-    AwsStsVerifier verifier =
-        new AwsStsVerifier.Builder()
-            .withRegion("us-west-2")
-            .withProxyEndpoint(URI.create("http://localhost:8888"))
-            .build();
+  void buildCreatesRealClient() {
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().withRegion("us-west-2").build();
     Assertions.assertEquals("aws", verifier.getProviderId());
     Assertions.assertNotNull(verifier.builder());
   }

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/client/StsVerifier.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/client/StsVerifier.java
@@ -1,0 +1,198 @@
+package com.salesforce.multicloudj.sts.client;
+
+import com.google.common.collect.ImmutableSet;
+import com.salesforce.multicloudj.sts.driver.AbstractStsVerifier;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.ValidateOptions;
+import java.net.URI;
+import java.util.ServiceLoader;
+
+/**
+ * StsVerifier provides portable validation of cloud native auth signed requests. It is the
+ * receiving half of the signing flow performed by {@link StsUtilities}: given the portable {@code
+ * signedIdentity} string a caller produced, it proves that identity against the substrate and
+ * returns the verified {@link CallerIdentity}.
+ */
+public class StsVerifier {
+  protected AbstractStsVerifier verifier;
+
+  /**
+   * Constructor for StsVerifier with StsVerifierBuilder.
+   *
+   * @param builder The StsVerifierBuilder used to construct this verifier.
+   */
+  protected StsVerifier(StsVerifierBuilder builder) {
+    this.verifier = builder.verifier;
+  }
+
+  /**
+   * Creates a new StsVerifierBuilder for the specified provider.
+   *
+   * @param providerId The ID of the provider/substrate such as aws.
+   * @return A new StsVerifierBuilder instance.
+   */
+  public static StsVerifierBuilder builder(String providerId) {
+    return new StsVerifierBuilder(providerId);
+  }
+
+  /**
+   * Returns an Iterable of all available AbstractStsVerifier implementations.
+   *
+   * @return An Iterable of AbstractStsVerifier instances.
+   */
+  private static Iterable<AbstractStsVerifier> all() {
+    ServiceLoader<AbstractStsVerifier> services = ServiceLoader.load(AbstractStsVerifier.class);
+    ImmutableSet.Builder<AbstractStsVerifier> builder = ImmutableSet.builder();
+    for (AbstractStsVerifier service : services) {
+      builder.add(service);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Finds the builder for the specified provider.
+   *
+   * @param providerId The ID of the provider.
+   * @return The AbstractStsVerifier.Builder for the specified provider.
+   * @throws IllegalArgumentException if no provider is found for the given ID.
+   */
+  private static AbstractStsVerifier.Builder<?, ?> findProviderBuilder(String providerId) {
+    for (AbstractStsVerifier provider : all()) {
+      if (provider.getProviderId().equals(providerId)) {
+        return createBuilderInstance(provider);
+      }
+    }
+    throw new IllegalArgumentException(
+        "No STS verifier provider found for providerId: " + providerId);
+  }
+
+  /**
+   * Creates a builder instance for the given provider.
+   *
+   * @param provider The AbstractStsVerifier provider.
+   * @return The AbstractStsVerifier.Builder for the provider.
+   * @throws RuntimeException if the builder creation fails.
+   */
+  private static AbstractStsVerifier.Builder<?, ?> createBuilderInstance(
+      AbstractStsVerifier provider) {
+    try {
+      return (AbstractStsVerifier.Builder<?, ?>)
+          provider.getClass().getMethod("builder").invoke(provider);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to create builder for provider: " + provider.getClass().getName(), e);
+    }
+  }
+
+  /**
+   * Validates a signed auth request and returns the identity of the original signer.
+   *
+   * @param signedIdentity the portable token string produced by {@link
+   *     StsUtilities#newCloudNativeAuthSignedRequest}.
+   * @return the verified {@link CallerIdentity}.
+   */
+  public CallerIdentity validateSignedAuthRequest(String signedIdentity) {
+    return validateSignedAuthRequest(signedIdentity, null);
+  }
+
+  /**
+   * Validates a signed auth request using the supplied options and returns the identity of the
+   * original signer.
+   *
+   * @param signedIdentity the portable token string produced by {@link
+   *     StsUtilities#newCloudNativeAuthSignedRequest}.
+   * @param options validation options such as expected custom headers; may be null for defaults.
+   * @return the verified {@link CallerIdentity}.
+   */
+  public CallerIdentity validateSignedAuthRequest(String signedIdentity, ValidateOptions options) {
+    try {
+      return this.verifier.verifySignedAuthRequest(signedIdentity, options);
+    } catch (Throwable t) {
+      throw this.verifier.mapException(t);
+    }
+  }
+
+  /** Builder class for StsVerifier. */
+  public static class StsVerifierBuilder {
+    protected AbstractStsVerifier verifier;
+    protected AbstractStsVerifier.Builder<?, ?> builder;
+
+    /**
+     * Constructor for StsVerifierBuilder.
+     *
+     * @param providerId The ID of the provider such as aws.
+     */
+    public StsVerifierBuilder(String providerId) {
+      this.builder = findProviderBuilder(providerId);
+    }
+
+    /**
+     * Sets the region for the STS verifier.
+     *
+     * @param region The region to set.
+     * @return This StsVerifierBuilder instance.
+     */
+    public StsVerifierBuilder withRegion(String region) {
+      this.builder.withRegion(region);
+      return this;
+    }
+
+    /**
+     * Sets the endpoint override for the STS verifier.
+     *
+     * @param endpoint The endpoint to set.
+     * @return This StsVerifierBuilder instance.
+     */
+    public StsVerifierBuilder withEndpoint(URI endpoint) {
+      this.builder.withEndpoint(endpoint);
+      return this;
+    }
+
+    /**
+     * Sets the proxy endpoint override for the STS verifier.
+     *
+     * @param proxyEndpoint The proxy endpoint to set.
+     * @return This StsVerifierBuilder instance.
+     */
+    public StsVerifierBuilder withProxyEndpoint(URI proxyEndpoint) {
+      this.builder.withProxyEndpoint(proxyEndpoint);
+      return this;
+    }
+
+    /**
+     * Controls whether system property proxy values are used.
+     *
+     * @param useSystemPropertyProxyValues Whether to use system property values for proxy
+     *     configuration.
+     * @return This StsVerifierBuilder instance.
+     */
+    public StsVerifierBuilder withUseSystemPropertyProxyValues(
+        Boolean useSystemPropertyProxyValues) {
+      this.builder.withUseSystemPropertyProxyValues(useSystemPropertyProxyValues);
+      return this;
+    }
+
+    /**
+     * Controls whether environment variable proxy values are used.
+     *
+     * @param useEnvironmentVariableProxyValues Whether to use environment variable values for proxy
+     *     configuration.
+     * @return This StsVerifierBuilder instance.
+     */
+    public StsVerifierBuilder withUseEnvironmentVariableProxyValues(
+        Boolean useEnvironmentVariableProxyValues) {
+      this.builder.withUseEnvironmentVariableProxyValues(useEnvironmentVariableProxyValues);
+      return this;
+    }
+
+    /**
+     * Builds and returns an StsVerifier instance.
+     *
+     * @return A new StsVerifier instance.
+     */
+    public StsVerifier build() {
+      this.verifier = this.builder.build();
+      return new StsVerifier(this);
+    }
+  }
+}

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/client/StsVerifier.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/client/StsVerifier.java
@@ -149,43 +149,6 @@ public class StsVerifier {
     }
 
     /**
-     * Sets the proxy endpoint override for the STS verifier.
-     *
-     * @param proxyEndpoint The proxy endpoint to set.
-     * @return This StsVerifierBuilder instance.
-     */
-    public StsVerifierBuilder withProxyEndpoint(URI proxyEndpoint) {
-      this.builder.withProxyEndpoint(proxyEndpoint);
-      return this;
-    }
-
-    /**
-     * Controls whether system property proxy values are used.
-     *
-     * @param useSystemPropertyProxyValues Whether to use system property values for proxy
-     *     configuration.
-     * @return This StsVerifierBuilder instance.
-     */
-    public StsVerifierBuilder withUseSystemPropertyProxyValues(
-        Boolean useSystemPropertyProxyValues) {
-      this.builder.withUseSystemPropertyProxyValues(useSystemPropertyProxyValues);
-      return this;
-    }
-
-    /**
-     * Controls whether environment variable proxy values are used.
-     *
-     * @param useEnvironmentVariableProxyValues Whether to use environment variable values for proxy
-     *     configuration.
-     * @return This StsVerifierBuilder instance.
-     */
-    public StsVerifierBuilder withUseEnvironmentVariableProxyValues(
-        Boolean useEnvironmentVariableProxyValues) {
-      this.builder.withUseEnvironmentVariableProxyValues(useEnvironmentVariableProxyValues);
-      return this;
-    }
-
-    /**
      * Builds and returns an StsVerifier instance.
      *
      * @return A new StsVerifier instance.

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/client/StsVerifier.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/client/StsVerifier.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableSet;
 import com.salesforce.multicloudj.sts.driver.AbstractStsVerifier;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
-import java.net.URI;
 import java.util.ServiceLoader;
 
 /**
@@ -134,17 +133,6 @@ public class StsVerifier {
      */
     public StsVerifierBuilder withRegion(String region) {
       this.builder.withRegion(region);
-      return this;
-    }
-
-    /**
-     * Sets the endpoint override for the STS verifier.
-     *
-     * @param endpoint The endpoint to set.
-     * @return This StsVerifierBuilder instance.
-     */
-    public StsVerifierBuilder withEndpoint(URI endpoint) {
-      this.builder.withEndpoint(endpoint);
       return this;
     }
 

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/driver/AbstractStsVerifier.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/driver/AbstractStsVerifier.java
@@ -1,0 +1,170 @@
+package com.salesforce.multicloudj.sts.driver;
+
+import com.salesforce.multicloudj.common.provider.Provider;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.ValidateOptions;
+import java.net.URI;
+import lombok.Getter;
+
+/**
+ * Abstract base class for Security Token Service (STS) verifier implementations. A verifier is the
+ * receiving half of the cloud native auth flow: it consumes the portable {@code signedIdentity}
+ * string produced by an {@link AbstractStsUtilities} signer, proves it against the substrate, and
+ * returns the identity of the original signer.
+ *
+ * <p>This class is internal to the SDK; every provider that supports verification implements it.
+ */
+public abstract class AbstractStsVerifier implements Provider {
+  protected final String providerId;
+  protected final String region;
+
+  /**
+   * Constructs an AbstractStsVerifier from a Builder.
+   *
+   * @param builder The Builder instance to use for construction.
+   */
+  public AbstractStsVerifier(Builder<?, ?> builder) {
+    this.providerId = builder.providerId;
+    this.region = builder.region;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getProviderId() {
+    return providerId;
+  }
+
+  /**
+   * Validates a signed auth request and returns the identity of the original signer.
+   *
+   * @param signedIdentity the portable token string produced by a signer's {@code
+   *     newCloudNativeAuthSignedRequest}. For AWS and Alibaba this is a presigned GetCallerIdentity
+   *     URL; for GCP it is a signed JWT.
+   * @return the verified {@link CallerIdentity} of the signer.
+   */
+  public CallerIdentity verifySignedAuthRequest(String signedIdentity) {
+    return verifySignedAuthRequest(signedIdentity, null);
+  }
+
+  /**
+   * Validates a signed auth request using the supplied options and returns the identity of the
+   * original signer.
+   *
+   * @param signedIdentity the portable token string produced by a signer's {@code
+   *     newCloudNativeAuthSignedRequest}.
+   * @param options validation options such as expected custom headers; may be null for defaults.
+   * @return the verified {@link CallerIdentity} of the signer.
+   */
+  public CallerIdentity verifySignedAuthRequest(String signedIdentity, ValidateOptions options) {
+    return validateSignedAuthRequest(signedIdentity, options);
+  }
+
+  /**
+   * Abstract builder for AbstractStsVerifier implementations.
+   *
+   * @param <A> The concrete implementation type of AbstractStsVerifier.
+   * @param <T> The concrete implementation type of Builder.
+   */
+  public abstract static class Builder<A extends AbstractStsVerifier, T extends Builder<A, T>>
+      implements Provider.Builder {
+    @Getter protected String region;
+    @Getter protected URI endpoint;
+    @Getter protected URI proxyEndpoint;
+    @Getter protected Boolean useSystemPropertyProxyValues;
+    @Getter protected Boolean useEnvironmentVariableProxyValues;
+    protected String providerId;
+
+    /**
+     * Sets the region.
+     *
+     * @param region The region to set.
+     * @return This Builder instance.
+     */
+    public T withRegion(String region) {
+      this.region = region;
+      return self();
+    }
+
+    /**
+     * Sets the endpoint to override.
+     *
+     * @param endpoint The endpoint to set.
+     * @return This Builder instance.
+     */
+    public T withEndpoint(URI endpoint) {
+      this.endpoint = endpoint;
+      return self();
+    }
+
+    /**
+     * Sets the proxy endpoint to override.
+     *
+     * @param proxyEndpoint The proxy endpoint to set.
+     * @return This Builder instance.
+     */
+    public T withProxyEndpoint(URI proxyEndpoint) {
+      this.proxyEndpoint = proxyEndpoint;
+      return self();
+    }
+
+    /**
+     * Method to control whether system property values (e.g., http.proxyHost, http.proxyPort,
+     * https.proxyHost, https.proxyPort) should be used for proxy configuration. When set to false,
+     * these system properties will be ignored.
+     *
+     * @param useSystemPropertyProxyValues Whether to use system property values for proxy
+     *     configuration
+     * @return This Builder instance.
+     */
+    public T withUseSystemPropertyProxyValues(Boolean useSystemPropertyProxyValues) {
+      this.useSystemPropertyProxyValues = useSystemPropertyProxyValues;
+      return self();
+    }
+
+    /**
+     * Method to control whether environment variable values (e.g., HTTP_PROXY, HTTPS_PROXY,
+     * NO_PROXY) should be used for proxy configuration. When set to false, these environment
+     * variables will be ignored.
+     *
+     * @param useEnvironmentVariableProxyValues Whether to use environment variable values for proxy
+     *     configuration
+     * @return This Builder instance.
+     */
+    public T withUseEnvironmentVariableProxyValues(Boolean useEnvironmentVariableProxyValues) {
+      this.useEnvironmentVariableProxyValues = useEnvironmentVariableProxyValues;
+      return self();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public T providerId(String providerId) {
+      this.providerId = providerId;
+      return self();
+    }
+
+    /**
+     * Returns the builder instance.
+     *
+     * @return This Builder instance.
+     */
+    public abstract T self();
+
+    /**
+     * Builds and returns an instance of AbstractStsVerifier.
+     *
+     * @return An instance of AbstractStsVerifier.
+     */
+    public abstract A build();
+  }
+
+  /**
+   * Substrate-specific implementation that validates the signed identity and returns the caller
+   * identity.
+   *
+   * @param signedIdentity the portable token string produced by a signer.
+   * @param options validation options; may be null.
+   * @return the verified {@link CallerIdentity}.
+   */
+  protected abstract CallerIdentity validateSignedAuthRequest(
+      String signedIdentity, ValidateOptions options);
+}

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/driver/AbstractStsVerifier.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/driver/AbstractStsVerifier.java
@@ -69,9 +69,6 @@ public abstract class AbstractStsVerifier implements Provider {
       implements Provider.Builder {
     @Getter protected String region;
     @Getter protected URI endpoint;
-    @Getter protected URI proxyEndpoint;
-    @Getter protected Boolean useSystemPropertyProxyValues;
-    @Getter protected Boolean useEnvironmentVariableProxyValues;
     protected String providerId;
 
     /**
@@ -93,45 +90,6 @@ public abstract class AbstractStsVerifier implements Provider {
      */
     public T withEndpoint(URI endpoint) {
       this.endpoint = endpoint;
-      return self();
-    }
-
-    /**
-     * Sets the proxy endpoint to override.
-     *
-     * @param proxyEndpoint The proxy endpoint to set.
-     * @return This Builder instance.
-     */
-    public T withProxyEndpoint(URI proxyEndpoint) {
-      this.proxyEndpoint = proxyEndpoint;
-      return self();
-    }
-
-    /**
-     * Method to control whether system property values (e.g., http.proxyHost, http.proxyPort,
-     * https.proxyHost, https.proxyPort) should be used for proxy configuration. When set to false,
-     * these system properties will be ignored.
-     *
-     * @param useSystemPropertyProxyValues Whether to use system property values for proxy
-     *     configuration
-     * @return This Builder instance.
-     */
-    public T withUseSystemPropertyProxyValues(Boolean useSystemPropertyProxyValues) {
-      this.useSystemPropertyProxyValues = useSystemPropertyProxyValues;
-      return self();
-    }
-
-    /**
-     * Method to control whether environment variable values (e.g., HTTP_PROXY, HTTPS_PROXY,
-     * NO_PROXY) should be used for proxy configuration. When set to false, these environment
-     * variables will be ignored.
-     *
-     * @param useEnvironmentVariableProxyValues Whether to use environment variable values for proxy
-     *     configuration
-     * @return This Builder instance.
-     */
-    public T withUseEnvironmentVariableProxyValues(Boolean useEnvironmentVariableProxyValues) {
-      this.useEnvironmentVariableProxyValues = useEnvironmentVariableProxyValues;
       return self();
     }
 

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/driver/AbstractStsVerifier.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/driver/AbstractStsVerifier.java
@@ -3,7 +3,6 @@ package com.salesforce.multicloudj.sts.driver;
 import com.salesforce.multicloudj.common.provider.Provider;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
-import java.net.URI;
 import lombok.Getter;
 
 /**
@@ -68,7 +67,6 @@ public abstract class AbstractStsVerifier implements Provider {
   public abstract static class Builder<A extends AbstractStsVerifier, T extends Builder<A, T>>
       implements Provider.Builder {
     @Getter protected String region;
-    @Getter protected URI endpoint;
     protected String providerId;
 
     /**
@@ -79,17 +77,6 @@ public abstract class AbstractStsVerifier implements Provider {
      */
     public T withRegion(String region) {
       this.region = region;
-      return self();
-    }
-
-    /**
-     * Sets the endpoint to override.
-     *
-     * @param endpoint The endpoint to set.
-     * @return This Builder instance.
-     */
-    public T withEndpoint(URI endpoint) {
-      this.endpoint = endpoint;
       return self();
     }
 

--- a/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/ValidateOptions.java
+++ b/sts/sts-client/src/main/java/com/salesforce/multicloudj/sts/model/ValidateOptions.java
@@ -1,0 +1,68 @@
+package com.salesforce.multicloudj.sts.model;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.Getter;
+
+/**
+ * ValidateOptions carries optional, substrate-agnostic knobs that influence how a signed cloud
+ * native auth request is validated by a verifier.
+ *
+ * <p>All options are optional; an instance built with no customization requests the default
+ * validation behavior. When expected custom headers are supplied, validation fails if any expected
+ * header is missing from the signed request or has a different value.
+ */
+@Getter
+public class ValidateOptions {
+
+  /**
+   * Key-value pairs that must match the custom headers carried by the signed request. Validation
+   * fails if any expected header is missing or has a different value.
+   */
+  private final Map<String, String> expectedCustomHeaders;
+
+  private ValidateOptions(Builder builder) {
+    this.expectedCustomHeaders =
+        Collections.unmodifiableMap(new LinkedHashMap<>(builder.expectedCustomHeaders));
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Builder for {@link ValidateOptions}. */
+  public static class Builder {
+    private final Map<String, String> expectedCustomHeaders = new LinkedHashMap<>();
+
+    /**
+     * Adds a single expected custom header that must be present in the signed request with the
+     * given value.
+     *
+     * @param name header name
+     * @param value expected header value
+     * @return this builder
+     */
+    public Builder withExpectedCustomHeader(String name, String value) {
+      this.expectedCustomHeaders.put(name, value);
+      return this;
+    }
+
+    /**
+     * Adds all supplied expected custom headers that must be present in the signed request.
+     *
+     * @param expectedCustomHeaders expected headers to add
+     * @return this builder
+     */
+    public Builder withExpectedCustomHeaders(Map<String, String> expectedCustomHeaders) {
+      if (expectedCustomHeaders != null) {
+        this.expectedCustomHeaders.putAll(expectedCustomHeaders);
+      }
+      return this;
+    }
+
+    public ValidateOptions build() {
+      return new ValidateOptions(this);
+    }
+  }
+}

--- a/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/StsVerifierTest.java
+++ b/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/StsVerifierTest.java
@@ -1,0 +1,92 @@
+package com.salesforce.multicloudj.sts.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.salesforce.multicloudj.common.exceptions.UnknownException;
+import com.salesforce.multicloudj.sts.driver.AbstractStsVerifier;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.ValidateOptions;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StsVerifierTest {
+
+  @Test
+  void buildsVerifierAndValidatesSignedIdentity() {
+    withMockedProvider(
+        builder -> {
+          StsVerifier verifier =
+              builder
+                  .withRegion("test-region")
+                  .withEndpoint(URI.create("http://localhost:1234"))
+                  .withProxyEndpoint(URI.create("http://localhost:8888"))
+                  .withUseSystemPropertyProxyValues(true)
+                  .withUseEnvironmentVariableProxyValues(false)
+                  .build();
+          assertNotNull(verifier);
+
+          CallerIdentity identity = verifier.validateSignedAuthRequest("caller-1");
+          assertEquals("caller-1", identity.getUserId());
+          assertEquals("arn:test:caller-1", identity.getCloudResourceName());
+          assertEquals("0", identity.getAccountId());
+        });
+  }
+
+  @Test
+  void passesValidateOptionsThrough() {
+    withMockedProvider(
+        builder -> {
+          StsVerifier verifier = builder.build();
+          ValidateOptions options =
+              ValidateOptions.builder().withExpectedCustomHeader("x-h", "v").build();
+          CallerIdentity identity = verifier.validateSignedAuthRequest("caller-2", options);
+          assertEquals("1", identity.getAccountId());
+        });
+  }
+
+  @Test
+  void mapsExceptionThrownByVerifier() {
+    withMockedProvider(
+        builder -> {
+          StsVerifier verifier = builder.build();
+          assertThrows(
+              UnknownException.class, () -> verifier.validateSignedAuthRequest("boom"));
+        });
+  }
+
+  @Test
+  void unknownProviderThrows() {
+    withMockedProvider(
+        builder ->
+            assertThrows(
+                IllegalArgumentException.class, () -> StsVerifier.builder("does-not-exist")));
+  }
+
+  private void withMockedProvider(Consumer<StsVerifier.StsVerifierBuilder> body) {
+    TestConcreteAbstractStsVerifier provider = new TestConcreteAbstractStsVerifier();
+    ServiceLoader<TestConcreteAbstractStsVerifier> serviceLoader = mock(ServiceLoader.class);
+    Iterator<TestConcreteAbstractStsVerifier> providerIterator = List.of(provider).iterator();
+    when(serviceLoader.iterator()).thenReturn(providerIterator);
+
+    try (MockedStatic<ServiceLoader> serviceLoaderStatic =
+        Mockito.mockStatic(ServiceLoader.class)) {
+      serviceLoaderStatic
+          .when(() -> ServiceLoader.load(AbstractStsVerifier.class))
+          .thenReturn(serviceLoader);
+      body.accept(StsVerifier.builder("mockProviderId"));
+    }
+  }
+}

--- a/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/StsVerifierTest.java
+++ b/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/StsVerifierTest.java
@@ -32,9 +32,6 @@ class StsVerifierTest {
               builder
                   .withRegion("test-region")
                   .withEndpoint(URI.create("http://localhost:1234"))
-                  .withProxyEndpoint(URI.create("http://localhost:8888"))
-                  .withUseSystemPropertyProxyValues(true)
-                  .withUseEnvironmentVariableProxyValues(false)
                   .build();
           assertNotNull(verifier);
 

--- a/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/StsVerifierTest.java
+++ b/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/StsVerifierTest.java
@@ -10,7 +10,6 @@ import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.driver.AbstractStsVerifier;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
-import java.net.URI;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -28,11 +27,7 @@ class StsVerifierTest {
   void buildsVerifierAndValidatesSignedIdentity() {
     withMockedProvider(
         builder -> {
-          StsVerifier verifier =
-              builder
-                  .withRegion("test-region")
-                  .withEndpoint(URI.create("http://localhost:1234"))
-                  .build();
+          StsVerifier verifier = builder.withRegion("test-region").build();
           assertNotNull(verifier);
 
           CallerIdentity identity = verifier.validateSignedAuthRequest("caller-1");

--- a/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/TestConcreteAbstractStsVerifier.java
+++ b/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/client/TestConcreteAbstractStsVerifier.java
@@ -1,0 +1,57 @@
+package com.salesforce.multicloudj.sts.client;
+
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import com.salesforce.multicloudj.common.exceptions.UnknownException;
+import com.salesforce.multicloudj.sts.driver.AbstractStsVerifier;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.ValidateOptions;
+
+/** Test double for the STS verifier facade and abstract driver contract. */
+public class TestConcreteAbstractStsVerifier extends AbstractStsVerifier {
+
+  public TestConcreteAbstractStsVerifier(Builder builder) {
+    super(builder);
+  }
+
+  public TestConcreteAbstractStsVerifier() {
+    super(new Builder());
+  }
+
+  @Override
+  public Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  protected CallerIdentity validateSignedAuthRequest(
+      String signedIdentity, ValidateOptions options) {
+    if ("boom".equals(signedIdentity)) {
+      throw new IllegalStateException("boom");
+    }
+    String headerCount =
+        options == null ? "0" : String.valueOf(options.getExpectedCustomHeaders().size());
+    return new CallerIdentity(signedIdentity, "arn:test:" + signedIdentity, headerCount);
+  }
+
+  @Override
+  public SubstrateSdkException mapException(Throwable t) {
+    return new UnknownException(t);
+  }
+
+  public static class Builder
+      extends AbstractStsVerifier.Builder<TestConcreteAbstractStsVerifier, Builder> {
+    protected Builder() {
+      providerId("mockProviderId");
+    }
+
+    @Override
+    public Builder self() {
+      return this;
+    }
+
+    @Override
+    public TestConcreteAbstractStsVerifier build() {
+      return new TestConcreteAbstractStsVerifier(this);
+    }
+  }
+}

--- a/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/model/ValidateOptionsTest.java
+++ b/sts/sts-client/src/test/java/com/salesforce/multicloudj/sts/model/ValidateOptionsTest.java
@@ -1,0 +1,53 @@
+package com.salesforce.multicloudj.sts.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ValidateOptionsTest {
+
+  @Test
+  void emptyByDefault() {
+    ValidateOptions options = ValidateOptions.builder().build();
+    assertTrue(options.getExpectedCustomHeaders().isEmpty());
+  }
+
+  @Test
+  void addsSingleAndBulkHeaders() {
+    Map<String, String> bulk = new LinkedHashMap<>();
+    bulk.put("x-a", "1");
+    bulk.put("x-b", "2");
+
+    ValidateOptions options =
+        ValidateOptions.builder()
+            .withExpectedCustomHeader("x-c", "3")
+            .withExpectedCustomHeaders(bulk)
+            .build();
+
+    Map<String, String> headers = options.getExpectedCustomHeaders();
+    assertEquals(3, headers.size());
+    assertEquals("1", headers.get("x-a"));
+    assertEquals("2", headers.get("x-b"));
+    assertEquals("3", headers.get("x-c"));
+  }
+
+  @Test
+  void nullBulkHeadersIsIgnored() {
+    ValidateOptions options =
+        ValidateOptions.builder().withExpectedCustomHeaders(null).build();
+    assertTrue(options.getExpectedCustomHeaders().isEmpty());
+  }
+
+  @Test
+  void returnedMapIsUnmodifiable() {
+    ValidateOptions options =
+        ValidateOptions.builder().withExpectedCustomHeader("x-a", "1").build();
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> options.getExpectedCustomHeaders().put("x-b", "2"));
+  }
+}

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsUtilities.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsUtilities.java
@@ -1,0 +1,301 @@
+package com.salesforce.multicloudj.sts.gcp;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.auth.oauth2.ComputeEngineCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ImpersonatedCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.auto.service.AutoService;
+import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
+import com.google.cloud.iam.credentials.v1.IamCredentialsSettings;
+import com.google.cloud.iam.credentials.v1.SignJwtResponse;
+import com.salesforce.multicloudj.common.exceptions.DeadlineExceededException;
+import com.salesforce.multicloudj.common.exceptions.ExceptionHandler;
+import com.salesforce.multicloudj.common.exceptions.FailedPreconditionException;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.ResourceAlreadyExistsException;
+import com.salesforce.multicloudj.common.exceptions.ResourceExhaustedException;
+import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
+import com.salesforce.multicloudj.common.exceptions.UnknownException;
+import com.salesforce.multicloudj.common.gcp.GcpConstants;
+import com.salesforce.multicloudj.common.gcp.GcpRetryClassifier;
+import com.salesforce.multicloudj.sts.driver.AbstractStsUtilities;
+import com.salesforce.multicloudj.sts.model.SignOptions;
+import com.salesforce.multicloudj.sts.model.SignedAuthRequest;
+import com.salesforce.multicloudj.sts.model.StsCredentials;
+import java.io.IOException;
+import java.net.http.HttpRequest;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * GCP implementation of the STS signer. It produces a signed identity that is a JWT signed by a
+ * service account through the IAM {@code SignJwt} API. The JWT carries the service account email in
+ * its {@code iss}/{@code sub} claims, {@code iat}/{@code exp} time bounds, and any caller supplied
+ * custom headers as additional claims.
+ *
+ * <p>Because the JWT is signed with the service account's Google-managed key, a receiver can verify
+ * it offline against the service account's public keys published at {@code
+ * https://www.googleapis.com/service_accounts/v1/metadata/jwk/{serviceAccountEmail}} — no local key
+ * material or shared secret is required.
+ *
+ * <p>The service account whose key signs the JWT is taken from the {@code role} on the supplied
+ * {@link com.salesforce.multicloudj.sts.model.CredentialsOverrider}; when it is set the IAM client
+ * impersonates that service account so it can sign as it. When it is absent the signer
+ * authenticates with Application Default Credentials and signs as the account those credentials
+ * represent.
+ */
+@AutoService(AbstractStsUtilities.class)
+public class GcpStsUtilities extends AbstractStsUtilities<GcpStsUtilities> {
+  private static final long JWT_EXPIRY_SECONDS = 300L;
+  private static final String SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+  private static final String SA_NAME_FORMAT = "projects/-/serviceAccounts/%s";
+  private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
+
+  /**
+   * Seam over the IAM {@code SignJwt} call so the signing step can be exercised in isolation. The
+   * default implementation calls the IAM Credentials API; tests supply their own.
+   */
+  @FunctionalInterface
+  interface JwtSigner {
+    /**
+     * Signs the JSON claims payload as the given service account and returns the compact JWT.
+     *
+     * @param serviceAccountName the fully qualified service account resource name
+     * @param payload the JSON-encoded JWT claims
+     * @return the signed compact JWT
+     * @throws IOException if the signing call fails
+     */
+    String sign(String serviceAccountName, String payload) throws IOException;
+  }
+
+  // Non-null only when injected for tests; otherwise the default IAM-backed signer is used lazily.
+  private final JwtSigner jwtSigner;
+  // Non-null only when injected for tests; skips service account auto-detection.
+  private final String serviceAccountEmailOverride;
+  // Lazily created IAM client reused across sign calls, guarded by clientLock.
+  private volatile IamCredentialsClient iamCredentialsClient;
+  private final Object clientLock = new Object();
+
+  public GcpStsUtilities(Builder builder) {
+    super(builder);
+    this.jwtSigner = null;
+    this.serviceAccountEmailOverride = null;
+  }
+
+  public GcpStsUtilities() {
+    this(new Builder());
+  }
+
+  /** Constructor used by tests to inject the signing seam and a fixed service account email. */
+  GcpStsUtilities(Builder builder, JwtSigner jwtSigner, String serviceAccountEmail) {
+    super(builder);
+    this.jwtSigner = jwtSigner;
+    this.serviceAccountEmailOverride = serviceAccountEmail;
+  }
+
+  @Override
+  public Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  protected SignedAuthRequest newCloudNativeAuthSignedRequest(HttpRequest request) {
+    return newCloudNativeAuthSignedRequest(request, null);
+  }
+
+  @Override
+  protected SignedAuthRequest newCloudNativeAuthSignedRequest(
+      HttpRequest request, SignOptions options) {
+    if (options == null) {
+      options = SignOptions.builder().build();
+    }
+
+    String serviceAccountEmail = resolveServiceAccountEmail();
+
+    // Assemble the JWT claims. iss/sub identify the signing service account and iat/exp bound the
+    // token's validity; caller supplied custom headers ride along as additional claims that the
+    // verifier can assert.
+    long now = Instant.now().getEpochSecond();
+    GenericJson claims = new GenericJson();
+    claims.setFactory(JSON_FACTORY);
+    claims.set("iss", serviceAccountEmail);
+    claims.set("sub", serviceAccountEmail);
+    claims.set("iat", now);
+    claims.set("exp", now + JWT_EXPIRY_SECONDS);
+    for (Map.Entry<String, String> header : options.getCustomHeaders().entrySet()) {
+      claims.set(header.getKey(), header.getValue());
+    }
+
+    String payload;
+    try {
+      payload = JSON_FACTORY.toString(claims);
+    } catch (IOException e) {
+      throw new UnknownException("failed to serialize JWT claims", e);
+    }
+
+    String signedJwt;
+    try {
+      signedJwt = signer().sign(String.format(SA_NAME_FORMAT, serviceAccountEmail), payload);
+    } catch (IOException e) {
+      throw new UnknownException("failed to sign JWT for " + serviceAccountEmail, e);
+    }
+
+    // The signed JWT is self-contained and offline-verifiable, so it is both the replayable signed
+    // identity and the security token carried by the credentials. There is no HTTP request to
+    // replay for JWT-based identity.
+    StsCredentials credentials =
+        new StsCredentials(StringUtils.EMPTY, StringUtils.EMPTY, signedJwt);
+    return new SignedAuthRequest(null, credentials, signedJwt);
+  }
+
+  private JwtSigner signer() {
+    return jwtSigner != null ? jwtSigner : this::signWithIam;
+  }
+
+  private String signWithIam(String serviceAccountName, String payload) throws IOException {
+    SignJwtResponse response =
+        iamCredentialsClient().signJwt(serviceAccountName, Collections.emptyList(), payload);
+    return response.getSignedJwt();
+  }
+
+  private IamCredentialsClient iamCredentialsClient() throws IOException {
+    IamCredentialsClient client = iamCredentialsClient;
+    if (client == null) {
+      synchronized (clientLock) {
+        client = iamCredentialsClient;
+        if (client == null) {
+          client = buildIamCredentialsClient();
+          iamCredentialsClient = client;
+        }
+      }
+    }
+    return client;
+  }
+
+  private IamCredentialsClient buildIamCredentialsClient() throws IOException {
+    GoogleCredentials sourceCredentials = GoogleCredentials.getApplicationDefault();
+    if (sourceCredentials.createScopedRequired()) {
+      sourceCredentials = sourceCredentials.createScoped(List.of(SCOPE));
+    }
+
+    // When the caller names a target service account, impersonate it so the IAM client can sign as
+    // that account. This supports environments where the default credentials cannot sign directly
+    // but are permitted to impersonate the target service account.
+    GoogleCredentials signingCredentials = sourceCredentials;
+    String role = credentialsOverrider == null ? null : credentialsOverrider.getRole();
+    if (StringUtils.isNotBlank(role)) {
+      signingCredentials =
+          ImpersonatedCredentials.newBuilder()
+              .setSourceCredentials(sourceCredentials)
+              .setTargetPrincipal(role)
+              .setScopes(List.of(SCOPE))
+              .build();
+    }
+
+    IamCredentialsSettings settings =
+        IamCredentialsSettings.newBuilder()
+            .setCredentialsProvider(FixedCredentialsProvider.create(signingCredentials))
+            .build();
+    return IamCredentialsClient.create(settings);
+  }
+
+  /**
+   * Resolves the service account whose key signs the JWT. A {@code role} on the credentials
+   * overrider names it explicitly; otherwise it is derived from the account behind Application
+   * Default Credentials.
+   */
+  private String resolveServiceAccountEmail() {
+    if (StringUtils.isNotBlank(serviceAccountEmailOverride)) {
+      return serviceAccountEmailOverride;
+    }
+    String role = credentialsOverrider == null ? null : credentialsOverrider.getRole();
+    if (StringUtils.isNotBlank(role)) {
+      return role;
+    }
+    String email = serviceAccountEmailFromCredentials();
+    if (StringUtils.isBlank(email)) {
+      throw new InvalidArgumentException(
+          "could not determine the signing service account email; supply it as the "
+              + "credentialsOverrider role");
+    }
+    return email;
+  }
+
+  private static String serviceAccountEmailFromCredentials() {
+    try {
+      GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
+      if (credentials instanceof ServiceAccountCredentials) {
+        return ((ServiceAccountCredentials) credentials).getClientEmail();
+      }
+      if (credentials instanceof ComputeEngineCredentials) {
+        return ((ComputeEngineCredentials) credentials).getAccount();
+      }
+      return null;
+    } catch (IOException e) {
+      throw new UnknownException("could not load application default credentials", e);
+    }
+  }
+
+  @Override
+  public SubstrateSdkException mapException(Throwable t) {
+    Class<? extends SubstrateSdkException> exceptionClass = UnknownException.class;
+    if (t instanceof ApiException) {
+      StatusCode statusCode = ((ApiException) t).getStatusCode();
+      if (statusCode != null) {
+        exceptionClass = ERROR_MAPPING.getOrDefault(statusCode.getCode(), UnknownException.class);
+      }
+    }
+    return ExceptionHandler.build(exceptionClass, t, GcpRetryClassifier.classify(t));
+  }
+
+  private static final Map<StatusCode.Code, Class<? extends SubstrateSdkException>> ERROR_MAPPING =
+      new HashMap<>();
+
+  static {
+    ERROR_MAPPING.put(StatusCode.Code.CANCELLED, UnknownException.class);
+    ERROR_MAPPING.put(StatusCode.Code.UNKNOWN, UnknownException.class);
+    ERROR_MAPPING.put(StatusCode.Code.INVALID_ARGUMENT, InvalidArgumentException.class);
+    ERROR_MAPPING.put(StatusCode.Code.DEADLINE_EXCEEDED, DeadlineExceededException.class);
+    ERROR_MAPPING.put(StatusCode.Code.NOT_FOUND, ResourceNotFoundException.class);
+    ERROR_MAPPING.put(StatusCode.Code.ALREADY_EXISTS, ResourceAlreadyExistsException.class);
+    ERROR_MAPPING.put(StatusCode.Code.PERMISSION_DENIED, UnAuthorizedException.class);
+    ERROR_MAPPING.put(StatusCode.Code.RESOURCE_EXHAUSTED, ResourceExhaustedException.class);
+    ERROR_MAPPING.put(StatusCode.Code.FAILED_PRECONDITION, FailedPreconditionException.class);
+    ERROR_MAPPING.put(StatusCode.Code.ABORTED, DeadlineExceededException.class);
+    ERROR_MAPPING.put(StatusCode.Code.OUT_OF_RANGE, InvalidArgumentException.class);
+    ERROR_MAPPING.put(StatusCode.Code.UNIMPLEMENTED, UnSupportedOperationException.class);
+    ERROR_MAPPING.put(StatusCode.Code.INTERNAL, UnknownException.class);
+    ERROR_MAPPING.put(StatusCode.Code.UNAVAILABLE, UnknownException.class);
+    ERROR_MAPPING.put(StatusCode.Code.DATA_LOSS, UnknownException.class);
+    ERROR_MAPPING.put(StatusCode.Code.UNAUTHENTICATED, UnAuthorizedException.class);
+  }
+
+  public static class Builder extends AbstractStsUtilities.Builder<GcpStsUtilities> {
+    protected Builder() {
+      providerId(GcpConstants.PROVIDER_ID);
+    }
+
+    /** Builds a signer backed by the supplied signing seam and service account, used by tests. */
+    GcpStsUtilities build(JwtSigner jwtSigner, String serviceAccountEmail) {
+      return new GcpStsUtilities(this, jwtSigner, serviceAccountEmail);
+    }
+
+    @Override
+    public GcpStsUtilities build() {
+      return new GcpStsUtilities(this);
+    }
+  }
+}

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsUtilities.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsUtilities.java
@@ -1,5 +1,8 @@
 package com.salesforce.multicloudj.sts.gcp;
 
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.gson.GsonFactory;
@@ -62,6 +65,8 @@ public class GcpStsUtilities extends AbstractStsUtilities<GcpStsUtilities> {
   private static final long JWT_EXPIRY_SECONDS = 300L;
   private static final String SCOPE = "https://www.googleapis.com/auth/cloud-platform";
   private static final String SA_NAME_FORMAT = "projects/-/serviceAccounts/%s";
+  private static final String METADATA_SA_EMAIL_URL =
+      "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email";
   private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
 
   /**
@@ -214,8 +219,8 @@ public class GcpStsUtilities extends AbstractStsUtilities<GcpStsUtilities> {
 
   /**
    * Resolves the service account whose key signs the JWT. A {@code role} on the credentials
-   * overrider names it explicitly; otherwise it is derived from the account behind Application
-   * Default Credentials.
+   * overrider names it explicitly; otherwise it is auto-detected from the account behind
+   * Application Default Credentials, falling back to the GCE metadata server.
    */
   private String resolveServiceAccountEmail() {
     if (StringUtils.isNotBlank(serviceAccountEmailOverride)) {
@@ -225,27 +230,61 @@ public class GcpStsUtilities extends AbstractStsUtilities<GcpStsUtilities> {
     if (StringUtils.isNotBlank(role)) {
       return role;
     }
-    String email = serviceAccountEmailFromCredentials();
+    String email = defaultServiceAccountEmail();
     if (StringUtils.isBlank(email)) {
       throw new InvalidArgumentException(
-          "could not determine the signing service account email; supply it as the "
-              + "credentialsOverrider role");
+          "could not determine the signing service account email from application default "
+              + "credentials or the metadata server; supply it as the credentialsOverrider role");
     }
     return email;
   }
 
-  private static String serviceAccountEmailFromCredentials() {
+  /**
+   * Auto-detects the signing service account email. It first reads the {@code client_email} from
+   * the account behind Application Default Credentials, then falls back to the GCE metadata server
+   * (which serves on GCE, GKE, and Cloud Run).
+   */
+  private static String defaultServiceAccountEmail() {
     try {
       GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
       if (credentials instanceof ServiceAccountCredentials) {
-        return ((ServiceAccountCredentials) credentials).getClientEmail();
+        String email = ((ServiceAccountCredentials) credentials).getClientEmail();
+        if (StringUtils.isNotBlank(email)) {
+          return email;
+        }
+      }
+      // Impersonated credentials sign as their target service account, so that target is the
+      // account whose key signs the JWT.
+      if (credentials instanceof ImpersonatedCredentials) {
+        String email = ((ImpersonatedCredentials) credentials).getAccount();
+        if (StringUtils.isNotBlank(email)) {
+          return email;
+        }
       }
       if (credentials instanceof ComputeEngineCredentials) {
-        return ((ComputeEngineCredentials) credentials).getAccount();
+        String email = ((ComputeEngineCredentials) credentials).getAccount();
+        if (StringUtils.isNotBlank(email) && !"default".equals(email)) {
+          return email;
+        }
       }
-      return null;
     } catch (IOException e) {
-      throw new UnknownException("could not load application default credentials", e);
+      // Fall through to the metadata server, which serves the email on GCE/GKE/Cloud Run.
+    }
+    return serviceAccountEmailFromMetadataServer();
+  }
+
+  private static String serviceAccountEmailFromMetadataServer() {
+    try {
+      com.google.api.client.http.HttpRequest request =
+          new NetHttpTransport()
+              .createRequestFactory()
+              .buildGetRequest(new GenericUrl(METADATA_SA_EMAIL_URL));
+      request.getHeaders().set("Metadata-Flavor", "Google");
+      HttpResponse response = request.execute();
+      String email = response.parseAsString();
+      return email == null ? null : email.trim();
+    } catch (IOException e) {
+      return null;
     }
   }
 

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifier.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifier.java
@@ -97,7 +97,7 @@ public class GcpStsVerifier extends AbstractStsVerifier {
     JsonWebSignature jws;
     try {
       jws = JsonWebSignature.parse(jsonFactory, signedIdentity);
-    } catch (IOException e) {
+    } catch (IOException | IllegalArgumentException e) {
       throw new InvalidArgumentException("failed to parse JWT", e);
     }
 

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifier.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifier.java
@@ -1,0 +1,341 @@
+package com.salesforce.multicloudj.sts.gcp;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.apache.v2.ApacheHttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.json.webtoken.JsonWebSignature;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.auto.service.AutoService;
+import com.salesforce.multicloudj.common.exceptions.ExceptionHandler;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.common.exceptions.UnknownException;
+import com.salesforce.multicloudj.common.gcp.GcpConstants;
+import com.salesforce.multicloudj.sts.driver.AbstractStsVerifier;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.ValidateOptions;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+/**
+ * GCP implementation of the STS verifier. It validates a signed identity that is a JWT produced by
+ * a service account (via the IAM {@code SignJwt} API) by verifying the JWT's RSA signature against
+ * the service account's Google-managed public keys.
+ *
+ * <p>The public keys are published at {@code
+ * https://www.googleapis.com/service_accounts/v1/metadata/jwk/{serviceAccountEmail}} as a JWKS
+ * document. The verifier selects the key by the JWT {@code kid} header, verifies the signature,
+ * enforces the {@code exp}/{@code iat} time bounds with a small clock-skew tolerance, and returns
+ * the identity carried in the token's {@code iss}/{@code sub} claims.
+ */
+@AutoService(AbstractStsVerifier.class)
+public class GcpStsVerifier extends AbstractStsVerifier {
+  private static final String DEFAULT_JWKS_BASE_URL = "https://www.googleapis.com";
+  private static final String JWKS_PATH = "/service_accounts/v1/metadata/jwk/";
+  private static final String SERVICE_ACCOUNT_DOMAIN_SUFFIX = ".iam.gserviceaccount.com";
+  private static final long CLOCK_SKEW_TOLERANCE_SECONDS = 60L;
+  private static final long DEFAULT_CACHE_TTL_SECONDS = 3600L;
+
+  private final HttpTransportFactory httpTransportFactory;
+  private final String jwksBaseUrl;
+  private final JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
+  private final Map<String, CachedKeys> keyCache = new ConcurrentHashMap<>();
+
+  public GcpStsVerifier() {
+    this(new Builder());
+  }
+
+  public GcpStsVerifier(Builder builder) {
+    super(builder);
+    this.httpTransportFactory = buildHttpTransportFactory(builder);
+    this.jwksBaseUrl = resolveJwksBaseUrl(builder);
+  }
+
+  /** Constructor that accepts a preconfigured transport factory, used by tests. */
+  public GcpStsVerifier(Builder builder, HttpTransportFactory httpTransportFactory) {
+    super(builder);
+    this.httpTransportFactory = httpTransportFactory;
+    this.jwksBaseUrl = resolveJwksBaseUrl(builder);
+  }
+
+  @Override
+  public Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  protected CallerIdentity validateSignedAuthRequest(
+      String signedIdentity, ValidateOptions options) {
+    if (signedIdentity == null || signedIdentity.isEmpty()) {
+      throw new InvalidArgumentException("signedIdentity cannot be empty");
+    }
+
+    JsonWebSignature jws;
+    try {
+      jws = JsonWebSignature.parse(jsonFactory, signedIdentity);
+    } catch (IOException e) {
+      throw new InvalidArgumentException("failed to parse JWT", e);
+    }
+
+    String algorithm = jws.getHeader().getAlgorithm();
+    if (algorithm == null || !algorithm.startsWith("RS")) {
+      throw new InvalidArgumentException("unsupported signing method: " + algorithm);
+    }
+
+    JsonWebSignature.Payload payload = jws.getPayload();
+    String issuer = payload.getIssuer();
+    if (StringUtils.isBlank(issuer)) {
+      throw new InvalidArgumentException("JWT missing iss claim");
+    }
+
+    Map<String, PublicKey> keys = getPublicKeys(issuer);
+    String kid = jws.getHeader().getKeyId();
+    PublicKey publicKey = keys.get(kid);
+    if (publicKey == null) {
+      throw new ResourceNotFoundException(
+          "key ID \"" + kid + "\" not found in public keys for " + issuer);
+    }
+
+    boolean verified;
+    try {
+      verified = jws.verifySignature(publicKey);
+    } catch (Exception e) {
+      throw new UnAuthorizedException("JWT signature verification failed", e);
+    }
+    if (!verified) {
+      throw new UnAuthorizedException("JWT signature verification failed");
+    }
+
+    verifyTimeBounds(payload);
+    verifyExpectedCustomHeaders(payload, options);
+
+    String subject = payload.getSubject();
+    String projectId = projectIdFromIssuer(issuer);
+    return new CallerIdentity(subject, issuer, projectId);
+  }
+
+  private void verifyTimeBounds(JsonWebSignature.Payload payload) {
+    long now = Instant.now().getEpochSecond();
+    Long exp = payload.getExpirationTimeSeconds();
+    if (exp != null && now > exp + CLOCK_SKEW_TOLERANCE_SECONDS) {
+      throw new UnAuthorizedException("JWT is expired");
+    }
+    Long iat = payload.getIssuedAtTimeSeconds();
+    if (iat != null && now + CLOCK_SKEW_TOLERANCE_SECONDS < iat) {
+      throw new UnAuthorizedException("JWT used before issued");
+    }
+  }
+
+  private static void verifyExpectedCustomHeaders(
+      JsonWebSignature.Payload payload, ValidateOptions options) {
+    if (options == null) {
+      return;
+    }
+    for (Map.Entry<String, String> expected : options.getExpectedCustomHeaders().entrySet()) {
+      Object actual = payload.get(expected.getKey());
+      if (actual == null) {
+        throw new InvalidArgumentException(
+            "expected custom header \"" + expected.getKey() + "\" not found in JWT claims");
+      }
+      if (!expected.getValue().equals(String.valueOf(actual))) {
+        throw new InvalidArgumentException(
+            "custom header \"" + expected.getKey() + "\" has an unexpected value");
+      }
+    }
+  }
+
+  private static String projectIdFromIssuer(String issuer) {
+    int at = issuer.indexOf('@');
+    if (at < 0 || at == issuer.length() - 1) {
+      return StringUtils.EMPTY;
+    }
+    String domain = issuer.substring(at + 1);
+    if (domain.endsWith(SERVICE_ACCOUNT_DOMAIN_SUFFIX)) {
+      return domain.substring(0, domain.length() - SERVICE_ACCOUNT_DOMAIN_SUFFIX.length());
+    }
+    return StringUtils.EMPTY;
+  }
+
+  private Map<String, PublicKey> getPublicKeys(String serviceAccountEmail) {
+    CachedKeys cached = keyCache.get(serviceAccountEmail);
+    if (cached != null && Instant.now().getEpochSecond() < cached.expiresAt) {
+      return cached.keys;
+    }
+
+    String url =
+        jwksBaseUrl
+            + JWKS_PATH
+            + URLEncoder.encode(serviceAccountEmail, StandardCharsets.UTF_8);
+    GenericJson response;
+    try {
+      HttpTransport transport =
+          httpTransportFactory != null ? httpTransportFactory.create() : new NetHttpTransport();
+      HttpResponse httpResponse =
+          transport.createRequestFactory().buildGetRequest(new GenericUrl(url)).execute();
+      response =
+          jsonFactory.fromInputStream(
+              httpResponse.getContent(), httpResponse.getContentCharset(), GenericJson.class);
+    } catch (IOException e) {
+      throw new UnknownException("failed to fetch public keys for " + serviceAccountEmail, e);
+    }
+
+    Map<String, PublicKey> keys = parseJwks(response);
+    keyCache.put(
+        serviceAccountEmail,
+        new CachedKeys(keys, Instant.now().getEpochSecond() + DEFAULT_CACHE_TTL_SECONDS));
+    return keys;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, PublicKey> parseJwks(GenericJson response) {
+    Map<String, PublicKey> keys = new HashMap<>();
+    Object keysObject = response.get("keys");
+    if (!(keysObject instanceof List)) {
+      return keys;
+    }
+    Base64.Decoder decoder = Base64.getUrlDecoder();
+    KeyFactory keyFactory;
+    try {
+      keyFactory = KeyFactory.getInstance("RSA");
+    } catch (Exception e) {
+      throw new UnknownException("RSA KeyFactory unavailable", e);
+    }
+    for (Object element : (List<Object>) keysObject) {
+      if (!(element instanceof Map)) {
+        continue;
+      }
+      Map<String, Object> key = (Map<String, Object>) element;
+      String kty = asString(key.get("kty"));
+      if (!"RSA".equals(kty)) {
+        continue;
+      }
+      String kid = asString(key.get("kid"));
+      String modulus = asString(key.get("n"));
+      String exponent = asString(key.get("e"));
+      if (modulus == null || exponent == null) {
+        continue;
+      }
+      try {
+        BigInteger n = new BigInteger(1, decoder.decode(modulus));
+        BigInteger e = new BigInteger(1, decoder.decode(exponent));
+        RSAPublicKey publicKey =
+            (RSAPublicKey) keyFactory.generatePublic(new RSAPublicKeySpec(n, e));
+        keys.put(kid, publicKey);
+      } catch (Exception ex) {
+        throw new UnknownException("failed to decode public key " + kid, ex);
+      }
+    }
+    return keys;
+  }
+
+  private static String asString(Object value) {
+    return value == null ? null : String.valueOf(value);
+  }
+
+  private static String resolveJwksBaseUrl(Builder builder) {
+    if (builder.getEndpoint() != null) {
+      String endpoint = builder.getEndpoint().toString();
+      return endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+    }
+    return DEFAULT_JWKS_BASE_URL;
+  }
+
+  private static HttpTransportFactory buildHttpTransportFactory(Builder builder) {
+    if (builder.getProxyEndpoint() == null
+        && builder.getUseSystemPropertyProxyValues() == null
+        && builder.getUseEnvironmentVariableProxyValues() == null) {
+      return null;
+    }
+    HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+    if (Boolean.FALSE.equals(builder.getUseSystemPropertyProxyValues())) {
+      httpClientBuilder.setRoutePlanner(
+          new org.apache.http.impl.conn.DefaultRoutePlanner(
+              org.apache.http.impl.conn.DefaultSchemePortResolver.INSTANCE) {
+            @Override
+            protected org.apache.http.HttpHost determineProxy(
+                org.apache.http.HttpHost target,
+                org.apache.http.HttpRequest request,
+                org.apache.http.protocol.HttpContext context) {
+              return null;
+            }
+          });
+    } else {
+      httpClientBuilder.useSystemProperties();
+    }
+    httpClientBuilder.setDefaultRequestConfig(buildRequestConfig(builder));
+    CloseableHttpClient httpClient = httpClientBuilder.build();
+    ApacheHttpTransport transport = new ApacheHttpTransport(httpClient);
+    return () -> transport;
+  }
+
+  private static RequestConfig buildRequestConfig(Builder builder) {
+    RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+    if (builder.getProxyEndpoint() != null) {
+      URI endpoint = builder.getProxyEndpoint();
+      requestConfigBuilder.setProxy(
+          new org.apache.http.HttpHost(
+              endpoint.getHost(), endpoint.getPort(), endpoint.getScheme()));
+    }
+    return requestConfigBuilder.build();
+  }
+
+  @Override
+  public SubstrateSdkException mapException(Throwable t) {
+    return ExceptionHandler.build(UnknownException.class, t);
+  }
+
+  private static final class CachedKeys {
+    private final Map<String, PublicKey> keys;
+    private final long expiresAt;
+
+    CachedKeys(Map<String, PublicKey> keys, long expiresAt) {
+      this.keys = keys;
+      this.expiresAt = expiresAt;
+    }
+  }
+
+  public static class Builder extends AbstractStsVerifier.Builder<GcpStsVerifier, Builder> {
+    protected Builder() {
+      providerId(GcpConstants.PROVIDER_ID);
+    }
+
+    @Override
+    public Builder self() {
+      return this;
+    }
+
+    /** Builds a verifier backed by the supplied transport factory, used by tests. */
+    public GcpStsVerifier build(HttpTransportFactory httpTransportFactory) {
+      return new GcpStsVerifier(this, httpTransportFactory);
+    }
+
+    @Override
+    public GcpStsVerifier build() {
+      return new GcpStsVerifier(this);
+    }
+  }
+}

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifier.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifier.java
@@ -56,7 +56,6 @@ public class GcpStsVerifier extends AbstractStsVerifier {
   private static final long DEFAULT_CACHE_TTL_SECONDS = 3600L;
 
   private final HttpTransportFactory httpTransportFactory;
-  private final String jwksBaseUrl;
   private final JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
   private final Map<String, CachedKeys> keyCache = new ConcurrentHashMap<>();
 
@@ -67,14 +66,12 @@ public class GcpStsVerifier extends AbstractStsVerifier {
   public GcpStsVerifier(Builder builder) {
     super(builder);
     this.httpTransportFactory = null;
-    this.jwksBaseUrl = resolveJwksBaseUrl(builder);
   }
 
   /** Constructor that accepts a preconfigured transport factory, used by tests. */
   public GcpStsVerifier(Builder builder, HttpTransportFactory httpTransportFactory) {
     super(builder);
     this.httpTransportFactory = httpTransportFactory;
-    this.jwksBaseUrl = resolveJwksBaseUrl(builder);
   }
 
   @Override
@@ -182,7 +179,7 @@ public class GcpStsVerifier extends AbstractStsVerifier {
     }
 
     String url =
-        jwksBaseUrl
+        DEFAULT_JWKS_BASE_URL
             + JWKS_PATH
             + URLEncoder.encode(serviceAccountEmail, StandardCharsets.UTF_8);
     GenericJson response;
@@ -249,14 +246,6 @@ public class GcpStsVerifier extends AbstractStsVerifier {
 
   private static String asString(Object value) {
     return value == null ? null : String.valueOf(value);
-  }
-
-  private static String resolveJwksBaseUrl(Builder builder) {
-    if (builder.getEndpoint() != null) {
-      String endpoint = builder.getEndpoint().toString();
-      return endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
-    }
-    return DEFAULT_JWKS_BASE_URL;
   }
 
   @Override

--- a/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifier.java
+++ b/sts/sts-gcp/src/main/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifier.java
@@ -3,7 +3,6 @@ package com.salesforce.multicloudj.sts.gcp;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.http.apache.v2.ApacheHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
@@ -23,7 +22,6 @@ import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
@@ -37,9 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 
 /**
  * GCP implementation of the STS verifier. It validates a signed identity that is a JWT produced by
@@ -71,7 +66,7 @@ public class GcpStsVerifier extends AbstractStsVerifier {
 
   public GcpStsVerifier(Builder builder) {
     super(builder);
-    this.httpTransportFactory = buildHttpTransportFactory(builder);
+    this.httpTransportFactory = null;
     this.jwksBaseUrl = resolveJwksBaseUrl(builder);
   }
 
@@ -262,45 +257,6 @@ public class GcpStsVerifier extends AbstractStsVerifier {
       return endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
     }
     return DEFAULT_JWKS_BASE_URL;
-  }
-
-  private static HttpTransportFactory buildHttpTransportFactory(Builder builder) {
-    if (builder.getProxyEndpoint() == null
-        && builder.getUseSystemPropertyProxyValues() == null
-        && builder.getUseEnvironmentVariableProxyValues() == null) {
-      return null;
-    }
-    HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-    if (Boolean.FALSE.equals(builder.getUseSystemPropertyProxyValues())) {
-      httpClientBuilder.setRoutePlanner(
-          new org.apache.http.impl.conn.DefaultRoutePlanner(
-              org.apache.http.impl.conn.DefaultSchemePortResolver.INSTANCE) {
-            @Override
-            protected org.apache.http.HttpHost determineProxy(
-                org.apache.http.HttpHost target,
-                org.apache.http.HttpRequest request,
-                org.apache.http.protocol.HttpContext context) {
-              return null;
-            }
-          });
-    } else {
-      httpClientBuilder.useSystemProperties();
-    }
-    httpClientBuilder.setDefaultRequestConfig(buildRequestConfig(builder));
-    CloseableHttpClient httpClient = httpClientBuilder.build();
-    ApacheHttpTransport transport = new ApacheHttpTransport(httpClient);
-    return () -> transport;
-  }
-
-  private static RequestConfig buildRequestConfig(Builder builder) {
-    RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
-    if (builder.getProxyEndpoint() != null) {
-      URI endpoint = builder.getProxyEndpoint();
-      requestConfigBuilder.setProxy(
-          new org.apache.http.HttpHost(
-              endpoint.getHost(), endpoint.getPort(), endpoint.getScheme()));
-    }
-    return requestConfigBuilder.build();
   }
 
   @Override

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsUtilitiesTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsUtilitiesTest.java
@@ -1,0 +1,202 @@
+package com.salesforce.multicloudj.sts.gcp;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.json.webtoken.JsonWebSignature;
+import com.google.api.client.json.webtoken.JsonWebToken;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import com.salesforce.multicloudj.common.exceptions.UnknownException;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.SignOptions;
+import com.salesforce.multicloudj.sts.model.SignedAuthRequest;
+import com.salesforce.multicloudj.sts.model.ValidateOptions;
+import java.math.BigInteger;
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GcpStsUtilitiesTest {
+
+  private static final String SERVICE_ACCOUNT = "test-sa@my-project.iam.gserviceaccount.com";
+  private static final String KID = "test-key-1";
+
+  private WireMockServer wireMockServer;
+  private KeyPair keyPair;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+    wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+    wireMockServer.start();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (wireMockServer != null) {
+      wireMockServer.stop();
+    }
+  }
+
+  @Test
+  void providerId() {
+    Assertions.assertEquals("gcp", new GcpStsUtilities().getProviderId());
+  }
+
+  @Test
+  void signsJwtWithIssuerAndSubject() throws Exception {
+    SignedAuthRequest signed =
+        signer().newCloudNativeAuthSignedRequest(null, SignOptions.builder().build());
+
+    String jwt = signed.getSignedIdentity();
+    Assertions.assertNotNull(jwt);
+    // The signed identity and the credentials' security token are the same self-contained JWT.
+    Assertions.assertEquals(jwt, signed.getCredentials().getSecurityToken());
+
+    JsonWebSignature parsed = JsonWebSignature.parse(GsonFactory.getDefaultInstance(), jwt);
+    Assertions.assertEquals("RS256", parsed.getHeader().getAlgorithm());
+    Assertions.assertEquals(KID, parsed.getHeader().getKeyId());
+    Assertions.assertEquals(SERVICE_ACCOUNT, parsed.getPayload().getIssuer());
+    Assertions.assertEquals(SERVICE_ACCOUNT, parsed.getPayload().getSubject());
+    Assertions.assertNotNull(parsed.getPayload().getIssuedAtTimeSeconds());
+    Assertions.assertNotNull(parsed.getPayload().getExpirationTimeSeconds());
+    Assertions.assertEquals(
+        300L,
+        parsed.getPayload().getExpirationTimeSeconds()
+            - parsed.getPayload().getIssuedAtTimeSeconds());
+  }
+
+  @Test
+  void signedJwtRoundTripsThroughVerifier() {
+    stubJwks();
+    Map<String, String> customHeaders = new LinkedHashMap<>();
+    customHeaders.put("x-target-resource", "my-service");
+
+    SignOptions signOptions = SignOptions.builder().withCustomHeaders(customHeaders).build();
+    SignedAuthRequest signed = signer().newCloudNativeAuthSignedRequest(null, signOptions);
+
+    ValidateOptions validateOptions =
+        ValidateOptions.builder().withExpectedCustomHeaders(customHeaders).build();
+    CallerIdentity identity =
+        verifier().verifySignedAuthRequest(signed.getSignedIdentity(), validateOptions);
+
+    Assertions.assertEquals(SERVICE_ACCOUNT, identity.getUserId());
+    Assertions.assertEquals(SERVICE_ACCOUNT, identity.getCloudResourceName());
+    Assertions.assertEquals("my-project", identity.getAccountId());
+  }
+
+  @Test
+  void customHeadersAreSignedAsClaims() throws Exception {
+    Map<String, String> customHeaders = new LinkedHashMap<>();
+    customHeaders.put("x-request-source", "example");
+    customHeaders.put("x-tenant-id", "tenant-42");
+
+    SignOptions signOptions = SignOptions.builder().withCustomHeaders(customHeaders).build();
+    SignedAuthRequest signed = signer().newCloudNativeAuthSignedRequest(null, signOptions);
+
+    JsonWebSignature parsed =
+        JsonWebSignature.parse(GsonFactory.getDefaultInstance(), signed.getSignedIdentity());
+    Assertions.assertEquals("example", parsed.getPayload().get("x-request-source"));
+    Assertions.assertEquals("tenant-42", parsed.getPayload().get("x-tenant-id"));
+  }
+
+  @Test
+  void nullOptionsProducesBareIdentity() throws Exception {
+    SignedAuthRequest signed = signer().newCloudNativeAuthSignedRequest(null);
+    JsonWebSignature parsed =
+        JsonWebSignature.parse(GsonFactory.getDefaultInstance(), signed.getSignedIdentity());
+    Assertions.assertEquals(SERVICE_ACCOUNT, parsed.getPayload().getIssuer());
+  }
+
+  @Test
+  void signingFailureWrappedAsUnknown() {
+    GcpStsUtilities utilities =
+        new GcpStsUtilities.Builder()
+            .build(
+                (name, payload) -> {
+                  throw new java.io.IOException("permission denied");
+                },
+                SERVICE_ACCOUNT);
+    Assertions.assertThrows(
+        UnknownException.class,
+        () -> utilities.newCloudNativeAuthSignedRequest(null, SignOptions.builder().build()));
+  }
+
+  @Test
+  void mapExceptionWrapsAsUnknown() {
+    SubstrateSdkException mapped =
+        new GcpStsUtilities().mapException(new RuntimeException("boom"));
+    Assertions.assertInstanceOf(UnknownException.class, mapped);
+  }
+
+  /** Builds a signer whose signing seam signs the claims payload with the test RSA key. */
+  private GcpStsUtilities signer() {
+    return new GcpStsUtilities.Builder().build(this::signPayload, SERVICE_ACCOUNT);
+  }
+
+  private String signPayload(String serviceAccountName, String payload) throws java.io.IOException {
+    Assertions.assertEquals("projects/-/serviceAccounts/" + SERVICE_ACCOUNT, serviceAccountName);
+    JsonWebToken.Payload claims =
+        GsonFactory.getDefaultInstance()
+            .createJsonParser(payload)
+            .parse(JsonWebToken.Payload.class);
+    JsonWebSignature.Header header =
+        new JsonWebSignature.Header().setAlgorithm("RS256").setType("JWT").setKeyId(KID);
+    try {
+      return JsonWebSignature.signUsingRsaSha256(
+          keyPair.getPrivate(), GsonFactory.getDefaultInstance(), header, claims);
+    } catch (java.security.GeneralSecurityException e) {
+      throw new java.io.IOException(e);
+    }
+  }
+
+  private GcpStsVerifier verifier() {
+    return new GcpStsVerifier.Builder()
+        .withEndpoint(URI.create("http://localhost:" + wireMockServer.port()))
+        .build();
+  }
+
+  private void stubJwks() {
+    RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+    Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+    String n = encoder.encodeToString(toUnsignedBytes(publicKey.getModulus()));
+    String e = encoder.encodeToString(toUnsignedBytes(publicKey.getPublicExponent()));
+    String jwks =
+        "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\""
+            + KID
+            + "\",\"n\":\""
+            + n
+            + "\",\"e\":\""
+            + e
+            + "\"}]}";
+    wireMockServer.stubFor(
+        get(urlMatching("/service_accounts/v1/metadata/jwk/.*"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(jwks)));
+  }
+
+  private static byte[] toUnsignedBytes(BigInteger value) {
+    byte[] bytes = value.toByteArray();
+    if (bytes.length > 1 && bytes[0] == 0) {
+      byte[] trimmed = new byte[bytes.length - 1];
+      System.arraycopy(bytes, 1, trimmed, 0, trimmed.length);
+      return trimmed;
+    }
+    return bytes;
+  }
+}

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsUtilitiesTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsUtilitiesTest.java
@@ -1,16 +1,15 @@
 package com.salesforce.multicloudj.sts.gcp;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.json.webtoken.JsonWebToken;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.StatusCode;
+import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ImpersonatedCredentials;
@@ -35,14 +34,12 @@ import com.salesforce.multicloudj.sts.model.SignOptions;
 import com.salesforce.multicloudj.sts.model.SignedAuthRequest;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
 import java.math.BigInteger;
-import java.net.URI;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,21 +51,11 @@ class GcpStsUtilitiesTest {
   private static final String SERVICE_ACCOUNT = "test-sa@my-project.iam.gserviceaccount.com";
   private static final String KID = "test-key-1";
 
-  private WireMockServer wireMockServer;
   private KeyPair keyPair;
 
   @BeforeEach
   void setUp() throws Exception {
     keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
-    wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
-    wireMockServer.start();
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (wireMockServer != null) {
-      wireMockServer.stop();
-    }
   }
 
   @Test
@@ -167,7 +154,6 @@ class GcpStsUtilitiesTest {
 
   @Test
   void signedJwtRoundTripsThroughVerifier() {
-    stubJwks();
     Map<String, String> customHeaders = new LinkedHashMap<>();
     customHeaders.put("x-target-resource", "my-service");
 
@@ -373,32 +359,42 @@ class GcpStsUtilitiesTest {
     }
   }
 
+  /** Builds a verifier whose JWKS fetch returns the current key pair's public key document. */
   private GcpStsVerifier verifier() {
-    return new GcpStsVerifier.Builder()
-        .withEndpoint(URI.create("http://localhost:" + wireMockServer.port()))
-        .build();
+    HttpTransportFactory factory = () -> transportReturning(jwksBody());
+    return new GcpStsVerifier.Builder().build(factory);
   }
 
-  private void stubJwks() {
+  private static HttpTransport transportReturning(String body) {
+    return new MockHttpTransport() {
+      @Override
+      public MockLowLevelHttpRequest buildRequest(String method, String url) {
+        return new MockLowLevelHttpRequest() {
+          @Override
+          public MockLowLevelHttpResponse execute() {
+            MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+            response.setStatusCode(200);
+            response.setContentType("application/json");
+            response.setContent(body);
+            return response;
+          }
+        };
+      }
+    };
+  }
+
+  private String jwksBody() {
     RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
     Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
     String n = encoder.encodeToString(toUnsignedBytes(publicKey.getModulus()));
     String e = encoder.encodeToString(toUnsignedBytes(publicKey.getPublicExponent()));
-    String jwks =
-        "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\""
-            + KID
-            + "\",\"n\":\""
-            + n
-            + "\",\"e\":\""
-            + e
-            + "\"}]}";
-    wireMockServer.stubFor(
-        get(urlMatching("/service_accounts/v1/metadata/jwk/.*"))
-            .willReturn(
-                aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody(jwks)));
+    return "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\""
+        + KID
+        + "\",\"n\":\""
+        + n
+        + "\",\"e\":\""
+        + e
+        + "\"}]}";
   }
 
   private static byte[] toUnsignedBytes(BigInteger value) {

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsUtilitiesTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsUtilitiesTest.java
@@ -15,6 +15,9 @@ import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ImpersonatedCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
+import com.google.cloud.iam.credentials.v1.IamCredentialsSettings;
+import com.google.cloud.iam.credentials.v1.SignJwtResponse;
 import com.salesforce.multicloudj.common.exceptions.DeadlineExceededException;
 import com.salesforce.multicloudj.common.exceptions.FailedPreconditionException;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
@@ -71,6 +74,72 @@ class GcpStsUtilitiesTest {
   @Test
   void providerId() {
     Assertions.assertEquals("gcp", new GcpStsUtilities().getProviderId());
+  }
+
+  @Test
+  void builderAndDefaultBuildProduceGcpUtilities() {
+    Assertions.assertEquals("gcp", new GcpStsUtilities().builder().build().getProviderId());
+    Assertions.assertEquals("gcp", new GcpStsUtilities.Builder().build().getProviderId());
+  }
+
+  @Test
+  void signsThroughIamCredentialsClient() throws Exception {
+    GoogleCredentials source = Mockito.mock(GoogleCredentials.class);
+    Mockito.when(source.createScopedRequired()).thenReturn(true);
+    Mockito.when(source.createScoped(Mockito.anyCollection())).thenReturn(source);
+    IamCredentialsClient client = Mockito.mock(IamCredentialsClient.class);
+    SignJwtResponse response =
+        SignJwtResponse.newBuilder().setSignedJwt("signed.jwt.token").build();
+    Mockito.when(client.signJwt(Mockito.anyString(), Mockito.anyList(), Mockito.anyString()))
+        .thenReturn(response);
+
+    // No injected signer, so the production IAM-backed path runs; the email override skips
+    // auto-detection so this isolates the IAM signing seam.
+    GcpStsUtilities utilities =
+        new GcpStsUtilities.Builder().build((GcpStsUtilities.JwtSigner) null, SERVICE_ACCOUNT);
+    try (MockedStatic<GoogleCredentials> mockedGoogleCreds =
+            Mockito.mockStatic(GoogleCredentials.class);
+        MockedStatic<IamCredentialsClient> mockedClient =
+            Mockito.mockStatic(IamCredentialsClient.class)) {
+      mockedGoogleCreds.when(GoogleCredentials::getApplicationDefault).thenReturn(source);
+      mockedClient
+          .when(() -> IamCredentialsClient.create(Mockito.any(IamCredentialsSettings.class)))
+          .thenReturn(client);
+
+      SignedAuthRequest signed =
+          utilities.newCloudNativeAuthSignedRequest(null, SignOptions.builder().build());
+      Assertions.assertEquals("signed.jwt.token", signed.getSignedIdentity());
+    }
+  }
+
+  @Test
+  void signsThroughIamCredentialsClientImpersonatingRole() throws Exception {
+    String role = "impersonated-sa@my-project.iam.gserviceaccount.com";
+    GoogleCredentials source = Mockito.mock(GoogleCredentials.class);
+    Mockito.when(source.createScopedRequired()).thenReturn(false);
+    IamCredentialsClient client = Mockito.mock(IamCredentialsClient.class);
+    SignJwtResponse response =
+        SignJwtResponse.newBuilder().setSignedJwt("impersonated.jwt").build();
+    Mockito.when(client.signJwt(Mockito.anyString(), Mockito.anyList(), Mockito.anyString()))
+        .thenReturn(response);
+
+    GcpStsUtilities.Builder builder = new GcpStsUtilities.Builder();
+    builder.withCredentialsOverrider(
+        new CredentialsOverrider.Builder(CredentialsType.ASSUME_ROLE).withRole(role).build());
+    GcpStsUtilities utilities = builder.build((GcpStsUtilities.JwtSigner) null, null);
+    try (MockedStatic<GoogleCredentials> mockedGoogleCreds =
+            Mockito.mockStatic(GoogleCredentials.class);
+        MockedStatic<IamCredentialsClient> mockedClient =
+            Mockito.mockStatic(IamCredentialsClient.class)) {
+      mockedGoogleCreds.when(GoogleCredentials::getApplicationDefault).thenReturn(source);
+      mockedClient
+          .when(() -> IamCredentialsClient.create(Mockito.any(IamCredentialsSettings.class)))
+          .thenReturn(client);
+
+      SignedAuthRequest signed =
+          utilities.newCloudNativeAuthSignedRequest(null, SignOptions.builder().build());
+      Assertions.assertEquals("impersonated.jwt", signed.getSignedIdentity());
+    }
   }
 
   @Test

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsUtilitiesTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsUtilitiesTest.java
@@ -9,9 +9,25 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.json.webtoken.JsonWebToken;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.auth.oauth2.ComputeEngineCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ImpersonatedCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.salesforce.multicloudj.common.exceptions.DeadlineExceededException;
+import com.salesforce.multicloudj.common.exceptions.FailedPreconditionException;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.ResourceAlreadyExistsException;
+import com.salesforce.multicloudj.common.exceptions.ResourceExhaustedException;
+import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.common.exceptions.UnSupportedOperationException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.CredentialsOverrider;
+import com.salesforce.multicloudj.sts.model.CredentialsType;
 import com.salesforce.multicloudj.sts.model.SignOptions;
 import com.salesforce.multicloudj.sts.model.SignedAuthRequest;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
@@ -27,6 +43,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 class GcpStsUtilitiesTest {
 
@@ -141,9 +159,133 @@ class GcpStsUtilitiesTest {
     Assertions.assertInstanceOf(UnknownException.class, mapped);
   }
 
+  @Test
+  void mapExceptionMapsApiExceptionStatusCodes() {
+    GcpStsUtilities utilities = new GcpStsUtilities();
+    assertExceptionMapping(utilities, StatusCode.Code.CANCELLED, UnknownException.class);
+    assertExceptionMapping(utilities, StatusCode.Code.UNKNOWN, UnknownException.class);
+    assertExceptionMapping(
+        utilities, StatusCode.Code.INVALID_ARGUMENT, InvalidArgumentException.class);
+    assertExceptionMapping(
+        utilities, StatusCode.Code.DEADLINE_EXCEEDED, DeadlineExceededException.class);
+    assertExceptionMapping(utilities, StatusCode.Code.NOT_FOUND, ResourceNotFoundException.class);
+    assertExceptionMapping(
+        utilities, StatusCode.Code.ALREADY_EXISTS, ResourceAlreadyExistsException.class);
+    assertExceptionMapping(
+        utilities, StatusCode.Code.PERMISSION_DENIED, UnAuthorizedException.class);
+    assertExceptionMapping(
+        utilities, StatusCode.Code.RESOURCE_EXHAUSTED, ResourceExhaustedException.class);
+    assertExceptionMapping(
+        utilities, StatusCode.Code.FAILED_PRECONDITION, FailedPreconditionException.class);
+    assertExceptionMapping(utilities, StatusCode.Code.ABORTED, DeadlineExceededException.class);
+    assertExceptionMapping(
+        utilities, StatusCode.Code.OUT_OF_RANGE, InvalidArgumentException.class);
+    assertExceptionMapping(
+        utilities, StatusCode.Code.UNIMPLEMENTED, UnSupportedOperationException.class);
+    assertExceptionMapping(utilities, StatusCode.Code.INTERNAL, UnknownException.class);
+    assertExceptionMapping(utilities, StatusCode.Code.UNAVAILABLE, UnknownException.class);
+    assertExceptionMapping(utilities, StatusCode.Code.DATA_LOSS, UnknownException.class);
+    assertExceptionMapping(
+        utilities, StatusCode.Code.UNAUTHENTICATED, UnAuthorizedException.class);
+  }
+
+  @Test
+  void mapExceptionWithNullStatusCodeWrapsAsUnknown() {
+    ApiException apiException = Mockito.mock(ApiException.class);
+    Mockito.when(apiException.getStatusCode()).thenReturn(null);
+    Assertions.assertInstanceOf(
+        UnknownException.class, new GcpStsUtilities().mapException(apiException));
+  }
+
+  @Test
+  void credentialsOverriderRoleIsUsedAsSigningServiceAccount() throws Exception {
+    String role = "impersonated-sa@my-project.iam.gserviceaccount.com";
+    GcpStsUtilities.Builder builder = new GcpStsUtilities.Builder();
+    builder.withCredentialsOverrider(
+        new CredentialsOverrider.Builder(CredentialsType.ASSUME_ROLE).withRole(role).build());
+    GcpStsUtilities utilities = builder.build(this::signAnyPayload, null);
+
+    SignedAuthRequest signed =
+        utilities.newCloudNativeAuthSignedRequest(null, SignOptions.builder().build());
+    JsonWebSignature parsed =
+        JsonWebSignature.parse(GsonFactory.getDefaultInstance(), signed.getSignedIdentity());
+    Assertions.assertEquals(role, parsed.getPayload().getIssuer());
+    Assertions.assertEquals(role, parsed.getPayload().getSubject());
+  }
+
+  @Test
+  void resolvesServiceAccountFromServiceAccountCredentials() throws Exception {
+    ServiceAccountCredentials credentials = Mockito.mock(ServiceAccountCredentials.class);
+    Mockito.when(credentials.getClientEmail()).thenReturn(SERVICE_ACCOUNT);
+    Assertions.assertEquals(SERVICE_ACCOUNT, resolvedIssuerWithApplicationDefault(credentials));
+  }
+
+  @Test
+  void resolvesServiceAccountFromImpersonatedCredentials() throws Exception {
+    ImpersonatedCredentials credentials = Mockito.mock(ImpersonatedCredentials.class);
+    Mockito.when(credentials.getAccount()).thenReturn(SERVICE_ACCOUNT);
+    Assertions.assertEquals(SERVICE_ACCOUNT, resolvedIssuerWithApplicationDefault(credentials));
+  }
+
+  @Test
+  void resolvesServiceAccountFromComputeEngineCredentials() throws Exception {
+    ComputeEngineCredentials credentials = Mockito.mock(ComputeEngineCredentials.class);
+    Mockito.when(credentials.getAccount()).thenReturn(SERVICE_ACCOUNT);
+    Assertions.assertEquals(SERVICE_ACCOUNT, resolvedIssuerWithApplicationDefault(credentials));
+  }
+
+  /**
+   * Signs an identity while Application Default Credentials resolve to {@code credentials}, and
+   * returns the {@code iss} claim of the produced JWT (i.e. the auto-detected service account).
+   */
+  private String resolvedIssuerWithApplicationDefault(GoogleCredentials credentials)
+      throws Exception {
+    GcpStsUtilities utilities =
+        new GcpStsUtilities.Builder().build(this::signAnyPayload, null);
+    try (MockedStatic<GoogleCredentials> mockedGoogleCreds =
+        Mockito.mockStatic(GoogleCredentials.class)) {
+      mockedGoogleCreds
+          .when(GoogleCredentials::getApplicationDefault)
+          .thenReturn(credentials);
+      SignedAuthRequest signed =
+          utilities.newCloudNativeAuthSignedRequest(null, SignOptions.builder().build());
+      return JsonWebSignature.parse(GsonFactory.getDefaultInstance(), signed.getSignedIdentity())
+          .getPayload()
+          .getIssuer();
+    }
+  }
+
+  private void assertExceptionMapping(
+      GcpStsUtilities utilities,
+      StatusCode.Code statusCode,
+      Class<? extends SubstrateSdkException> expected) {
+    ApiException apiException = Mockito.mock(ApiException.class);
+    StatusCode mockStatusCode = Mockito.mock(StatusCode.class);
+    Mockito.when(apiException.getStatusCode()).thenReturn(mockStatusCode);
+    Mockito.when(mockStatusCode.getCode()).thenReturn(statusCode);
+    Assertions.assertInstanceOf(expected, utilities.mapException(apiException));
+  }
+
   /** Builds a signer whose signing seam signs the claims payload with the test RSA key. */
   private GcpStsUtilities signer() {
     return new GcpStsUtilities.Builder().build(this::signPayload, SERVICE_ACCOUNT);
+  }
+
+  /** Signs the claims for any service account without asserting a specific resource name. */
+  private String signAnyPayload(String serviceAccountName, String payload)
+      throws java.io.IOException {
+    JsonWebToken.Payload claims =
+        GsonFactory.getDefaultInstance()
+            .createJsonParser(payload)
+            .parse(JsonWebToken.Payload.class);
+    JsonWebSignature.Header header =
+        new JsonWebSignature.Header().setAlgorithm("RS256").setType("JWT").setKeyId(KID);
+    try {
+      return JsonWebSignature.signUsingRsaSha256(
+          keyPair.getPrivate(), GsonFactory.getDefaultInstance(), header, claims);
+    } catch (java.security.GeneralSecurityException e) {
+      throw new java.io.IOException(e);
+    }
   }
 
   private String signPayload(String serviceAccountName, String payload) throws java.io.IOException {

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifierTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifierTest.java
@@ -11,10 +11,13 @@ import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.json.webtoken.JsonWebToken;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
 import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPublicKey;
@@ -123,10 +126,145 @@ class GcpStsVerifierTest {
         InvalidArgumentException.class, () -> verifier().verifySignedAuthRequest(jwt, options));
   }
 
+  @Test
+  void malformedJwtThrowsInvalidArgument() {
+    Assertions.assertThrows(
+        InvalidArgumentException.class,
+        () -> verifier().verifySignedAuthRequest("not-a-jwt-at-all"));
+  }
+
+  @Test
+  void unsupportedAlgorithmThrowsInvalidArgument() {
+    String token = manualToken("{\"alg\":\"HS256\",\"typ\":\"JWT\"}", "{\"iss\":\"x\"}");
+    Assertions.assertThrows(
+        InvalidArgumentException.class, () -> verifier().verifySignedAuthRequest(token));
+  }
+
+  @Test
+  void missingAlgorithmThrowsInvalidArgument() {
+    String token = manualToken("{\"typ\":\"JWT\"}", "{\"iss\":\"x\"}");
+    Assertions.assertThrows(
+        InvalidArgumentException.class, () -> verifier().verifySignedAuthRequest(token));
+  }
+
+  @Test
+  void missingIssuerThrowsInvalidArgument() throws Exception {
+    String token = signJwtWithoutIssuer(Instant.now());
+    Assertions.assertThrows(
+        InvalidArgumentException.class, () -> verifier().verifySignedAuthRequest(token));
+  }
+
+  @Test
+  void jwksFetchFailureThrowsUnknown() throws Exception {
+    // No JWKS stub configured; WireMock returns 404 and the fetch fails.
+    String jwt = signJwt(Instant.now(), null);
+    Assertions.assertThrows(
+        UnknownException.class, () -> verifier().verifySignedAuthRequest(jwt));
+  }
+
+  @Test
+  void issuedInFutureThrowsUnauthorized() throws Exception {
+    stubJwks();
+    String jwt = signJwt(Instant.now().plusSeconds(3600), null);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier().verifySignedAuthRequest(jwt));
+  }
+
+  @Test
+  void issuerWithoutServiceAccountDomainYieldsEmptyAccountId() throws Exception {
+    stubJwks();
+    String jwt = signJwtWithIssuer(Instant.now(), "plain-issuer-no-at-sign");
+
+    CallerIdentity identity = verifier().verifySignedAuthRequest(jwt);
+    Assertions.assertEquals("", identity.getAccountId());
+    Assertions.assertEquals("plain-issuer-no-at-sign", identity.getUserId());
+  }
+
+  @Test
+  void jwksWithoutMatchingKeyThrowsNotFound() throws Exception {
+    // JWKS body has a non-RSA key and a key missing modulus - both skipped, none match.
+    String jwks =
+        "{\"keys\":[{\"kty\":\"oct\",\"kid\":\"" + KID + "\"},"
+            + "{\"kty\":\"RSA\",\"kid\":\"" + KID + "\",\"e\":\"AQAB\"}]}";
+    wireMockServer.stubFor(
+        get(urlMatching("/service_accounts/v1/metadata/jwk/.*"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(jwks)));
+    String jwt = signJwt(Instant.now(), null);
+
+    Assertions.assertThrows(
+        ResourceNotFoundException.class, () -> verifier().verifySignedAuthRequest(jwt));
+  }
+
+  @Test
+  void cachedKeysReusedOnSecondCall() throws Exception {
+    stubJwks();
+    GcpStsVerifier verifier = verifier();
+    String jwt1 = signJwt(Instant.now(), null);
+    String jwt2 = signJwt(Instant.now(), null);
+
+    Assertions.assertEquals(SERVICE_ACCOUNT, verifier.verifySignedAuthRequest(jwt1).getUserId());
+    Assertions.assertEquals(SERVICE_ACCOUNT, verifier.verifySignedAuthRequest(jwt2).getUserId());
+    wireMockServer.verify(
+        1, com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor(
+            urlMatching("/service_accounts/v1/metadata/jwk/.*")));
+  }
+
+  @Test
+  void buildWithProxyCreatesRealVerifier() {
+    GcpStsVerifier verifier =
+        new GcpStsVerifier.Builder()
+            .withProxyEndpoint(URI.create("http://localhost:8888"))
+            .withUseSystemPropertyProxyValues(false)
+            .build();
+    Assertions.assertEquals("gcp", verifier.getProviderId());
+  }
+
+  @Test
+  void mapExceptionWrapsAsUnknown() {
+    SubstrateSdkException mapped =
+        new GcpStsVerifier().mapException(new RuntimeException("boom"));
+    Assertions.assertInstanceOf(UnknownException.class, mapped);
+  }
+
   private GcpStsVerifier verifier() {
     return new GcpStsVerifier.Builder()
         .withEndpoint(URI.create("http://localhost:" + wireMockServer.port()))
         .build();
+  }
+
+  private static String manualToken(String headerJson, String payloadJson) {
+    Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+    return encoder.encodeToString(headerJson.getBytes(StandardCharsets.UTF_8))
+        + "."
+        + encoder.encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8))
+        + "."
+        + encoder.encodeToString("sig".getBytes(StandardCharsets.UTF_8));
+  }
+
+  private String signJwtWithoutIssuer(Instant issuedAt) throws Exception {
+    JsonWebSignature.Header header =
+        new JsonWebSignature.Header().setAlgorithm("RS256").setType("JWT").setKeyId(KID);
+    JsonWebToken.Payload payload = new JsonWebToken.Payload();
+    payload.setIssuedAtTimeSeconds(issuedAt.getEpochSecond());
+    payload.setExpirationTimeSeconds(issuedAt.plusSeconds(300).getEpochSecond());
+    return JsonWebSignature.signUsingRsaSha256(
+        keyPair.getPrivate(), GsonFactory.getDefaultInstance(), header, payload);
+  }
+
+  private String signJwtWithIssuer(Instant issuedAt, String issuer) throws Exception {
+    JsonWebSignature.Header header =
+        new JsonWebSignature.Header().setAlgorithm("RS256").setType("JWT").setKeyId(KID);
+    JsonWebToken.Payload payload = new JsonWebToken.Payload();
+    payload.setIssuer(issuer);
+    payload.setSubject(issuer);
+    payload.setIssuedAtTimeSeconds(issuedAt.getEpochSecond());
+    payload.setExpirationTimeSeconds(issuedAt.plusSeconds(300).getEpochSecond());
+    return JsonWebSignature.signUsingRsaSha256(
+        keyPair.getPrivate(), GsonFactory.getDefaultInstance(), header, payload);
   }
 
   private void stubJwks() {

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifierTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifierTest.java
@@ -1,0 +1,182 @@
+package com.salesforce.multicloudj.sts.gcp;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.json.webtoken.JsonWebSignature;
+import com.google.api.client.json.webtoken.JsonWebToken;
+import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
+import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
+import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
+import com.salesforce.multicloudj.sts.model.CallerIdentity;
+import com.salesforce.multicloudj.sts.model.ValidateOptions;
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.Base64;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GcpStsVerifierTest {
+
+  private static final String SERVICE_ACCOUNT =
+      "test-sa@my-project.iam.gserviceaccount.com";
+  private static final String KID = "test-key-1";
+
+  private WireMockServer wireMockServer;
+  private KeyPair keyPair;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+    wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+    wireMockServer.start();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (wireMockServer != null) {
+      wireMockServer.stop();
+    }
+  }
+
+  @Test
+  void providerId() {
+    Assertions.assertEquals("gcp", new GcpStsVerifier().getProviderId());
+  }
+
+  @Test
+  void returnsCallerIdentityFromValidJwt() throws Exception {
+    stubJwks();
+    String jwt = signJwt(Instant.now(), null);
+
+    CallerIdentity identity = verifier().verifySignedAuthRequest(jwt);
+
+    Assertions.assertEquals(SERVICE_ACCOUNT, identity.getUserId());
+    Assertions.assertEquals(SERVICE_ACCOUNT, identity.getCloudResourceName());
+    Assertions.assertEquals("my-project", identity.getAccountId());
+  }
+
+  @Test
+  void rejectsEmptySignedIdentity() {
+    Assertions.assertThrows(
+        InvalidArgumentException.class, () -> verifier().verifySignedAuthRequest(""));
+  }
+
+  @Test
+  void expiredJwtThrowsUnauthorized() throws Exception {
+    stubJwks();
+    String jwt = signJwt(Instant.now().minusSeconds(3600), null);
+
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier().verifySignedAuthRequest(jwt));
+  }
+
+  @Test
+  void unknownKeyIdThrowsNotFound() throws Exception {
+    stubJwks();
+    String jwt = signJwt(Instant.now(), "other-kid", null);
+
+    Assertions.assertThrows(
+        ResourceNotFoundException.class, () -> verifier().verifySignedAuthRequest(jwt));
+  }
+
+  @Test
+  void tamperedSignatureThrowsUnauthorized() throws Exception {
+    stubJwks();
+    String jwt = signJwt(Instant.now(), null);
+    String tampered = jwt.substring(0, jwt.length() - 4) + "AAAA";
+
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier().verifySignedAuthRequest(tampered));
+  }
+
+  @Test
+  void matchingExpectedCustomHeaderPasses() throws Exception {
+    stubJwks();
+    String jwt = signJwt(Instant.now(), "my-service");
+    ValidateOptions options =
+        ValidateOptions.builder()
+            .withExpectedCustomHeader("x-target-resource", "my-service")
+            .build();
+
+    CallerIdentity identity = verifier().verifySignedAuthRequest(jwt, options);
+    Assertions.assertEquals("my-project", identity.getAccountId());
+  }
+
+  @Test
+  void mismatchedExpectedCustomHeaderFails() throws Exception {
+    stubJwks();
+    String jwt = signJwt(Instant.now(), "my-service");
+    ValidateOptions options =
+        ValidateOptions.builder().withExpectedCustomHeader("x-target-resource", "other").build();
+
+    Assertions.assertThrows(
+        InvalidArgumentException.class, () -> verifier().verifySignedAuthRequest(jwt, options));
+  }
+
+  private GcpStsVerifier verifier() {
+    return new GcpStsVerifier.Builder()
+        .withEndpoint(URI.create("http://localhost:" + wireMockServer.port()))
+        .build();
+  }
+
+  private void stubJwks() {
+    RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+    Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+    String n = encoder.encodeToString(toUnsignedBytes(publicKey.getModulus()));
+    String e = encoder.encodeToString(toUnsignedBytes(publicKey.getPublicExponent()));
+    String jwks =
+        "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\""
+            + KID
+            + "\",\"n\":\""
+            + n
+            + "\",\"e\":\""
+            + e
+            + "\"}]}";
+    wireMockServer.stubFor(
+        get(urlMatching("/service_accounts/v1/metadata/jwk/.*"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(jwks)));
+  }
+
+  private String signJwt(Instant issuedAt, String targetResource) throws Exception {
+    return signJwt(issuedAt, KID, targetResource);
+  }
+
+  private String signJwt(Instant issuedAt, String kid, String targetResource) throws Exception {
+    JsonWebSignature.Header header =
+        new JsonWebSignature.Header().setAlgorithm("RS256").setType("JWT").setKeyId(kid);
+    JsonWebToken.Payload payload = new JsonWebToken.Payload();
+    payload.setIssuer(SERVICE_ACCOUNT);
+    payload.setSubject(SERVICE_ACCOUNT);
+    payload.setIssuedAtTimeSeconds(issuedAt.getEpochSecond());
+    payload.setExpirationTimeSeconds(issuedAt.plusSeconds(300).getEpochSecond());
+    if (targetResource != null) {
+      payload.set("x-target-resource", targetResource);
+    }
+    return JsonWebSignature.signUsingRsaSha256(
+        keyPair.getPrivate(), GsonFactory.getDefaultInstance(), header, payload);
+  }
+
+  private static byte[] toUnsignedBytes(java.math.BigInteger value) {
+    byte[] bytes = value.toByteArray();
+    if (bytes.length > 1 && bytes[0] == 0) {
+      byte[] trimmed = new byte[bytes.length - 1];
+      System.arraycopy(bytes, 1, trimmed, 0, trimmed.length);
+      return trimmed;
+    }
+    return bytes;
+  }
+}

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifierTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifierTest.java
@@ -1,15 +1,12 @@
 package com.salesforce.multicloudj.sts.gcp;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
-
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.json.webtoken.JsonWebToken;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.auth.http.HttpTransportFactory;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
@@ -18,14 +15,14 @@ import com.salesforce.multicloudj.common.exceptions.UnAuthorizedException;
 import com.salesforce.multicloudj.common.exceptions.UnknownException;
 import com.salesforce.multicloudj.sts.model.CallerIdentity;
 import com.salesforce.multicloudj.sts.model.ValidateOptions;
-import java.net.URI;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
 import java.util.Base64;
-import org.junit.jupiter.api.AfterEach;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,21 +33,11 @@ class GcpStsVerifierTest {
       "test-sa@my-project.iam.gserviceaccount.com";
   private static final String KID = "test-key-1";
 
-  private WireMockServer wireMockServer;
   private KeyPair keyPair;
 
   @BeforeEach
   void setUp() throws Exception {
     keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
-    wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
-    wireMockServer.start();
-  }
-
-  @AfterEach
-  void tearDown() {
-    if (wireMockServer != null) {
-      wireMockServer.stop();
-    }
   }
 
   @Test
@@ -60,7 +47,6 @@ class GcpStsVerifierTest {
 
   @Test
   void returnsCallerIdentityFromValidJwt() throws Exception {
-    stubJwks();
     String jwt = signJwt(Instant.now(), null);
 
     CallerIdentity identity = verifier().verifySignedAuthRequest(jwt);
@@ -78,7 +64,6 @@ class GcpStsVerifierTest {
 
   @Test
   void expiredJwtThrowsUnauthorized() throws Exception {
-    stubJwks();
     String jwt = signJwt(Instant.now().minusSeconds(3600), null);
 
     Assertions.assertThrows(
@@ -87,7 +72,6 @@ class GcpStsVerifierTest {
 
   @Test
   void unknownKeyIdThrowsNotFound() throws Exception {
-    stubJwks();
     String jwt = signJwt(Instant.now(), "other-kid", null);
 
     Assertions.assertThrows(
@@ -96,7 +80,6 @@ class GcpStsVerifierTest {
 
   @Test
   void tamperedSignatureThrowsUnauthorized() throws Exception {
-    stubJwks();
     String jwt = signJwt(Instant.now(), null);
     String tampered = jwt.substring(0, jwt.length() - 4) + "AAAA";
 
@@ -106,7 +89,6 @@ class GcpStsVerifierTest {
 
   @Test
   void matchingExpectedCustomHeaderPasses() throws Exception {
-    stubJwks();
     String jwt = signJwt(Instant.now(), "my-service");
     ValidateOptions options =
         ValidateOptions.builder()
@@ -119,7 +101,6 @@ class GcpStsVerifierTest {
 
   @Test
   void mismatchedExpectedCustomHeaderFails() throws Exception {
-    stubJwks();
     String jwt = signJwt(Instant.now(), "my-service");
     ValidateOptions options =
         ValidateOptions.builder().withExpectedCustomHeader("x-target-resource", "other").build();
@@ -158,15 +139,15 @@ class GcpStsVerifierTest {
 
   @Test
   void jwksFetchFailureThrowsUnknown() throws Exception {
-    // No JWKS stub configured; WireMock returns 404 and the fetch fails.
+    // The JWKS endpoint returns 404 and the fetch fails.
     String jwt = signJwt(Instant.now(), null);
+    GcpStsVerifier verifier = verifierReturning(404, "");
     Assertions.assertThrows(
-        UnknownException.class, () -> verifier().verifySignedAuthRequest(jwt));
+        UnknownException.class, () -> verifier.verifySignedAuthRequest(jwt));
   }
 
   @Test
   void issuedInFutureThrowsUnauthorized() throws Exception {
-    stubJwks();
     String jwt = signJwt(Instant.now().plusSeconds(3600), null);
     Assertions.assertThrows(
         UnAuthorizedException.class, () -> verifier().verifySignedAuthRequest(jwt));
@@ -174,7 +155,6 @@ class GcpStsVerifierTest {
 
   @Test
   void issuerWithoutServiceAccountDomainYieldsEmptyAccountId() throws Exception {
-    stubJwks();
     String jwt = signJwtWithIssuer(Instant.now(), "plain-issuer-no-at-sign");
 
     CallerIdentity identity = verifier().verifySignedAuthRequest(jwt);
@@ -188,31 +168,24 @@ class GcpStsVerifierTest {
     String jwks =
         "{\"keys\":[{\"kty\":\"oct\",\"kid\":\"" + KID + "\"},"
             + "{\"kty\":\"RSA\",\"kid\":\"" + KID + "\",\"e\":\"AQAB\"}]}";
-    wireMockServer.stubFor(
-        get(urlMatching("/service_accounts/v1/metadata/jwk/.*"))
-            .willReturn(
-                aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody(jwks)));
     String jwt = signJwt(Instant.now(), null);
 
+    GcpStsVerifier verifier = verifierReturning(200, jwks);
     Assertions.assertThrows(
-        ResourceNotFoundException.class, () -> verifier().verifySignedAuthRequest(jwt));
+        ResourceNotFoundException.class, () -> verifier.verifySignedAuthRequest(jwt));
   }
 
   @Test
   void cachedKeysReusedOnSecondCall() throws Exception {
-    stubJwks();
-    GcpStsVerifier verifier = verifier();
+    AtomicInteger fetchCount = new AtomicInteger();
+    HttpTransportFactory factory = () -> countingTransport(fetchCount, jwksBody());
+    GcpStsVerifier verifier = new GcpStsVerifier.Builder().build(factory);
     String jwt1 = signJwt(Instant.now(), null);
     String jwt2 = signJwt(Instant.now(), null);
 
     Assertions.assertEquals(SERVICE_ACCOUNT, verifier.verifySignedAuthRequest(jwt1).getUserId());
     Assertions.assertEquals(SERVICE_ACCOUNT, verifier.verifySignedAuthRequest(jwt2).getUserId());
-    wireMockServer.verify(
-        1, com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor(
-            urlMatching("/service_accounts/v1/metadata/jwk/.*")));
+    Assertions.assertEquals(1, fetchCount.get());
   }
 
   @Test
@@ -229,13 +202,9 @@ class GcpStsVerifierTest {
 
   @Test
   void verifiesThroughSuppliedTransportFactory() throws Exception {
-    stubJwks();
     String jwt = signJwt(Instant.now(), null);
-    HttpTransportFactory factory = NetHttpTransport::new;
-    GcpStsVerifier verifier =
-        new GcpStsVerifier.Builder()
-            .withEndpoint(URI.create("http://localhost:" + wireMockServer.port()))
-            .build(factory);
+    HttpTransportFactory factory = () -> transportReturning(200, jwksBody());
+    GcpStsVerifier verifier = new GcpStsVerifier.Builder().build(factory);
 
     CallerIdentity identity = verifier.verifySignedAuthRequest(jwt);
     Assertions.assertEquals(SERVICE_ACCOUNT, identity.getUserId());
@@ -243,7 +212,6 @@ class GcpStsVerifierTest {
 
   @Test
   void missingExpectedCustomHeaderFails() throws Exception {
-    stubJwks();
     String jwt = signJwt(Instant.now(), null);
     ValidateOptions options =
         ValidateOptions.builder().withExpectedCustomHeader("x-absent-header", "value").build();
@@ -254,7 +222,6 @@ class GcpStsVerifierTest {
 
   @Test
   void issuerWithNonServiceAccountDomainYieldsEmptyAccountId() throws Exception {
-    stubJwks();
     String jwt = signJwtWithIssuer(Instant.now(), "user@example.com");
 
     CallerIdentity identity = verifier().verifySignedAuthRequest(jwt);
@@ -264,36 +231,79 @@ class GcpStsVerifierTest {
 
   @Test
   void jwksWithoutKeysArrayThrowsNotFound() throws Exception {
-    stubJwksBody("{\"metadata\":\"no keys here\"}");
     String jwt = signJwt(Instant.now(), null);
+    GcpStsVerifier verifier = verifierReturning(200, "{\"metadata\":\"no keys here\"}");
 
     Assertions.assertThrows(
-        ResourceNotFoundException.class, () -> verifier().verifySignedAuthRequest(jwt));
+        ResourceNotFoundException.class, () -> verifier.verifySignedAuthRequest(jwt));
   }
 
   @Test
   void jwksWithNonObjectKeyEntryThrowsNotFound() throws Exception {
-    stubJwksBody("{\"keys\":[\"not-an-object\"]}");
     String jwt = signJwt(Instant.now(), null);
+    GcpStsVerifier verifier = verifierReturning(200, "{\"keys\":[\"not-an-object\"]}");
 
     Assertions.assertThrows(
-        ResourceNotFoundException.class, () -> verifier().verifySignedAuthRequest(jwt));
+        ResourceNotFoundException.class, () -> verifier.verifySignedAuthRequest(jwt));
   }
 
   @Test
   void jwksWithMalformedModulusThrowsUnknown() throws Exception {
-    stubJwksBody(
-        "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"" + KID + "\",\"n\":\"@@@\",\"e\":\"AQAB\"}]}");
     String jwt = signJwt(Instant.now(), null);
+    GcpStsVerifier verifier =
+        verifierReturning(
+            200,
+            "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"" + KID + "\",\"n\":\"@@@\",\"e\":\"AQAB\"}]}");
 
     Assertions.assertThrows(
-        UnknownException.class, () -> verifier().verifySignedAuthRequest(jwt));
+        UnknownException.class, () -> verifier.verifySignedAuthRequest(jwt));
   }
 
+  /** Builds a verifier whose JWKS fetch returns a 200 with the current key pair's JWKS document. */
   private GcpStsVerifier verifier() {
-    return new GcpStsVerifier.Builder()
-        .withEndpoint(URI.create("http://localhost:" + wireMockServer.port()))
-        .build();
+    return verifierReturning(200, jwksBody());
+  }
+
+  private static GcpStsVerifier verifierReturning(int status, String body) {
+    HttpTransportFactory factory = () -> transportReturning(status, body);
+    return new GcpStsVerifier.Builder().build(factory);
+  }
+
+  private static HttpTransport transportReturning(int status, String body) {
+    return new MockHttpTransport() {
+      @Override
+      public MockLowLevelHttpRequest buildRequest(String method, String url) {
+        return new MockLowLevelHttpRequest() {
+          @Override
+          public MockLowLevelHttpResponse execute() {
+            MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+            response.setStatusCode(status);
+            response.setContentType("application/json");
+            response.setContent(body);
+            return response;
+          }
+        };
+      }
+    };
+  }
+
+  private static HttpTransport countingTransport(AtomicInteger counter, String body) {
+    return new MockHttpTransport() {
+      @Override
+      public MockLowLevelHttpRequest buildRequest(String method, String url) {
+        counter.incrementAndGet();
+        return new MockLowLevelHttpRequest() {
+          @Override
+          public MockLowLevelHttpResponse execute() {
+            MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+            response.setStatusCode(200);
+            response.setContentType("application/json");
+            response.setContent(body);
+            return response;
+          }
+        };
+      }
+    };
   }
 
   private static String manualToken(String headerJson, String payloadJson) {
@@ -327,30 +337,18 @@ class GcpStsVerifierTest {
         keyPair.getPrivate(), GsonFactory.getDefaultInstance(), header, payload);
   }
 
-  private void stubJwks() {
+  private String jwksBody() {
     RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
     Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
     String n = encoder.encodeToString(toUnsignedBytes(publicKey.getModulus()));
     String e = encoder.encodeToString(toUnsignedBytes(publicKey.getPublicExponent()));
-    String jwks =
-        "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\""
-            + KID
-            + "\",\"n\":\""
-            + n
-            + "\",\"e\":\""
-            + e
-            + "\"}]}";
-    stubJwksBody(jwks);
-  }
-
-  private void stubJwksBody(String body) {
-    wireMockServer.stubFor(
-        get(urlMatching("/service_accounts/v1/metadata/jwk/.*"))
-            .willReturn(
-                aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody(body)));
+    return "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\""
+        + KID
+        + "\",\"n\":\""
+        + n
+        + "\",\"e\":\""
+        + e
+        + "\"}]}";
   }
 
   private String signJwt(Instant issuedAt, String targetResource) throws Exception {

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifierTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifierTest.java
@@ -6,9 +6,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.json.webtoken.JsonWebToken;
+import com.google.auth.http.HttpTransportFactory;
 import com.salesforce.multicloudj.common.exceptions.InvalidArgumentException;
 import com.salesforce.multicloudj.common.exceptions.ResourceNotFoundException;
 import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
@@ -230,6 +232,81 @@ class GcpStsVerifierTest {
     Assertions.assertInstanceOf(UnknownException.class, mapped);
   }
 
+  @Test
+  void builderReturnsGcpBuilder() {
+    Assertions.assertEquals("gcp", new GcpStsVerifier().builder().build().getProviderId());
+  }
+
+  @Test
+  void verifiesThroughSuppliedTransportFactory() throws Exception {
+    stubJwks();
+    String jwt = signJwt(Instant.now(), null);
+    HttpTransportFactory factory = NetHttpTransport::new;
+    GcpStsVerifier verifier =
+        new GcpStsVerifier.Builder()
+            .withEndpoint(URI.create("http://localhost:" + wireMockServer.port()))
+            .build(factory);
+
+    CallerIdentity identity = verifier.verifySignedAuthRequest(jwt);
+    Assertions.assertEquals(SERVICE_ACCOUNT, identity.getUserId());
+  }
+
+  @Test
+  void missingExpectedCustomHeaderFails() throws Exception {
+    stubJwks();
+    String jwt = signJwt(Instant.now(), null);
+    ValidateOptions options =
+        ValidateOptions.builder().withExpectedCustomHeader("x-absent-header", "value").build();
+
+    Assertions.assertThrows(
+        InvalidArgumentException.class, () -> verifier().verifySignedAuthRequest(jwt, options));
+  }
+
+  @Test
+  void issuerWithNonServiceAccountDomainYieldsEmptyAccountId() throws Exception {
+    stubJwks();
+    String jwt = signJwtWithIssuer(Instant.now(), "user@example.com");
+
+    CallerIdentity identity = verifier().verifySignedAuthRequest(jwt);
+    Assertions.assertEquals("", identity.getAccountId());
+    Assertions.assertEquals("user@example.com", identity.getUserId());
+  }
+
+  @Test
+  void jwksWithoutKeysArrayThrowsNotFound() throws Exception {
+    stubJwksBody("{\"metadata\":\"no keys here\"}");
+    String jwt = signJwt(Instant.now(), null);
+
+    Assertions.assertThrows(
+        ResourceNotFoundException.class, () -> verifier().verifySignedAuthRequest(jwt));
+  }
+
+  @Test
+  void jwksWithNonObjectKeyEntryThrowsNotFound() throws Exception {
+    stubJwksBody("{\"keys\":[\"not-an-object\"]}");
+    String jwt = signJwt(Instant.now(), null);
+
+    Assertions.assertThrows(
+        ResourceNotFoundException.class, () -> verifier().verifySignedAuthRequest(jwt));
+  }
+
+  @Test
+  void jwksWithMalformedModulusThrowsUnknown() throws Exception {
+    stubJwksBody(
+        "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"" + KID + "\",\"n\":\"@@@\",\"e\":\"AQAB\"}]}");
+    String jwt = signJwt(Instant.now(), null);
+
+    Assertions.assertThrows(
+        UnknownException.class, () -> verifier().verifySignedAuthRequest(jwt));
+  }
+
+  @Test
+  void buildWithSystemPropertyProxyValuesCreatesRealVerifier() {
+    GcpStsVerifier verifier =
+        new GcpStsVerifier.Builder().withUseSystemPropertyProxyValues(true).build();
+    Assertions.assertEquals("gcp", verifier.getProviderId());
+  }
+
   private GcpStsVerifier verifier() {
     return new GcpStsVerifier.Builder()
         .withEndpoint(URI.create("http://localhost:" + wireMockServer.port()))
@@ -280,13 +357,17 @@ class GcpStsVerifierTest {
             + "\",\"e\":\""
             + e
             + "\"}]}";
+    stubJwksBody(jwks);
+  }
+
+  private void stubJwksBody(String body) {
     wireMockServer.stubFor(
         get(urlMatching("/service_accounts/v1/metadata/jwk/.*"))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withHeader("Content-Type", "application/json")
-                    .withBody(jwks)));
+                    .withBody(body)));
   }
 
   private String signJwt(Instant issuedAt, String targetResource) throws Exception {

--- a/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifierTest.java
+++ b/sts/sts-gcp/src/test/java/com/salesforce/multicloudj/sts/gcp/GcpStsVerifierTest.java
@@ -216,16 +216,6 @@ class GcpStsVerifierTest {
   }
 
   @Test
-  void buildWithProxyCreatesRealVerifier() {
-    GcpStsVerifier verifier =
-        new GcpStsVerifier.Builder()
-            .withProxyEndpoint(URI.create("http://localhost:8888"))
-            .withUseSystemPropertyProxyValues(false)
-            .build();
-    Assertions.assertEquals("gcp", verifier.getProviderId());
-  }
-
-  @Test
   void mapExceptionWrapsAsUnknown() {
     SubstrateSdkException mapped =
         new GcpStsVerifier().mapException(new RuntimeException("boom"));
@@ -298,13 +288,6 @@ class GcpStsVerifierTest {
 
     Assertions.assertThrows(
         UnknownException.class, () -> verifier().verifySignedAuthRequest(jwt));
-  }
-
-  @Test
-  void buildWithSystemPropertyProxyValuesCreatesRealVerifier() {
-    GcpStsVerifier verifier =
-        new GcpStsVerifier.Builder().withUseSystemPropertyProxyValues(true).build();
-    Assertions.assertEquals("gcp", verifier.getProviderId());
   }
 
   private GcpStsVerifier verifier() {


### PR DESCRIPTION
## Summary
Adds the receiving/validation half of cloud-native auth that pairs with the existing signer (`StsUtilities`). A verifier consumes the portable `signedIdentity` string produced by the signer and returns the verified caller identity (reusing the existing `CallerIdentity` model). Ported from the go-cloud STS verifier.

## Changes
**Client module (`sts-client`, cloud-agnostic):**
- `AbstractStsVerifier` — driver contract: `verifySignedAuthRequest(String)` / `(String, ValidateOptions)` → abstract `validateSignedAuthRequest`; three-layer builder with region/endpoint/proxy options.
- `StsVerifier` — public facade with `ServiceLoader` discovery + builder.
- `ValidateOptions` — carries `expectedCustomHeaders` for the caller to assert on the signed request.

**Provider implementations (isolated, `@AutoService`):**
- **AWS** — reconstructs a POST from the presigned `GetCallerIdentity` URL, replays against STS, parses the XML result into `CallerIdentity`.
- **GCP** — offline JWT verification: JWKS fetch by `kid`, RSA signature check, `exp`/`iat` with 60s leeway, custom-claim checks; project derived from the issuer.
- **Alibaba** — replays the signed GET URL against Alibaba STS, parses JSON into `CallerIdentity`. `AliStsUtilities` now populates `signedIdentity` so the token is replayable.

## API Example
```java
StsVerifier verifier = StsVerifier.builder("aws").withRegion("us-west-2").build();
CallerIdentity identity = verifier.validateSignedAuthRequest(signedIdentity);
```

## Testing
- Unit tests, all green, no credentials required:
  - `mvn test -pl sts/sts-aws -Dtest=AwsStsVerifierTest` (7)
  - `mvn test -pl sts/sts-gcp -Dtest=GcpStsVerifierTest` (8, WireMock-served JWKS + in-test RSA keypair)
  - `mvn test -pl sts/sts-ali -Dtest=AliStsVerifierTest` (6)
- Full sts reactor builds with checkstyle clean.

## Follow-ups (not in this PR)
- Conformance tests (record/replay) and record mode. AWS/Ali can round-trip through their existing signers; GCP has no in-SDK signer to mint the JWT end-to-end, so its conformance path needs a design decision (in-test keypair vs. real SA via IAM `signJwt`).

## Cross-Cloud Compatibility
- AWS: presigned GetCallerIdentity replay.
- GCP: offline JWKS/RSA JWT verification (no network to STS).
- Alibaba: signed GET replay (RPC signature covers the HTTP method).