### PR TITLE
blob: add opt-in delete-marker listing and cloud-neutral noncurrentAt to listBlobVersions

### DIFF
--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
@@ -408,13 +408,13 @@ public class AwsBlobStore extends AbstractBlobStore implements AwsSdkService {
   /**
    * Lists versions for a single key using S3's paginated {@code ListObjectVersions} API.
    *
-   * <p>Only entries for the requested key are returned. When {@code includeDeleteMarkers} is set on
-   * the request, delete-marker entries are merged with content versions on a single timeline;
-   * otherwise only content versions are returned.
+   * <p>Only entries for the requested key are returned. When {@code includeArchived} is set on the
+   * request, delete-marker entries are merged with content versions on a single timeline; otherwise
+   * only content versions are returned.
    */
   protected Iterator<BlobMetadata> doListBlobVersions(ListBlobVersionsRequest request) {
     return new BlobMetadataIterator(
-        s3Client, getBucket(), request.getKey(), request.isIncludeDeleteMarkers());
+        s3Client, getBucket(), request.getKey(), request.isIncludeArchived());
   }
 
   /**

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/AwsBlobStore.java
@@ -408,11 +408,13 @@ public class AwsBlobStore extends AbstractBlobStore implements AwsSdkService {
   /**
    * Lists versions for a single key using S3's paginated {@code ListObjectVersions} API.
    *
-   * <p>This implementation is streaming/lazy: it walks paginator pages on demand and does not
-   * materialize all pages up front. Only versions for the requested key are returned.
+   * <p>Only entries for the requested key are returned. When {@code includeDeleteMarkers} is set on
+   * the request, delete-marker entries are merged with content versions on a single timeline;
+   * otherwise only content versions are returned.
    */
   protected Iterator<BlobMetadata> doListBlobVersions(ListBlobVersionsRequest request) {
-    return new BlobMetadataIterator(s3Client, getBucket(), request.getKey());
+    return new BlobMetadataIterator(
+        s3Client, getBucket(), request.getKey(), request.isIncludeDeleteMarkers());
   }
 
   /**

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIterator.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIterator.java
@@ -18,11 +18,17 @@ import software.amazon.awssdk.services.s3.model.ObjectVersion;
  *
  * <p>Iteration is lazy and streaming: S3 pages are pulled on demand and only one bounded page is
  * buffered at a time. S3 returns content versions and delete markers in two separate per-page
- * collections, each already ordered newest-first, and pages themselves arrive newest-first. Because
- * every page holds the next slice of a single global newest-first sequence for the key, the two
- * per-page collections can be merged within each page (a two-pointer merge) and the pages consumed
- * in order to reproduce the true newest-first timeline without ever sorting the complete remote
- * result or reaching across a page boundary.
+ * collections, and pages themselves arrive newest-first. Because every page holds the next slice of
+ * a single global newest-first sequence for the key, the two per-page collections can be merged
+ * within each page (a two-pointer merge) and the pages consumed in order to reproduce the true
+ * newest-first timeline without ever sorting the complete remote result or reaching across a page
+ * boundary.
+ *
+ * <p>S3 documents each collection as already newest-first, but that ordering is a remote contract
+ * this class cannot observe from the response alone, so as a defensive measure each per-page
+ * collection is re-sorted newest-first after exact-key filtering. The sort is bounded by one key's
+ * per-page history and keeps the merge correct even if the SDK ever returned a page's entries out
+ * of order.
  *
  * <p>Both collections always participate in the ordering so supersession times stay correct: a
  * content version stops being current when the next entry is created, and that superseding entry
@@ -31,6 +37,12 @@ import software.amazon.awssdk.services.s3.model.ObjectVersion;
  * markers are only emitted when {@code includeDeleteMarkers} is set, but a hidden marker still
  * advances the supersession pointer so the version below it reports the correct
  * {@code noncurrentAt}.
+ *
+ * <p>When a content version and a delete marker carry the same {@code lastModified} (a same-instant
+ * PUT then DELETE), timestamps alone cannot order them. S3 flags exactly one entry as the latest
+ * version, so that flag breaks the tie: the entry S3 considers current is emitted first and
+ * therefore reports no {@code noncurrentAt}. Same-instant ties deeper in the history, where neither
+ * entry is flagged latest, keep a stable content-version-first ordering.
  */
 public class BlobMetadataIterator implements Iterator<BlobMetadata> {
 
@@ -131,9 +143,18 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
     } else if (versionCursor >= pageVersions.size()) {
       takeVersion = false;
     } else {
-      Instant markerTime = pageMarkers.get(markerCursor).lastModified();
-      Instant versionTime = pageVersions.get(versionCursor).lastModified();
-      takeVersion = !isNewer(markerTime, versionTime);
+      ObjectVersion version = pageVersions.get(versionCursor);
+      DeleteMarkerEntry marker = pageMarkers.get(markerCursor);
+      Instant versionTime = version.lastModified();
+      Instant markerTime = marker.lastModified();
+      if (versionTime != null && versionTime.equals(markerTime)) {
+        // Same-instant PUT+DELETE: timestamps cannot order them, so honor S3's latest flag. If
+        // neither entry is flagged latest (a deeper same-instant tie), keep the content version
+        // first for a stable outcome.
+        takeVersion = !Boolean.TRUE.equals(marker.isLatest());
+      } else {
+        takeVersion = !isNewer(markerTime, versionTime);
+      }
     }
     return takeVersion
         ? new Entry(pageVersions.get(versionCursor++))
@@ -162,11 +183,46 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
         markers.add(markerEntry);
       }
     }
+    // S3 documents each collection as newest-first; re-sort defensively so the merge stays correct
+    // even if a page ever arrived out of order. Bounded by one key's per-page history.
+    versions.sort(
+        (a, b) ->
+            compareNewestFirst(
+                a.lastModified(),
+                Boolean.TRUE.equals(a.isLatest()),
+                b.lastModified(),
+                Boolean.TRUE.equals(b.isLatest())));
+    markers.sort(
+        (a, b) ->
+            compareNewestFirst(
+                a.lastModified(),
+                Boolean.TRUE.equals(a.isLatest()),
+                b.lastModified(),
+                Boolean.TRUE.equals(b.isLatest())));
     pageVersions = versions;
     pageMarkers = markers;
     versionCursor = 0;
     markerCursor = 0;
     return true;
+  }
+
+  /**
+   * Orders timeline entries newest-first. Ties on {@code lastModified} put the entry S3 flagged as
+   * the latest version ahead of the rest; entries without a timestamp sort last.
+   */
+  private static int compareNewestFirst(
+      Instant firstTime, boolean firstLatest, Instant secondTime, boolean secondLatest) {
+    if (firstTime != null && secondTime != null) {
+      int byTime = secondTime.compareTo(firstTime);
+      if (byTime != 0) {
+        return byTime;
+      }
+    } else if (firstTime == null && secondTime != null) {
+      return 1;
+    } else if (firstTime != null) {
+      return -1;
+    }
+    return Boolean.compare(secondLatest, firstLatest);
   }
 
   private static BlobMetadata toMarkerMetadata(DeleteMarkerEntry marker, Instant noncurrentAt) {

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIterator.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIterator.java
@@ -41,8 +41,8 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
   // Exact-key-filtered, newest-first collections of the current page only, with merge cursors.
   private List<ObjectVersion> pageVersions = Collections.emptyList();
   private List<DeleteMarkerEntry> pageMarkers = Collections.emptyList();
-  private int vi;
-  private int mi;
+  private int versionCursor;
+  private int markerCursor;
 
   // lastModified of the immediately-newer timeline entry (null for the newest entry overall).
   private Instant previousLastModified;
@@ -120,22 +120,24 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
    * their end) simply cause the following page to be loaded.
    */
   private Entry nextTimelineEntry() {
-    while (vi >= pageVersions.size() && mi >= pageMarkers.size()) {
+    while (versionCursor >= pageVersions.size() && markerCursor >= pageMarkers.size()) {
       if (!loadNextPage()) {
         return null;
       }
     }
     boolean takeVersion;
-    if (mi >= pageMarkers.size()) {
+    if (markerCursor >= pageMarkers.size()) {
       takeVersion = true;
-    } else if (vi >= pageVersions.size()) {
+    } else if (versionCursor >= pageVersions.size()) {
       takeVersion = false;
     } else {
-      Instant markerTime = pageMarkers.get(mi).lastModified();
-      Instant versionTime = pageVersions.get(vi).lastModified();
+      Instant markerTime = pageMarkers.get(markerCursor).lastModified();
+      Instant versionTime = pageVersions.get(versionCursor).lastModified();
       takeVersion = !isNewer(markerTime, versionTime);
     }
-    return takeVersion ? new Entry(pageVersions.get(vi++)) : new Entry(pageMarkers.get(mi++));
+    return takeVersion
+        ? new Entry(pageVersions.get(versionCursor++))
+        : new Entry(pageMarkers.get(markerCursor++));
   }
 
   /**
@@ -162,8 +164,8 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
     }
     pageVersions = versions;
     pageMarkers = markers;
-    vi = 0;
-    mi = 0;
+    versionCursor = 0;
+    markerCursor = 0;
     return true;
   }
 

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIterator.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIterator.java
@@ -1,10 +1,13 @@
 package com.salesforce.multicloudj.blob.aws;
 
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteMarkerEntry;
 import software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse;
 import software.amazon.awssdk.services.s3.model.ObjectVersion;
@@ -13,12 +16,18 @@ import software.amazon.awssdk.services.s3.model.ObjectVersion;
 public class BlobMetadataIterator implements Iterator<BlobMetadata> {
 
   private final String key;
+  private final boolean includeDeleteMarkers;
   private final Iterator<ListObjectVersionsResponse> responseIterator;
-  private Iterator<ObjectVersion> current = List.<ObjectVersion>of().iterator();
-  private BlobMetadata next;
+  private Iterator<BlobMetadata> resolved;
 
   public BlobMetadataIterator(S3Client s3Client, String bucket, String key) {
+    this(s3Client, bucket, key, false);
+  }
+
+  public BlobMetadataIterator(
+      S3Client s3Client, String bucket, String key, boolean includeDeleteMarkers) {
     this.key = key;
+    this.includeDeleteMarkers = includeDeleteMarkers;
     this.responseIterator =
         s3Client
             .listObjectVersionsPaginator(
@@ -26,36 +35,128 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
             .iterator();
   }
 
-  @Override
-  public boolean hasNext() {
-    if (next != null) {
-      return true;
+  /**
+   * Internal holder that unifies content versions and delete markers so both sit on a single
+   * timeline before the cloud-neutral {@link BlobMetadata} is produced.
+   */
+  private static final class Entry {
+    private final Instant lastModified;
+    private final boolean deleteMarker;
+    private final ObjectVersion version; // non-null when deleteMarker == false
+    private final DeleteMarkerEntry markerEntry; // non-null when deleteMarker == true
+
+    private Entry(ObjectVersion version) {
+      this.version = version;
+      this.markerEntry = null;
+      this.deleteMarker = false;
+      this.lastModified = version.lastModified();
     }
 
-    while (true) {
-      while (current.hasNext()) {
-        ObjectVersion version = current.next();
+    private Entry(DeleteMarkerEntry markerEntry) {
+      this.version = null;
+      this.markerEntry = markerEntry;
+      this.deleteMarker = true;
+      this.lastModified = markerEntry.lastModified();
+    }
+  }
+
+  /**
+   * Drains every page for the exact key and resolves the combined timeline. S3 returns content
+   * versions and delete markers in two separate per-page collections, each already ordered
+   * newest-first. Both are always gathered so that supersession times are correct: a content
+   * version stops being current when the next entry is created, and that superseding entry may be a
+   * delete marker. The two newest-first lists are merged into one newest-first timeline; each
+   * entry's supersession time is the creation time of the entry immediately newer than it, and the
+   * newest entry is still current and therefore has none. Delete markers are only emitted when
+   * {@code includeDeleteMarkers} is set, but they always participate in the ordering.
+   */
+  private void resolve() {
+    List<ObjectVersion> versions = new ArrayList<>();
+    List<DeleteMarkerEntry> markers = new ArrayList<>();
+    while (responseIterator.hasNext()) {
+      ListObjectVersionsResponse page = responseIterator.next();
+      for (ObjectVersion version : page.versions()) {
         // S3's prefix filter returns keys that START with the prefix, not exact matches.
-        if (!key.equals(version.key())) {
+        if (key.equals(version.key())) {
+          versions.add(version);
+        }
+      }
+      for (DeleteMarkerEntry markerEntry : page.deleteMarkers()) {
+        if (key.equals(markerEntry.key())) {
+          markers.add(markerEntry);
+        }
+      }
+    }
+
+    // Merge the two newest-first lists into one newest-first timeline. When there are no delete
+    // markers this preserves the version order S3 returned.
+    List<Entry> timeline = new ArrayList<>(versions.size() + markers.size());
+    int vi = 0;
+    int mi = 0;
+    while (vi < versions.size() || mi < markers.size()) {
+      boolean takeVersion;
+      if (mi >= markers.size()) {
+        takeVersion = true;
+      } else if (vi >= versions.size()) {
+        takeVersion = false;
+      } else {
+        takeVersion = !isNewer(markers.get(mi).lastModified(), versions.get(vi).lastModified());
+      }
+      timeline.add(takeVersion ? new Entry(versions.get(vi++)) : new Entry(markers.get(mi++)));
+    }
+
+    List<BlobMetadata> result = new ArrayList<>(timeline.size());
+    for (int i = 0; i < timeline.size(); i++) {
+      Entry entry = timeline.get(i);
+      Instant noncurrentAt = (i == 0) ? null : timeline.get(i - 1).lastModified;
+      if (entry.deleteMarker) {
+        if (!includeDeleteMarkers) {
           continue;
         }
-
-        next =
+        DeleteMarkerEntry marker = entry.markerEntry;
+        result.add(
+            BlobMetadata.builder()
+                .key(marker.key())
+                .versionId(marker.versionId())
+                .deleteMarker(true)
+                .lastModified(marker.lastModified())
+                .createdTime(marker.lastModified())
+                .noncurrentAt(noncurrentAt)
+                .build());
+      } else {
+        ObjectVersion version = entry.version;
+        result.add(
             BlobMetadata.builder()
                 .key(version.key())
                 .versionId(version.versionId())
                 .eTag(version.eTag())
                 .objectSize(version.size())
                 .lastModified(version.lastModified())
-                .build();
-        return true;
+                .createdTime(version.lastModified())
+                .noncurrentAt(noncurrentAt)
+                .build());
       }
-
-      if (!responseIterator.hasNext()) {
-        return false;
-      }
-      current = responseIterator.next().versions().iterator();
     }
+    resolved = result.iterator();
+  }
+
+  /** Returns true when {@code candidate} is strictly newer than {@code reference}. */
+  private static boolean isNewer(Instant candidate, Instant reference) {
+    if (candidate == null) {
+      return false;
+    }
+    if (reference == null) {
+      return true;
+    }
+    return candidate.isAfter(reference);
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (resolved == null) {
+      resolve();
+    }
+    return resolved.hasNext();
   }
 
   @Override
@@ -63,8 +164,6 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
     if (!hasNext()) {
       throw new NoSuchElementException();
     }
-    BlobMetadata result = next;
-    next = null;
-    return result;
+    return resolved.next();
   }
 }

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIterator.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIterator.java
@@ -3,6 +3,7 @@ package com.salesforce.multicloudj.blob.aws;
 import com.salesforce.multicloudj.blob.driver.BlobMetadata;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -12,13 +13,43 @@ import software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse;
 import software.amazon.awssdk.services.s3.model.ObjectVersion;
 
-/** Iterator object to retrieve BlobMetadata versions for an exact key. */
+/**
+ * Iterator that retrieves {@link BlobMetadata} versions for an exact key.
+ *
+ * <p>Iteration is lazy and streaming: S3 pages are pulled on demand and only one bounded page is
+ * buffered at a time. S3 returns content versions and delete markers in two separate per-page
+ * collections, each already ordered newest-first, and pages themselves arrive newest-first. Because
+ * every page holds the next slice of a single global newest-first sequence for the key, the two
+ * per-page collections can be merged within each page (a two-pointer merge) and the pages consumed
+ * in order to reproduce the true newest-first timeline without ever sorting the complete remote
+ * result or reaching across a page boundary.
+ *
+ * <p>Both collections always participate in the ordering so supersession times stay correct: a
+ * content version stops being current when the next entry is created, and that superseding entry
+ * may be a delete marker. Each emitted entry's {@code noncurrentAt} is the creation time of the
+ * entry immediately newer than it; the newest entry is still current and therefore has none. Delete
+ * markers are only emitted when {@code includeDeleteMarkers} is set, but a hidden marker still
+ * advances the supersession pointer so the version below it reports the correct
+ * {@code noncurrentAt}.
+ */
 public class BlobMetadataIterator implements Iterator<BlobMetadata> {
 
   private final String key;
   private final boolean includeDeleteMarkers;
   private final Iterator<ListObjectVersionsResponse> responseIterator;
-  private Iterator<BlobMetadata> resolved;
+
+  // Exact-key-filtered, newest-first collections of the current page only, with merge cursors.
+  private List<ObjectVersion> pageVersions = Collections.emptyList();
+  private List<DeleteMarkerEntry> pageMarkers = Collections.emptyList();
+  private int vi;
+  private int mi;
+
+  // lastModified of the immediately-newer timeline entry (null for the newest entry overall).
+  private Instant previousLastModified;
+
+  // One-element lookahead so filtered-out markers can be skipped transparently.
+  private BlobMetadata nextEmit;
+  private boolean exhausted;
 
   public BlobMetadataIterator(S3Client s3Client, String bucket, String key) {
     this(s3Client, bucket, key, false);
@@ -61,83 +92,102 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
   }
 
   /**
-   * Drains every page for the exact key and resolves the combined timeline. S3 returns content
-   * versions and delete markers in two separate per-page collections, each already ordered
-   * newest-first. Both are always gathered so that supersession times are correct: a content
-   * version stops being current when the next entry is created, and that superseding entry may be a
-   * delete marker. The two newest-first lists are merged into one newest-first timeline; each
-   * entry's supersession time is the creation time of the entry immediately newer than it, and the
-   * newest entry is still current and therefore has none. Delete markers are only emitted when
-   * {@code includeDeleteMarkers} is set, but they always participate in the ordering.
+   * Advances the merged timeline until the next emittable entry is buffered or the stream ends.
+   * Every entry consumed advances the supersession pointer, including hidden delete markers, so a
+   * content version's {@code noncurrentAt} still reflects a superseding marker that is not emitted.
    */
-  private void resolve() {
-    List<ObjectVersion> versions = new ArrayList<>();
-    List<DeleteMarkerEntry> markers = new ArrayList<>();
-    while (responseIterator.hasNext()) {
-      ListObjectVersionsResponse page = responseIterator.next();
-      for (ObjectVersion version : page.versions()) {
-        // S3's prefix filter returns keys that START with the prefix, not exact matches.
-        if (key.equals(version.key())) {
-          versions.add(version);
-        }
-      }
-      for (DeleteMarkerEntry markerEntry : page.deleteMarkers()) {
-        if (key.equals(markerEntry.key())) {
-          markers.add(markerEntry);
-        }
-      }
-    }
-
-    // Merge the two newest-first lists into one newest-first timeline. When there are no delete
-    // markers this preserves the version order S3 returned.
-    List<Entry> timeline = new ArrayList<>(versions.size() + markers.size());
-    int vi = 0;
-    int mi = 0;
-    while (vi < versions.size() || mi < markers.size()) {
-      boolean takeVersion;
-      if (mi >= markers.size()) {
-        takeVersion = true;
-      } else if (vi >= versions.size()) {
-        takeVersion = false;
-      } else {
-        takeVersion = !isNewer(markers.get(mi).lastModified(), versions.get(vi).lastModified());
-      }
-      timeline.add(takeVersion ? new Entry(versions.get(vi++)) : new Entry(markers.get(mi++)));
-    }
-
-    List<BlobMetadata> result = new ArrayList<>(timeline.size());
-    for (int i = 0; i < timeline.size(); i++) {
-      Entry entry = timeline.get(i);
-      Instant noncurrentAt = (i == 0) ? null : timeline.get(i - 1).lastModified;
+  private void advance() {
+    Entry entry;
+    while ((entry = nextTimelineEntry()) != null) {
+      Instant noncurrentAt = previousLastModified;
+      previousLastModified = entry.lastModified;
       if (entry.deleteMarker) {
         if (!includeDeleteMarkers) {
           continue;
         }
-        DeleteMarkerEntry marker = entry.markerEntry;
-        result.add(
-            BlobMetadata.builder()
-                .key(marker.key())
-                .versionId(marker.versionId())
-                .deleteMarker(true)
-                .lastModified(marker.lastModified())
-                .createdTime(marker.lastModified())
-                .noncurrentAt(noncurrentAt)
-                .build());
-      } else {
-        ObjectVersion version = entry.version;
-        result.add(
-            BlobMetadata.builder()
-                .key(version.key())
-                .versionId(version.versionId())
-                .eTag(version.eTag())
-                .objectSize(version.size())
-                .lastModified(version.lastModified())
-                .createdTime(version.lastModified())
-                .noncurrentAt(noncurrentAt)
-                .build());
+        nextEmit = toMarkerMetadata(entry.markerEntry, noncurrentAt);
+        return;
+      }
+      nextEmit = toVersionMetadata(entry.version, noncurrentAt);
+      return;
+    }
+    exhausted = true;
+  }
+
+  /**
+   * Returns the next entry in the global newest-first timeline, loading pages on demand, or null
+   * when the stream is exhausted. Pages that hold no matching key after filtering (both cursors at
+   * their end) simply cause the following page to be loaded.
+   */
+  private Entry nextTimelineEntry() {
+    while (vi >= pageVersions.size() && mi >= pageMarkers.size()) {
+      if (!loadNextPage()) {
+        return null;
       }
     }
-    resolved = result.iterator();
+    boolean takeVersion;
+    if (mi >= pageMarkers.size()) {
+      takeVersion = true;
+    } else if (vi >= pageVersions.size()) {
+      takeVersion = false;
+    } else {
+      Instant markerTime = pageMarkers.get(mi).lastModified();
+      Instant versionTime = pageVersions.get(vi).lastModified();
+      takeVersion = !isNewer(markerTime, versionTime);
+    }
+    return takeVersion ? new Entry(pageVersions.get(vi++)) : new Entry(pageMarkers.get(mi++));
+  }
+
+  /**
+   * Loads the next page from the paginator and filters both collections down to the exact key,
+   * resetting the merge cursors. Returns false when no more pages remain.
+   */
+  private boolean loadNextPage() {
+    if (!responseIterator.hasNext()) {
+      return false;
+    }
+    ListObjectVersionsResponse page = responseIterator.next();
+    List<ObjectVersion> versions = new ArrayList<>();
+    for (ObjectVersion version : page.versions()) {
+      // S3's prefix filter returns keys that START with the prefix, not exact matches.
+      if (key.equals(version.key())) {
+        versions.add(version);
+      }
+    }
+    List<DeleteMarkerEntry> markers = new ArrayList<>();
+    for (DeleteMarkerEntry markerEntry : page.deleteMarkers()) {
+      if (key.equals(markerEntry.key())) {
+        markers.add(markerEntry);
+      }
+    }
+    pageVersions = versions;
+    pageMarkers = markers;
+    vi = 0;
+    mi = 0;
+    return true;
+  }
+
+  private static BlobMetadata toMarkerMetadata(DeleteMarkerEntry marker, Instant noncurrentAt) {
+    return BlobMetadata.builder()
+        .key(marker.key())
+        .versionId(marker.versionId())
+        .deleteMarker(true)
+        .lastModified(marker.lastModified())
+        .createdTime(marker.lastModified())
+        .noncurrentAt(noncurrentAt)
+        .build();
+  }
+
+  private static BlobMetadata toVersionMetadata(ObjectVersion version, Instant noncurrentAt) {
+    return BlobMetadata.builder()
+        .key(version.key())
+        .versionId(version.versionId())
+        .eTag(version.eTag())
+        .objectSize(version.size())
+        .lastModified(version.lastModified())
+        .createdTime(version.lastModified())
+        .noncurrentAt(noncurrentAt)
+        .build();
   }
 
   /** Returns true when {@code candidate} is strictly newer than {@code reference}. */
@@ -153,10 +203,10 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
 
   @Override
   public boolean hasNext() {
-    if (resolved == null) {
-      resolve();
+    if (nextEmit == null && !exhausted) {
+      advance();
     }
-    return resolved.hasNext();
+    return nextEmit != null;
   }
 
   @Override
@@ -164,6 +214,8 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
     if (!hasNext()) {
       throw new NoSuchElementException();
     }
-    return resolved.next();
+    BlobMetadata result = nextEmit;
+    nextEmit = null;
+    return result;
   }
 }

--- a/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIterator.java
+++ b/blob/blob-aws/src/main/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIterator.java
@@ -18,30 +18,23 @@ import software.amazon.awssdk.services.s3.model.ObjectVersion;
  *
  * <p>Iteration is lazy and streaming: S3 pages are pulled on demand and only one bounded page is
  * buffered at a time. S3 returns content versions and delete markers in two separate per-page
- * collections, and pages themselves arrive newest-first. Because every page holds the next slice of
- * a single global newest-first sequence for the key, the two per-page collections can be merged
- * within each page (a two-pointer merge) and the pages consumed in order to reproduce the true
- * newest-first timeline without ever sorting the complete remote result or reaching across a page
- * boundary.
- *
- * <p>S3 documents each collection as already newest-first, but that ordering is a remote contract
- * this class cannot observe from the response alone, so as a defensive measure each per-page
- * collection is re-sorted newest-first after exact-key filtering. The sort is bounded by one key's
- * per-page history and keeps the merge correct even if the SDK ever returned a page's entries out
- * of order.
+ * collections, each documented as newest-first, and pages themselves arrive newest-first. Because
+ * every page holds the next slice of a single global newest-first sequence for the key, the two
+ * per-page collections can be merged within each page (a two-pointer merge) and the pages consumed
+ * in order to reproduce the true newest-first timeline without ever sorting the complete remote
+ * result or reaching across a page boundary.
  *
  * <p>Both collections always participate in the ordering so supersession times stay correct: a
  * content version stops being current when the next entry is created, and that superseding entry
- * may be a delete marker. Each emitted entry's {@code noncurrentAt} is the creation time of the
- * entry immediately newer than it; the newest entry is still current and therefore has none. Delete
+ * may be a delete marker. Each emitted entry's {@code archivedAt} is the creation time of the entry
+ * immediately newer than it; the newest entry is still current and therefore has none. Delete
  * markers are only emitted when {@code includeDeleteMarkers} is set, but a hidden marker still
- * advances the supersession pointer so the version below it reports the correct
- * {@code noncurrentAt}.
+ * advances the supersession pointer so the version below it reports the correct {@code archivedAt}.
  *
  * <p>When a content version and a delete marker carry the same {@code lastModified} (a same-instant
  * PUT then DELETE), timestamps alone cannot order them. S3 flags exactly one entry as the latest
  * version, so that flag breaks the tie: the entry S3 considers current is emitted first and
- * therefore reports no {@code noncurrentAt}. Same-instant ties deeper in the history, where neither
+ * therefore reports no {@code archivedAt}. Same-instant ties deeper in the history, where neither
  * entry is flagged latest, keep a stable content-version-first ordering.
  */
 public class BlobMetadataIterator implements Iterator<BlobMetadata> {
@@ -106,21 +99,21 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
   /**
    * Advances the merged timeline until the next emittable entry is buffered or the stream ends.
    * Every entry consumed advances the supersession pointer, including hidden delete markers, so a
-   * content version's {@code noncurrentAt} still reflects a superseding marker that is not emitted.
+   * content version's {@code archivedAt} still reflects a superseding marker that is not emitted.
    */
   private void advance() {
     Entry entry;
     while ((entry = nextTimelineEntry()) != null) {
-      Instant noncurrentAt = previousLastModified;
+      Instant archivedAt = previousLastModified;
       previousLastModified = entry.lastModified;
       if (entry.deleteMarker) {
         if (!includeDeleteMarkers) {
           continue;
         }
-        nextEmit = toMarkerMetadata(entry.markerEntry, noncurrentAt);
+        nextEmit = toMarkerMetadata(entry.markerEntry, archivedAt);
         return;
       }
-      nextEmit = toVersionMetadata(entry.version, noncurrentAt);
+      nextEmit = toVersionMetadata(entry.version, archivedAt);
       return;
     }
     exhausted = true;
@@ -183,22 +176,7 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
         markers.add(markerEntry);
       }
     }
-    // S3 documents each collection as newest-first; re-sort defensively so the merge stays correct
-    // even if a page ever arrived out of order. Bounded by one key's per-page history.
-    versions.sort(
-        (a, b) ->
-            compareNewestFirst(
-                a.lastModified(),
-                Boolean.TRUE.equals(a.isLatest()),
-                b.lastModified(),
-                Boolean.TRUE.equals(b.isLatest())));
-    markers.sort(
-        (a, b) ->
-            compareNewestFirst(
-                a.lastModified(),
-                Boolean.TRUE.equals(a.isLatest()),
-                b.lastModified(),
-                Boolean.TRUE.equals(b.isLatest())));
+    // S3 returns each collection newest-first, which the per-page two-pointer merge relies on.
     pageVersions = versions;
     pageMarkers = markers;
     versionCursor = 0;
@@ -206,37 +184,18 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
     return true;
   }
 
-  /**
-   * Orders timeline entries newest-first. Ties on {@code lastModified} put the entry S3 flagged as
-   * the latest version ahead of the rest; entries without a timestamp sort last.
-   */
-  private static int compareNewestFirst(
-      Instant firstTime, boolean firstLatest, Instant secondTime, boolean secondLatest) {
-    if (firstTime != null && secondTime != null) {
-      int byTime = secondTime.compareTo(firstTime);
-      if (byTime != 0) {
-        return byTime;
-      }
-    } else if (firstTime == null && secondTime != null) {
-      return 1;
-    } else if (firstTime != null) {
-      return -1;
-    }
-    return Boolean.compare(secondLatest, firstLatest);
-  }
-
-  private static BlobMetadata toMarkerMetadata(DeleteMarkerEntry marker, Instant noncurrentAt) {
+  private static BlobMetadata toMarkerMetadata(DeleteMarkerEntry marker, Instant archivedAt) {
     return BlobMetadata.builder()
         .key(marker.key())
         .versionId(marker.versionId())
-        .deleteMarker(true)
+        .archived(true)
         .lastModified(marker.lastModified())
         .createdTime(marker.lastModified())
-        .noncurrentAt(noncurrentAt)
+        .archivedAt(archivedAt)
         .build();
   }
 
-  private static BlobMetadata toVersionMetadata(ObjectVersion version, Instant noncurrentAt) {
+  private static BlobMetadata toVersionMetadata(ObjectVersion version, Instant archivedAt) {
     return BlobMetadata.builder()
         .key(version.key())
         .versionId(version.versionId())
@@ -244,7 +203,7 @@ public class BlobMetadataIterator implements Iterator<BlobMetadata> {
         .objectSize(version.size())
         .lastModified(version.lastModified())
         .createdTime(version.lastModified())
-        .noncurrentAt(noncurrentAt)
+        .archivedAt(archivedAt)
         .build();
   }
 

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/AwsBlobStoreTest.java
@@ -2349,13 +2349,17 @@ public class AwsBlobStoreTest {
   void testDoListBlobVersions_multiplePages() {
     String key = "obj-1";
 
+    // Newest-first across pages, matching S3's ordering: page1 holds the newest version.
+    Instant t1 = Instant.parse("2024-01-01T00:00:00Z");
+    Instant t2 = Instant.parse("2024-01-02T00:00:00Z");
+    Instant t3 = Instant.parse("2024-01-03T00:00:00Z");
     ObjectVersion version1 =
         ObjectVersion.builder()
             .key("obj-1")
             .versionId("v1")
             .eTag("etag-v1")
             .size(100L)
-            .lastModified(Instant.now())
+            .lastModified(t1)
             .build();
     ObjectVersion version2 =
         ObjectVersion.builder()
@@ -2363,7 +2367,7 @@ public class AwsBlobStoreTest {
             .versionId("v2")
             .eTag("etag-v2")
             .size(200L)
-            .lastModified(Instant.now())
+            .lastModified(t2)
             .build();
     ObjectVersion version3 =
         ObjectVersion.builder()
@@ -2371,13 +2375,13 @@ public class AwsBlobStoreTest {
             .versionId("v3")
             .eTag("etag-v3")
             .size(300L)
-            .lastModified(Instant.now())
+            .lastModified(t3)
             .build();
 
     ListObjectVersionsResponse page1 =
-        ListObjectVersionsResponse.builder().versions(version1).build();
+        ListObjectVersionsResponse.builder().versions(version3).build();
     ListObjectVersionsResponse page2 =
-        ListObjectVersionsResponse.builder().versions(version2, version3).build();
+        ListObjectVersionsResponse.builder().versions(version2, version1).build();
 
     ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
     when(iterable.iterator()).thenReturn(List.of(page1, page2).iterator());
@@ -2392,9 +2396,9 @@ public class AwsBlobStoreTest {
     versions.forEachRemaining(allVersions::add);
 
     assertEquals(3, allVersions.size());
-    assertEquals("v1", allVersions.get(0).getVersionId());
+    assertEquals("v3", allVersions.get(0).getVersionId());
     assertEquals("v2", allVersions.get(1).getVersionId());
-    assertEquals("v3", allVersions.get(2).getVersionId());
+    assertEquals("v1", allVersions.get(2).getVersionId());
   }
 
   @Test

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIteratorTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIteratorTest.java
@@ -2,6 +2,7 @@ package com.salesforce.multicloudj.blob.aws;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -15,6 +16,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteMarkerEntry;
 import software.amazon.awssdk.services.s3.model.ListObjectVersionsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectVersionsResponse;
 import software.amazon.awssdk.services.s3.model.ObjectVersion;
@@ -112,13 +114,111 @@ public class BlobMetadataIteratorTest {
     assertFalse(iterator.hasNext());
   }
 
+  @Test
+  void testDeleteMarkersEmittedAndMergedWhenIncluded() {
+    String key = "obj-1";
+    Instant t1 = Instant.parse("2024-01-01T00:00:00Z");
+    Instant t2 = Instant.parse("2024-01-02T00:00:00Z");
+    Instant t3 = Instant.parse("2024-01-03T00:00:00Z");
+
+    // S3 returns versions and delete markers in two separate newest-first collections.
+    // Timeline newest-first: v2 (t3) -> marker (t2) -> v1 (t1).
+    ObjectVersion v1 = version(key, "v1", 100L, t1);
+    ObjectVersion v2 = version(key, "v2", 200L, t3);
+    DeleteMarkerEntry marker = marker(key, "dm1", t2);
+
+    ListObjectVersionsResponse response =
+        ListObjectVersionsResponse.builder().versions(v2, v1).deleteMarkers(marker).build();
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(response).iterator());
+    when(mockS3Client.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    Iterator<BlobMetadata> iterator =
+        new BlobMetadataIterator(mockS3Client, TEST_BUCKET, key, true);
+    List<BlobMetadata> all = new ArrayList<>();
+    iterator.forEachRemaining(all::add);
+
+    assertEquals(3, all.size());
+
+    // Newest content version: current, so no supersession instant.
+    BlobMetadata current = all.get(0);
+    assertEquals("v2", current.getVersionId());
+    assertFalse(current.isDeleteMarker());
+    assertNull(current.getNoncurrentAt());
+
+    // Delete marker sits between v2 and v1; it stopped being current when v2 was created.
+    BlobMetadata dm = all.get(1);
+    assertEquals("dm1", dm.getVersionId());
+    assertTrue(dm.isDeleteMarker());
+    assertEquals(t2, dm.getCreatedTime());
+    assertEquals(t3, dm.getNoncurrentAt());
+
+    // Oldest content version stopped being current when the delete marker was created.
+    BlobMetadata oldest = all.get(2);
+    assertEquals("v1", oldest.getVersionId());
+    assertFalse(oldest.isDeleteMarker());
+    assertEquals(t1, oldest.getCreatedTime());
+    assertEquals(t2, oldest.getNoncurrentAt());
+  }
+
+  @Test
+  void testDeleteMarkersFilteredButStillDriveNoncurrentAt() {
+    String key = "obj-1";
+    Instant t1 = Instant.parse("2024-01-01T00:00:00Z");
+    Instant t2 = Instant.parse("2024-01-02T00:00:00Z");
+    Instant t3 = Instant.parse("2024-01-03T00:00:00Z");
+
+    ObjectVersion v1 = version(key, "v1", 100L, t1);
+    ObjectVersion v2 = version(key, "v2", 200L, t3);
+    DeleteMarkerEntry marker = marker(key, "dm1", t2);
+
+    ListObjectVersionsResponse response =
+        ListObjectVersionsResponse.builder().versions(v2, v1).deleteMarkers(marker).build();
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(response).iterator());
+    when(mockS3Client.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    // includeDeleteMarkers defaults to false via the 3-arg constructor.
+    Iterator<BlobMetadata> iterator = new BlobMetadataIterator(mockS3Client, TEST_BUCKET, key);
+    List<BlobMetadata> all = new ArrayList<>();
+    iterator.forEachRemaining(all::add);
+
+    // Only content versions are emitted, but the older version's noncurrentAt must still
+    // reflect that a delete marker (not the newer version) superseded it.
+    assertEquals(2, all.size());
+    assertEquals("v2", all.get(0).getVersionId());
+    assertFalse(all.get(0).isDeleteMarker());
+    assertNull(all.get(0).getNoncurrentAt());
+
+    assertEquals("v1", all.get(1).getVersionId());
+    assertFalse(all.get(1).isDeleteMarker());
+    assertEquals(t2, all.get(1).getNoncurrentAt());
+  }
+
   private static ObjectVersion version(String key, String versionId, long size) {
+    return version(key, versionId, size, Instant.now());
+  }
+
+  private static ObjectVersion version(
+      String key, String versionId, long size, Instant lastModified) {
     return ObjectVersion.builder()
         .key(key)
         .versionId(versionId)
         .eTag("etag-" + versionId)
         .size(size)
-        .lastModified(Instant.now())
+        .lastModified(lastModified)
+        .build();
+  }
+
+  private static DeleteMarkerEntry marker(String key, String versionId, Instant lastModified) {
+    return DeleteMarkerEntry.builder()
+        .key(key)
+        .versionId(versionId)
+        .lastModified(lastModified)
         .build();
   }
 }

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIteratorTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIteratorTest.java
@@ -149,26 +149,26 @@ public class BlobMetadataIteratorTest {
     // Newest content version: current, so no supersession instant.
     BlobMetadata current = all.get(0);
     assertEquals("v2", current.getVersionId());
-    assertFalse(current.isDeleteMarker());
-    assertNull(current.getNoncurrentAt());
+    assertFalse(current.isArchived());
+    assertNull(current.getArchivedAt());
 
     // Delete marker sits between v2 and v1; it stopped being current when v2 was created.
     BlobMetadata dm = all.get(1);
     assertEquals("dm1", dm.getVersionId());
-    assertTrue(dm.isDeleteMarker());
+    assertTrue(dm.isArchived());
     assertEquals(t2, dm.getCreatedTime());
-    assertEquals(t3, dm.getNoncurrentAt());
+    assertEquals(t3, dm.getArchivedAt());
 
     // Oldest content version stopped being current when the delete marker was created.
     BlobMetadata oldest = all.get(2);
     assertEquals("v1", oldest.getVersionId());
-    assertFalse(oldest.isDeleteMarker());
+    assertFalse(oldest.isArchived());
     assertEquals(t1, oldest.getCreatedTime());
-    assertEquals(t2, oldest.getNoncurrentAt());
+    assertEquals(t2, oldest.getArchivedAt());
   }
 
   @Test
-  void testDeleteMarkersFilteredButStillDriveNoncurrentAt() {
+  void testDeleteMarkersFilteredButStillDriveArchivedAt() {
     String key = "obj-1";
     Instant t1 = Instant.parse("2024-01-01T00:00:00Z");
     Instant t2 = Instant.parse("2024-01-02T00:00:00Z");
@@ -191,16 +191,16 @@ public class BlobMetadataIteratorTest {
     List<BlobMetadata> all = new ArrayList<>();
     iterator.forEachRemaining(all::add);
 
-    // Only content versions are emitted, but the older version's noncurrentAt must still
+    // Only content versions are emitted, but the older version's archivedAt must still
     // reflect that a delete marker (not the newer version) superseded it.
     assertEquals(2, all.size());
     assertEquals("v2", all.get(0).getVersionId());
-    assertFalse(all.get(0).isDeleteMarker());
-    assertNull(all.get(0).getNoncurrentAt());
+    assertFalse(all.get(0).isArchived());
+    assertNull(all.get(0).getArchivedAt());
 
     assertEquals("v1", all.get(1).getVersionId());
-    assertFalse(all.get(1).isDeleteMarker());
-    assertEquals(t2, all.get(1).getNoncurrentAt());
+    assertFalse(all.get(1).isArchived());
+    assertEquals(t2, all.get(1).getArchivedAt());
   }
 
   @Test
@@ -234,20 +234,20 @@ public class BlobMetadataIteratorTest {
     assertEquals(3, all.size());
 
     assertEquals("v3", all.get(0).getVersionId());
-    assertFalse(all.get(0).isDeleteMarker());
-    assertNull(all.get(0).getNoncurrentAt());
+    assertFalse(all.get(0).isArchived());
+    assertNull(all.get(0).getArchivedAt());
 
     // Delete marker from page 1 merges ahead of the version from page 2.
     assertEquals("dm1", all.get(1).getVersionId());
-    assertTrue(all.get(1).isDeleteMarker());
+    assertTrue(all.get(1).isArchived());
     assertEquals(t4, all.get(1).getCreatedTime());
-    assertEquals(t5, all.get(1).getNoncurrentAt());
+    assertEquals(t5, all.get(1).getArchivedAt());
 
     // Cross-page supersession: the older version stopped being current at the marker instant.
     assertEquals("v1", all.get(2).getVersionId());
-    assertFalse(all.get(2).isDeleteMarker());
+    assertFalse(all.get(2).isArchived());
     assertEquals(t2, all.get(2).getCreatedTime());
-    assertEquals(t4, all.get(2).getNoncurrentAt());
+    assertEquals(t4, all.get(2).getArchivedAt());
   }
 
   @Test
@@ -271,8 +271,8 @@ public class BlobMetadataIteratorTest {
 
     assertEquals(1, all.size());
     assertEquals("dm1", all.get(0).getVersionId());
-    assertTrue(all.get(0).isDeleteMarker());
-    assertNull(all.get(0).getNoncurrentAt());
+    assertTrue(all.get(0).isArchived());
+    assertNull(all.get(0).getArchivedAt());
   }
 
   @Test
@@ -392,7 +392,7 @@ public class BlobMetadataIteratorTest {
 
     // Both entries surface; equal-timestamp ordering is intentionally left unasserted.
     assertEquals(2, all.size());
-    long markerCount = all.stream().filter(BlobMetadata::isDeleteMarker).count();
+    long markerCount = all.stream().filter(BlobMetadata::isArchived).count();
     assertEquals(1, markerCount);
   }
 
@@ -437,47 +437,13 @@ public class BlobMetadataIteratorTest {
 
     // The delete marker S3 flagged latest is emitted first and is still current.
     assertEquals("dm1", all.get(0).getVersionId());
-    assertTrue(all.get(0).isDeleteMarker());
-    assertNull(all.get(0).getNoncurrentAt());
+    assertTrue(all.get(0).isArchived());
+    assertNull(all.get(0).getArchivedAt());
 
     // The content version sharing the instant is superseded by that marker.
     assertEquals("v1", all.get(1).getVersionId());
-    assertFalse(all.get(1).isDeleteMarker());
-    assertEquals(t, all.get(1).getNoncurrentAt());
-  }
-
-  @Test
-  void testUnsortedPageEntriesAreReorderedNewestFirst() {
-    String key = "obj-1";
-    Instant t1 = Instant.parse("2024-01-01T00:00:00Z");
-    Instant t2 = Instant.parse("2024-01-02T00:00:00Z");
-    Instant t3 = Instant.parse("2024-01-03T00:00:00Z");
-
-    // Feed the page out of newest-first order to prove the iterator re-sorts rather than trusting
-    // the SDK's documented ordering.
-    ObjectVersion v1 = version(key, "v1", 100L, t1);
-    ObjectVersion v2 = version(key, "v2", 200L, t2);
-    ObjectVersion v3 = version(key, "v3", 300L, t3);
-
-    ListObjectVersionsResponse response =
-        ListObjectVersionsResponse.builder().versions(v2, v1, v3).build();
-
-    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
-    when(iterable.iterator()).thenReturn(List.of(response).iterator());
-    when(mockS3Client.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
-        .thenReturn(iterable);
-
-    Iterator<BlobMetadata> iterator = new BlobMetadataIterator(mockS3Client, TEST_BUCKET, key);
-    List<BlobMetadata> all = new ArrayList<>();
-    iterator.forEachRemaining(all::add);
-
-    assertEquals(3, all.size());
-    assertEquals("v3", all.get(0).getVersionId());
-    assertNull(all.get(0).getNoncurrentAt());
-    assertEquals("v2", all.get(1).getVersionId());
-    assertEquals(t3, all.get(1).getNoncurrentAt());
-    assertEquals("v1", all.get(2).getVersionId());
-    assertEquals(t2, all.get(2).getNoncurrentAt());
+    assertFalse(all.get(1).isArchived());
+    assertEquals(t, all.get(1).getArchivedAt());
   }
 
   private static ObjectVersion version(String key, String versionId, long size) {

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIteratorTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIteratorTest.java
@@ -199,6 +199,199 @@ public class BlobMetadataIteratorTest {
     assertEquals(t2, all.get(1).getNoncurrentAt());
   }
 
+  @Test
+  void testMultiplePagesMergeDeleteMarkersAcrossPageBoundaries() {
+    String key = "obj-1";
+    Instant t2 = Instant.parse("2024-01-02T00:00:00Z");
+    Instant t4 = Instant.parse("2024-01-04T00:00:00Z");
+    Instant t5 = Instant.parse("2024-01-05T00:00:00Z");
+
+    // Global newest-first sequence for the key: v3 (t5) -> marker (t4) -> v1 (t2), split so that
+    // the marker on page 1 must merge ahead of the version on page 2.
+    ObjectVersion v3 = version(key, "v3", 300L, t5);
+    DeleteMarkerEntry marker = marker(key, "dm1", t4);
+    ObjectVersion v1 = version(key, "v1", 100L, t2);
+
+    ListObjectVersionsResponse page1 =
+        ListObjectVersionsResponse.builder().versions(v3).deleteMarkers(marker).build();
+    ListObjectVersionsResponse page2 =
+        ListObjectVersionsResponse.builder().versions(v1).build();
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(page1, page2).iterator());
+    when(mockS3Client.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    Iterator<BlobMetadata> iterator =
+        new BlobMetadataIterator(mockS3Client, TEST_BUCKET, key, true);
+    List<BlobMetadata> all = new ArrayList<>();
+    iterator.forEachRemaining(all::add);
+
+    assertEquals(3, all.size());
+
+    assertEquals("v3", all.get(0).getVersionId());
+    assertFalse(all.get(0).isDeleteMarker());
+    assertNull(all.get(0).getNoncurrentAt());
+
+    // Delete marker from page 1 merges ahead of the version from page 2.
+    assertEquals("dm1", all.get(1).getVersionId());
+    assertTrue(all.get(1).isDeleteMarker());
+    assertEquals(t4, all.get(1).getCreatedTime());
+    assertEquals(t5, all.get(1).getNoncurrentAt());
+
+    // Cross-page supersession: the older version stopped being current at the marker instant.
+    assertEquals("v1", all.get(2).getVersionId());
+    assertFalse(all.get(2).isDeleteMarker());
+    assertEquals(t2, all.get(2).getCreatedTime());
+    assertEquals(t4, all.get(2).getNoncurrentAt());
+  }
+
+  @Test
+  void testMarkerOnlyPageFlagOn() {
+    String key = "obj-1";
+    Instant t1 = Instant.parse("2024-01-01T00:00:00Z");
+    DeleteMarkerEntry marker = marker(key, "dm1", t1);
+
+    ListObjectVersionsResponse response =
+        ListObjectVersionsResponse.builder().deleteMarkers(marker).build();
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(response).iterator());
+    when(mockS3Client.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    Iterator<BlobMetadata> iterator =
+        new BlobMetadataIterator(mockS3Client, TEST_BUCKET, key, true);
+    List<BlobMetadata> all = new ArrayList<>();
+    iterator.forEachRemaining(all::add);
+
+    assertEquals(1, all.size());
+    assertEquals("dm1", all.get(0).getVersionId());
+    assertTrue(all.get(0).isDeleteMarker());
+    assertNull(all.get(0).getNoncurrentAt());
+  }
+
+  @Test
+  void testMarkerOnlyPageFlagOff() {
+    String key = "obj-1";
+    Instant t1 = Instant.parse("2024-01-01T00:00:00Z");
+    DeleteMarkerEntry marker = marker(key, "dm1", t1);
+
+    ListObjectVersionsResponse response =
+        ListObjectVersionsResponse.builder().deleteMarkers(marker).build();
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(response).iterator());
+    when(mockS3Client.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    // Default 3-arg constructor hides delete markers.
+    Iterator<BlobMetadata> iterator = new BlobMetadataIterator(mockS3Client, TEST_BUCKET, key);
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void testEmptyFilteredPageThenLaterPageWithData() {
+    String key = "obj-1";
+    // Page 1 holds only a sibling key that shares the prefix; it filters to empty.
+    ObjectVersion sibling = version("obj-1-extra", "vX", 999L);
+    ObjectVersion matching = version(key, "v1", 100L);
+
+    ListObjectVersionsResponse page1 =
+        ListObjectVersionsResponse.builder().versions(sibling).build();
+    ListObjectVersionsResponse page2 =
+        ListObjectVersionsResponse.builder().versions(matching).build();
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(page1, page2).iterator());
+    when(mockS3Client.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    Iterator<BlobMetadata> iterator = new BlobMetadataIterator(mockS3Client, TEST_BUCKET, key);
+    List<BlobMetadata> all = new ArrayList<>();
+    iterator.forEachRemaining(all::add);
+
+    assertEquals(1, all.size());
+    assertEquals(key, all.get(0).getKey());
+    assertEquals("v1", all.get(0).getVersionId());
+  }
+
+  @Test
+  void testLazyPageLoadingPullsPagesOnDemand() {
+    String key = "obj-1";
+    ListObjectVersionsResponse page1 =
+        ListObjectVersionsResponse.builder().versions(version(key, "v3", 300L)).build();
+    ListObjectVersionsResponse page2 =
+        ListObjectVersionsResponse.builder().versions(version(key, "v2", 200L)).build();
+    ListObjectVersionsResponse page3 =
+        ListObjectVersionsResponse.builder().versions(version(key, "v1", 100L)).build();
+
+    int[] fetched = {0};
+    Iterator<ListObjectVersionsResponse> counting =
+        new Iterator<>() {
+          private final Iterator<ListObjectVersionsResponse> delegate =
+              List.of(page1, page2, page3).iterator();
+
+          @Override
+          public boolean hasNext() {
+            return delegate.hasNext();
+          }
+
+          @Override
+          public ListObjectVersionsResponse next() {
+            fetched[0]++;
+            return delegate.next();
+          }
+        };
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(counting);
+    when(mockS3Client.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    Iterator<BlobMetadata> iterator = new BlobMetadataIterator(mockS3Client, TEST_BUCKET, key);
+
+    // Construction alone fetches nothing.
+    assertEquals(0, fetched[0]);
+
+    // Reading the first element pulls only the first page.
+    assertTrue(iterator.hasNext());
+    assertEquals("v3", iterator.next().getVersionId());
+    assertEquals(1, fetched[0]);
+
+    // Draining the rest pulls the remaining pages on demand.
+    List<BlobMetadata> rest = new ArrayList<>();
+    iterator.forEachRemaining(rest::add);
+    assertEquals(2, rest.size());
+    assertEquals(3, fetched[0]);
+  }
+
+  @Test
+  void testEqualTimestampsBothEntriesPresent() {
+    String key = "obj-1";
+    Instant t = Instant.parse("2024-01-01T00:00:00Z");
+    ObjectVersion v1 = version(key, "v1", 100L, t);
+    DeleteMarkerEntry marker = marker(key, "dm1", t);
+
+    ListObjectVersionsResponse response =
+        ListObjectVersionsResponse.builder().versions(v1).deleteMarkers(marker).build();
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(response).iterator());
+    when(mockS3Client.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    Iterator<BlobMetadata> iterator =
+        new BlobMetadataIterator(mockS3Client, TEST_BUCKET, key, true);
+    List<BlobMetadata> all = new ArrayList<>();
+    iterator.forEachRemaining(all::add);
+
+    // Both entries surface; equal-timestamp ordering is intentionally left unasserted.
+    assertEquals(2, all.size());
+    long markerCount = all.stream().filter(BlobMetadata::isDeleteMarker).count();
+    assertEquals(1, markerCount);
+  }
+
   private static ObjectVersion version(String key, String versionId, long size) {
     return version(key, versionId, size, Instant.now());
   }

--- a/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIteratorTest.java
+++ b/blob/blob-aws/src/test/java/com/salesforce/multicloudj/blob/aws/BlobMetadataIteratorTest.java
@@ -75,14 +75,18 @@ public class BlobMetadataIteratorTest {
   @Test
   void testMultiplePages() {
     String key = "obj-1";
-    ObjectVersion version1 = version(key, "v1", 100L);
-    ObjectVersion version2 = version(key, "v2", 200L);
-    ObjectVersion version3 = version(key, "v3", 300L);
+    Instant t1 = Instant.parse("2024-01-01T00:00:00Z");
+    Instant t2 = Instant.parse("2024-01-02T00:00:00Z");
+    Instant t3 = Instant.parse("2024-01-03T00:00:00Z");
+    // Newest-first across pages, matching S3's ordering: page1 holds the newest version.
+    ObjectVersion version3 = version(key, "v3", 300L, t3);
+    ObjectVersion version2 = version(key, "v2", 200L, t2);
+    ObjectVersion version1 = version(key, "v1", 100L, t1);
 
     ListObjectVersionsResponse page1 =
-        ListObjectVersionsResponse.builder().versions(version1).build();
+        ListObjectVersionsResponse.builder().versions(version3).build();
     ListObjectVersionsResponse page2 =
-        ListObjectVersionsResponse.builder().versions(version2, version3).build();
+        ListObjectVersionsResponse.builder().versions(version2, version1).build();
 
     ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
     when(iterable.iterator()).thenReturn(List.of(page1, page2).iterator());
@@ -94,9 +98,9 @@ public class BlobMetadataIteratorTest {
     iterator.forEachRemaining(all::add);
 
     assertEquals(3, all.size());
-    assertEquals("v1", all.get(0).getVersionId());
+    assertEquals("v3", all.get(0).getVersionId());
     assertEquals("v2", all.get(1).getVersionId());
-    assertEquals("v3", all.get(2).getVersionId());
+    assertEquals("v1", all.get(2).getVersionId());
   }
 
   @Test
@@ -390,6 +394,90 @@ public class BlobMetadataIteratorTest {
     assertEquals(2, all.size());
     long markerCount = all.stream().filter(BlobMetadata::isDeleteMarker).count();
     assertEquals(1, markerCount);
+  }
+
+  @Test
+  void testEqualTimestampsLatestFlagBreaksTie() {
+    String key = "obj-1";
+    Instant t = Instant.parse("2024-01-01T00:00:00Z");
+
+    // Same-instant PUT then DELETE: the delete marker is the current (latest) entry, so the
+    // latest flag must decide the order that the equal timestamps cannot.
+    ObjectVersion v1 =
+        ObjectVersion.builder()
+            .key(key)
+            .versionId("v1")
+            .eTag("etag-v1")
+            .size(100L)
+            .lastModified(t)
+            .isLatest(false)
+            .build();
+    DeleteMarkerEntry marker =
+        DeleteMarkerEntry.builder()
+            .key(key)
+            .versionId("dm1")
+            .lastModified(t)
+            .isLatest(true)
+            .build();
+
+    ListObjectVersionsResponse response =
+        ListObjectVersionsResponse.builder().versions(v1).deleteMarkers(marker).build();
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(response).iterator());
+    when(mockS3Client.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    Iterator<BlobMetadata> iterator =
+        new BlobMetadataIterator(mockS3Client, TEST_BUCKET, key, true);
+    List<BlobMetadata> all = new ArrayList<>();
+    iterator.forEachRemaining(all::add);
+
+    assertEquals(2, all.size());
+
+    // The delete marker S3 flagged latest is emitted first and is still current.
+    assertEquals("dm1", all.get(0).getVersionId());
+    assertTrue(all.get(0).isDeleteMarker());
+    assertNull(all.get(0).getNoncurrentAt());
+
+    // The content version sharing the instant is superseded by that marker.
+    assertEquals("v1", all.get(1).getVersionId());
+    assertFalse(all.get(1).isDeleteMarker());
+    assertEquals(t, all.get(1).getNoncurrentAt());
+  }
+
+  @Test
+  void testUnsortedPageEntriesAreReorderedNewestFirst() {
+    String key = "obj-1";
+    Instant t1 = Instant.parse("2024-01-01T00:00:00Z");
+    Instant t2 = Instant.parse("2024-01-02T00:00:00Z");
+    Instant t3 = Instant.parse("2024-01-03T00:00:00Z");
+
+    // Feed the page out of newest-first order to prove the iterator re-sorts rather than trusting
+    // the SDK's documented ordering.
+    ObjectVersion v1 = version(key, "v1", 100L, t1);
+    ObjectVersion v2 = version(key, "v2", 200L, t2);
+    ObjectVersion v3 = version(key, "v3", 300L, t3);
+
+    ListObjectVersionsResponse response =
+        ListObjectVersionsResponse.builder().versions(v2, v1, v3).build();
+
+    ListObjectVersionsIterable iterable = mock(ListObjectVersionsIterable.class);
+    when(iterable.iterator()).thenReturn(List.of(response).iterator());
+    when(mockS3Client.listObjectVersionsPaginator(any(ListObjectVersionsRequest.class)))
+        .thenReturn(iterable);
+
+    Iterator<BlobMetadata> iterator = new BlobMetadataIterator(mockS3Client, TEST_BUCKET, key);
+    List<BlobMetadata> all = new ArrayList<>();
+    iterator.forEachRemaining(all::add);
+
+    assertEquals(3, all.size());
+    assertEquals("v3", all.get(0).getVersionId());
+    assertNull(all.get(0).getNoncurrentAt());
+    assertEquals("v2", all.get(1).getVersionId());
+    assertEquals(t3, all.get(1).getNoncurrentAt());
+    assertEquals("v1", all.get(2).getVersionId());
+    assertEquals(t2, all.get(2).getNoncurrentAt());
   }
 
   private static ObjectVersion version(String key, String versionId, long size) {

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-delete-7.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-delete-7.json
@@ -1,0 +1,22 @@
+{
+  "id" : "29d5f11f-6cbb-418c-8614-43bc2a9baeb0",
+  "name" : "AwsBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-DELETE-7",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-delete-marker" : "true",
+      "x-amz-request-id" : "PVVQD7RTPGFSX1KZ",
+      "x-amz-id-2" : "t51+d9111jDLjpKlweqvppXj4kBgu8GlB8EnuZSVOR4HzsemeiVFm6vCPxGchm7BKexcRI85Ahd+owlar6TofWrSolTF/BgR",
+      "x-amz-version-id" : "DZWMgtk1nbN.G5cFLyHdyvFe7Ns14ven",
+      "Date" : "Mon, 07 Sep 2026 06:53:17 GMT"
+    }
+  },
+  "uuid" : "29d5f11f-6cbb-418c-8614-43bc2a9baeb0",
+  "persistent" : true,
+  "insertionIndex" : 788
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-get-1.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-get-1.json
@@ -1,0 +1,41 @@
+{
+  "id" : "a1e063ea-cff0-4b7c-8e57-96528abb8b81",
+  "name" : "AwsBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-1",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versions" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      },
+      "prefix" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListVersionsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>chameleon-jcloud-versioned</Name><Prefix>conformance-tests/list-object-versions/delete-marker-timeline-blob</Prefix><KeyMarker></KeyMarker><VersionIdMarker></VersionIdMarker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Version><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>NKl0hGFYidTDeYLiAlUktOSkswaD1PTd</VersionId><IsLatest>true</IsLatest><LastModified>2026-09-07T06:53:18.000Z</LastModified><ETag>&quot;f125b22cf257c2ec750c7a597e11c924&quot;</ETag><ChecksumAlgorithm>CRC64NVME</ChecksumAlgorithm><ChecksumType>FULL_OBJECT</ChecksumType><Size>9</Size><Owner><ID>b6eaab2af32ba61bce00b8c9aceaa1c649844388ec2c3827bbd3e2b06f798cf1</ID></Owner><StorageClass>STANDARD</StorageClass></Version><DeleteMarker><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>DZWMgtk1nbN.G5cFLyHdyvFe7Ns14ven</VersionId><IsLatest>false</IsLatest><LastModified>2026-09-07T06:53:17.000Z</LastModified><Owner><ID>b6eaab2af32ba61bce00b8c9aceaa1c649844388ec2c3827bbd3e2b06f798cf1</ID></Owner></DeleteMarker><Version><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>7MDb1A4x9HNUZ1UOemybAQiHj98aGex0</VersionId><IsLatest>false</IsLatest><LastModified>2026-09-07T06:53:16.000Z</LastModified><ETag>&quot;fbd17ddef276ea15252e4b9b91758267&quot;</ETag><ChecksumAlgorithm>CRC64NVME</ChecksumAlgorithm><ChecksumType>FULL_OBJECT</ChecksumType><Size>9</Size><Owner><ID>b6eaab2af32ba61bce00b8c9aceaa1c649844388ec2c3827bbd3e2b06f798cf1</ID></Owner><StorageClass>STANDARD</StorageClass></Version></ListVersionsResult>",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "T1NXV80ZYGX3F954",
+      "x-amz-id-2" : "gQCa1fe3YrCN1/cVwimKLRfbFHRIpmxCZpMY3v/RgyrXmxsFivnC83E6OmsZq6J0Bs+HTm6L4yk=",
+      "Date" : "Mon, 07 Sep 2026 06:53:24 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "a1e063ea-cff0-4b7c-8e57-96528abb8b81",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned",
+  "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-3",
+  "insertionIndex" : 782
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-get-2.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-get-2.json
@@ -1,0 +1,42 @@
+{
+  "id" : "3f99eda7-a300-43c6-972f-2b8abe19261e",
+  "name" : "AwsBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-2",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versions" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      },
+      "prefix" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListVersionsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>chameleon-jcloud-versioned</Name><Prefix>conformance-tests/list-object-versions/delete-marker-timeline-blob</Prefix><KeyMarker></KeyMarker><VersionIdMarker></VersionIdMarker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Version><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>NKl0hGFYidTDeYLiAlUktOSkswaD1PTd</VersionId><IsLatest>true</IsLatest><LastModified>2026-09-07T06:53:18.000Z</LastModified><ETag>&quot;f125b22cf257c2ec750c7a597e11c924&quot;</ETag><ChecksumAlgorithm>CRC64NVME</ChecksumAlgorithm><ChecksumType>FULL_OBJECT</ChecksumType><Size>9</Size><Owner><ID>b6eaab2af32ba61bce00b8c9aceaa1c649844388ec2c3827bbd3e2b06f798cf1</ID></Owner><StorageClass>STANDARD</StorageClass></Version><DeleteMarker><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>DZWMgtk1nbN.G5cFLyHdyvFe7Ns14ven</VersionId><IsLatest>false</IsLatest><LastModified>2026-09-07T06:53:17.000Z</LastModified><Owner><ID>b6eaab2af32ba61bce00b8c9aceaa1c649844388ec2c3827bbd3e2b06f798cf1</ID></Owner></DeleteMarker><Version><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>7MDb1A4x9HNUZ1UOemybAQiHj98aGex0</VersionId><IsLatest>false</IsLatest><LastModified>2026-09-07T06:53:16.000Z</LastModified><ETag>&quot;fbd17ddef276ea15252e4b9b91758267&quot;</ETag><ChecksumAlgorithm>CRC64NVME</ChecksumAlgorithm><ChecksumType>FULL_OBJECT</ChecksumType><Size>9</Size><Owner><ID>b6eaab2af32ba61bce00b8c9aceaa1c649844388ec2c3827bbd3e2b06f798cf1</ID></Owner><StorageClass>STANDARD</StorageClass></Version></ListVersionsResult>",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "YH91D3JEZTQYKKSD",
+      "x-amz-id-2" : "WkPhUpVxrqB20ZrgpQQu9VwlIHD/JPBzVTYWa4i9mQmfIL2AUAU4tZH6AYxrBjaLql6Dkod6MEo=",
+      "Date" : "Mon, 07 Sep 2026 06:53:22 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "3f99eda7-a300-43c6-972f-2b8abe19261e",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned",
+  "requiredScenarioState" : "scenario-1-chameleon-jcloud-versioned-2",
+  "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-3",
+  "insertionIndex" : 783
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-get-3.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-get-3.json
@@ -1,0 +1,41 @@
+{
+  "id" : "fdf71027-e177-4546-bada-fd055b816fad",
+  "name" : "AwsBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-3",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "NKl0hGFYidTDeYLiAlUktOSkswaD1PTd"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "Y29udGVudC1C",
+    "headers" : {
+      "Accept-Ranges" : "bytes",
+      "Server" : "AmazonS3",
+      "ETag" : "\"f125b22cf257c2ec750c7a597e11c924\"",
+      "x-amz-checksum-crc64nvme" : "R0m77OoBlyc=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Mon, 07 Sep 2026 06:53:18 GMT",
+      "x-amz-request-id" : "YH98H82YKY6QJYDJ",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "1EPOrxv2wmpgnFDrf9M+xbTYlfxkD7qmNgRRx4x1dM/dfgLmZPJ7wSsB5zvZDfF/CPCW8WMl7ug=",
+      "x-amz-version-id" : "NKl0hGFYidTDeYLiAlUktOSkswaD1PTd",
+      "Date" : "Mon, 07 Sep 2026 06:53:22 GMT",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "fdf71027-e177-4546-bada-fd055b816fad",
+  "persistent" : true,
+  "insertionIndex" : 784
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-get-4.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-get-4.json
@@ -1,0 +1,41 @@
+{
+  "id" : "8a828b6a-f3dc-48f6-b713-be8f4f3c9712",
+  "name" : "AwsBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-4",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "versionId" : {
+        "hasExactly" : [ {
+          "equalTo" : "7MDb1A4x9HNUZ1UOemybAQiHj98aGex0"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "Y29udGVudC1B",
+    "headers" : {
+      "Accept-Ranges" : "bytes",
+      "Server" : "AmazonS3",
+      "ETag" : "\"fbd17ddef276ea15252e4b9b91758267\"",
+      "x-amz-checksum-crc64nvme" : "xvqqtLpfDKw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "Last-Modified" : "Mon, 07 Sep 2026 06:53:16 GMT",
+      "x-amz-request-id" : "ZYR85554WJPB2C60",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "FxTep6Yrd0RIYvLvS8k5+LSRNc7pkEk6hymx/agLiyk2e8QwV9aSZrNjyjPlmLe5UAJBIkANOG4=",
+      "x-amz-version-id" : "7MDb1A4x9HNUZ1UOemybAQiHj98aGex0",
+      "Date" : "Mon, 07 Sep 2026 06:53:20 GMT",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "8a828b6a-f3dc-48f6-b713-be8f4f3c9712",
+  "persistent" : true,
+  "insertionIndex" : 785
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-get-5.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-get-5.json
@@ -1,0 +1,42 @@
+{
+  "id" : "32f5f3c1-ee89-46c5-ae21-ec784145c14e",
+  "name" : "AwsBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-5",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "versions" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      },
+      "prefix" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListVersionsResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name>chameleon-jcloud-versioned</Name><Prefix>conformance-tests/list-object-versions/delete-marker-timeline-blob</Prefix><KeyMarker></KeyMarker><VersionIdMarker></VersionIdMarker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Version><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>NKl0hGFYidTDeYLiAlUktOSkswaD1PTd</VersionId><IsLatest>true</IsLatest><LastModified>2026-09-07T06:53:18.000Z</LastModified><ETag>&quot;f125b22cf257c2ec750c7a597e11c924&quot;</ETag><ChecksumAlgorithm>CRC64NVME</ChecksumAlgorithm><ChecksumType>FULL_OBJECT</ChecksumType><Size>9</Size><Owner><ID>b6eaab2af32ba61bce00b8c9aceaa1c649844388ec2c3827bbd3e2b06f798cf1</ID></Owner><StorageClass>STANDARD</StorageClass></Version><DeleteMarker><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>DZWMgtk1nbN.G5cFLyHdyvFe7Ns14ven</VersionId><IsLatest>false</IsLatest><LastModified>2026-09-07T06:53:17.000Z</LastModified><Owner><ID>b6eaab2af32ba61bce00b8c9aceaa1c649844388ec2c3827bbd3e2b06f798cf1</ID></Owner></DeleteMarker><Version><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>7MDb1A4x9HNUZ1UOemybAQiHj98aGex0</VersionId><IsLatest>false</IsLatest><LastModified>2026-09-07T06:53:16.000Z</LastModified><ETag>&quot;fbd17ddef276ea15252e4b9b91758267&quot;</ETag><ChecksumAlgorithm>CRC64NVME</ChecksumAlgorithm><ChecksumType>FULL_OBJECT</ChecksumType><Size>9</Size><Owner><ID>b6eaab2af32ba61bce00b8c9aceaa1c649844388ec2c3827bbd3e2b06f798cf1</ID></Owner><StorageClass>STANDARD</StorageClass></Version></ListVersionsResult>",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "28W9C8MKQF2MMKER",
+      "x-amz-id-2" : "+OK3cRD2s+C5zXq548XCG6dcGolfEfhRbyn4a9YDlvYXKazjGVBQToj+lr9N7id9QO/lNpa+uyU=",
+      "Date" : "Mon, 07 Sep 2026 06:53:19 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "32f5f3c1-ee89-46c5-ae21-ec784145c14e",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-chameleon-jcloud-versioned",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-chameleon-jcloud-versioned-2",
+  "insertionIndex" : 786
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-post-0.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-post-0.json
@@ -1,0 +1,37 @@
+{
+  "id" : "a5c2eabc-b9a4-4195-9c5a-04051947a32f",
+  "name" : "AwsBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-POST-0",
+  "request" : {
+    "urlPath" : "/chameleon-jcloud-versioned",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "1"
+      }
+    },
+    "queryParameters" : {
+      "delete" : {
+        "hasExactly" : [ {
+          "equalTo" : ""
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Delete xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Object><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>NKl0hGFYidTDeYLiAlUktOSkswaD1PTd</VersionId></Object><Object><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>DZWMgtk1nbN.G5cFLyHdyvFe7Ns14ven</VersionId></Object><Object><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>7MDb1A4x9HNUZ1UOemybAQiHj98aGex0</VersionId></Object></Delete>"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<DeleteResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Deleted><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>7MDb1A4x9HNUZ1UOemybAQiHj98aGex0</VersionId></Deleted><Deleted><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>NKl0hGFYidTDeYLiAlUktOSkswaD1PTd</VersionId></Deleted><Deleted><Key>conformance-tests/list-object-versions/delete-marker-timeline-blob</Key><VersionId>DZWMgtk1nbN.G5cFLyHdyvFe7Ns14ven</VersionId><DeleteMarker>true</DeleteMarker><DeleteMarkerVersionId>DZWMgtk1nbN.G5cFLyHdyvFe7Ns14ven</DeleteMarkerVersionId></Deleted></DeleteResult>",
+    "headers" : {
+      "Server" : "AmazonS3",
+      "x-amz-request-id" : "7P1D041HGCB2C0AC",
+      "x-amz-id-2" : "RlXcrWmTMSI6Jg+VWZjZsQy6axXjlBHFBiTgSqJfeMVAFfWqINhpE3RxXTp0ablc6Yoa0v9ujds=",
+      "Date" : "Mon, 07 Sep 2026 06:53:25 GMT",
+      "Content-Type" : "application/xml"
+    }
+  },
+  "uuid" : "a5c2eabc-b9a4-4195-9c5a-04051947a32f",
+  "persistent" : true,
+  "insertionIndex" : 781
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-put-6.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-put-6.json
@@ -1,0 +1,28 @@
+{
+  "id" : "03e7e54f-174f-4bd5-8040-da8b37539905",
+  "name" : "AwsBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-PUT-6",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "Y29udGVudC1C"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"f125b22cf257c2ec750c7a597e11c924\"",
+      "x-amz-checksum-crc64nvme" : "R0m77OoBlyc=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "V9MQ9EV8V0CNBP9K",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "xErm1/WGIdHqTDZaAIJnyt0BKRMo/F+pjjjXlXcmXsM+fu/n/CBWIC+s2Lqe8gRy9myontfzXeTufkKurdKauzx+JvKIHHmD",
+      "x-amz-version-id" : "NKl0hGFYidTDeYLiAlUktOSkswaD1PTd",
+      "Date" : "Mon, 07 Sep 2026 06:53:18 GMT"
+    }
+  },
+  "uuid" : "03e7e54f-174f-4bd5-8040-da8b37539905",
+  "persistent" : true,
+  "insertionIndex" : 787
+}

--- a/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-put-8.json
+++ b/blob/blob-aws/src/test/resources/mappings/awsblobstoreit_testlistblobversions_deletemarkertimeline-put-8.json
@@ -1,0 +1,28 @@
+{
+  "id" : "80f8c75b-17c9-4378-8224-46cfc3bf9d1e",
+  "name" : "AwsBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-PUT-8",
+  "request" : {
+    "url" : "/chameleon-jcloud-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob",
+    "method" : "PUT",
+    "bodyPatterns" : [ {
+      "binaryEqualTo" : "Y29udGVudC1B"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Server" : "AmazonS3",
+      "ETag" : "\"fbd17ddef276ea15252e4b9b91758267\"",
+      "x-amz-checksum-crc64nvme" : "xvqqtLpfDKw=",
+      "x-amz-checksum-type" : "FULL_OBJECT",
+      "x-amz-request-id" : "RTWTH5WX5FWSJHRV",
+      "x-amz-server-side-encryption" : "AES256",
+      "x-amz-id-2" : "qfRFH4uDma65Dn52AeU1aTd7FdVaW4L3fN8bpU03Waaz1AtNFUVUFkzbxFGV01MrbHAzZB8LaKYTN4AOyxLQmkXYLOonYMhZ",
+      "x-amz-version-id" : "7MDb1A4x9HNUZ1UOemybAQiHj98aGex0",
+      "Date" : "Mon, 07 Sep 2026 06:53:16 GMT"
+    }
+  },
+  "uuid" : "80f8c75b-17c9-4378-8224-46cfc3bf9d1e",
+  "persistent" : true,
+  "insertionIndex" : 789
+}

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobMetadata.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobMetadata.java
@@ -47,4 +47,19 @@ public class BlobMetadata {
 
   /** The correlation ID associated with the operation that produced this metadata. */
   private final String correlationId;
+
+  /**
+   * Whether this entry is a delete marker rather than a content version. Delete markers record that
+   * an object was deleted at a point in time; they carry no downloadable content. Defaults to
+   * {@code false} for content versions and for stores that do not surface delete markers.
+   */
+  private final boolean deleteMarker;
+
+  /**
+   * The instant at which this content version stopped being the current version, or {@code null} if
+   * it is still current (or the store does not report it). Together with {@link #createdTime} this
+   * defines the version's validity interval {@code [createdTime, noncurrentAt)}, with the end
+   * instant exclusive.
+   */
+  private final Instant noncurrentAt;
 }

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobMetadata.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobMetadata.java
@@ -49,23 +49,17 @@ public class BlobMetadata {
   private final String correlationId;
 
   /**
-   * Whether this entry is a delete marker rather than a content version. Delete markers record that
-   * an object was deleted at a point in time; they carry no downloadable content. Defaults to
-   * {@code false} for content versions and for stores that do not surface delete markers.
+   * Whether this entry records that the object was archived (deleted) at a point in time rather
+   * than a downloadable content version. Defaults to {@code false} for content versions and for
+   * stores that do not surface archived entries.
    */
-  private final boolean deleteMarker;
+  private final boolean archived;
 
   /**
    * The instant at which this version stopped being the current version, or {@code null} if it is
    * still current (or the store does not report it). Together with {@link #createdTime} this
-   * defines the version's validity interval {@code [createdTime, noncurrentAt)}, with the end
-   * instant exclusive.
-   *
-   * <p>How this instant is obtained depends on the backing store: some stores report the
-   * supersession moment natively, while others derive it from the creation time of the immediately
-   * superseding version. The interval contract is identical in both cases, but the value may differ
-   * by a small margin from a store-native timestamp for the same logical event, so treat it as the
-   * boundary of the validity interval rather than an exact, cross-store-comparable clock reading.
+   * defines the version's validity interval {@code [createdTime, archivedAt)}, with the end instant
+   * exclusive.
    */
-  private final Instant noncurrentAt;
+  private final Instant archivedAt;
 }

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobMetadata.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/BlobMetadata.java
@@ -56,10 +56,16 @@ public class BlobMetadata {
   private final boolean deleteMarker;
 
   /**
-   * The instant at which this content version stopped being the current version, or {@code null} if
-   * it is still current (or the store does not report it). Together with {@link #createdTime} this
+   * The instant at which this version stopped being the current version, or {@code null} if it is
+   * still current (or the store does not report it). Together with {@link #createdTime} this
    * defines the version's validity interval {@code [createdTime, noncurrentAt)}, with the end
    * instant exclusive.
+   *
+   * <p>How this instant is obtained depends on the backing store: some stores report the
+   * supersession moment natively, while others derive it from the creation time of the immediately
+   * superseding version. The interval contract is identical in both cases, but the value may differ
+   * by a small margin from a store-native timestamp for the same logical event, so treat it as the
+   * boundary of the validity interval rather than an exact, cross-store-comparable clock reading.
    */
   private final Instant noncurrentAt;
 }

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/ListBlobVersionsRequest.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/ListBlobVersionsRequest.java
@@ -11,15 +11,15 @@ public class ListBlobVersionsRequest {
   private final String key;
 
   /**
-   * When {@code true}, the listing includes delete-marker entries in addition to content versions.
-   * When {@code false} (the default), only content versions are returned. Defaults to {@code false}
-   * so existing callers observe no behavioral change.
+   * When {@code true}, the listing includes archived (delete-marker) entries in addition to content
+   * versions. When {@code false} (the default), only content versions are returned. Defaults to
+   * {@code false} so existing callers observe no behavioral change.
    */
-  private final boolean includeDeleteMarkers;
+  private final boolean includeArchived;
 
   private ListBlobVersionsRequest(Builder builder) {
     this.key = builder.key;
-    this.includeDeleteMarkers = builder.includeDeleteMarkers;
+    this.includeArchived = builder.includeArchived;
   }
 
   public static Builder builder() {
@@ -28,7 +28,7 @@ public class ListBlobVersionsRequest {
 
   public static class Builder {
     private String key;
-    private boolean includeDeleteMarkers = false;
+    private boolean includeArchived = false;
 
     public Builder withKey(String key) {
       this.key = key;
@@ -36,13 +36,13 @@ public class ListBlobVersionsRequest {
     }
 
     /**
-     * Controls whether delete-marker entries are included in the version listing.
+     * Controls whether archived (delete-marker) entries are included in the version listing.
      *
-     * @param includeDeleteMarkers {@code true} to include delete markers, {@code false} (default)
-     *     to return only content versions.
+     * @param includeArchived {@code true} to include archived entries, {@code false} (default) to
+     *     return only content versions.
      */
-    public Builder withIncludeDeleteMarkers(boolean includeDeleteMarkers) {
-      this.includeDeleteMarkers = includeDeleteMarkers;
+    public Builder withIncludeArchived(boolean includeArchived) {
+      this.includeArchived = includeArchived;
       return this;
     }
 

--- a/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/ListBlobVersionsRequest.java
+++ b/blob/blob-client/src/main/java/com/salesforce/multicloudj/blob/driver/ListBlobVersionsRequest.java
@@ -10,8 +10,16 @@ public class ListBlobVersionsRequest {
 
   private final String key;
 
+  /**
+   * When {@code true}, the listing includes delete-marker entries in addition to content versions.
+   * When {@code false} (the default), only content versions are returned. Defaults to {@code false}
+   * so existing callers observe no behavioral change.
+   */
+  private final boolean includeDeleteMarkers;
+
   private ListBlobVersionsRequest(Builder builder) {
     this.key = builder.key;
+    this.includeDeleteMarkers = builder.includeDeleteMarkers;
   }
 
   public static Builder builder() {
@@ -20,9 +28,21 @@ public class ListBlobVersionsRequest {
 
   public static class Builder {
     private String key;
+    private boolean includeDeleteMarkers = false;
 
     public Builder withKey(String key) {
       this.key = key;
+      return this;
+    }
+
+    /**
+     * Controls whether delete-marker entries are included in the version listing.
+     *
+     * @param includeDeleteMarkers {@code true} to include delete markers, {@code false} (default)
+     *     to return only content versions.
+     */
+    public Builder withIncludeDeleteMarkers(boolean includeDeleteMarkers) {
+      this.includeDeleteMarkers = includeDeleteMarkers;
       return this;
     }
 

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -6379,20 +6379,20 @@ public abstract class AbstractBlobStoreIT {
       Assertions.assertTrue(
           defaultByVersion.containsKey(versionB), "Default listing should include version B");
       Assertions.assertTrue(
-          defaultByVersion.values().stream().noneMatch(BlobMetadata::isDeleteMarker),
+          defaultByVersion.values().stream().noneMatch(BlobMetadata::isArchived),
           "Default listing must not surface delete markers");
 
-      // Point-in-time semantics: A was superseded (has a noncurrentAt), B is current (has none).
+      // Point-in-time semantics: A was superseded (has a archivedAt), B is current (has none).
       BlobMetadata metaA = defaultByVersion.get(versionA);
       BlobMetadata metaB = defaultByVersion.get(versionB);
       Assertions.assertNotNull(
-          metaA.getNoncurrentAt(), "Superseded version A should report a noncurrentAt instant");
+          metaA.getArchivedAt(), "Superseded version A should report a archivedAt instant");
       Assertions.assertNull(
-          metaB.getNoncurrentAt(), "Current version B should not report a noncurrentAt instant");
+          metaB.getArchivedAt(), "Current version B should not report a archivedAt instant");
       if (metaA.getCreatedTime() != null) {
         Assertions.assertFalse(
-            metaA.getNoncurrentAt().isBefore(metaA.getCreatedTime()),
-            "Validity interval [createdTime, noncurrentAt) must be non-negative");
+            metaA.getArchivedAt().isBefore(metaA.getCreatedTime()),
+            "Validity interval [createdTime, archivedAt) must be non-negative");
       }
 
       // Both content versions must be downloadable by their versionIds.
@@ -6412,23 +6412,39 @@ public abstract class AbstractBlobStoreIT {
           includedByVersion.keySet().containsAll(defaultByVersion.keySet()),
           "Opt-in listing should contain every content version the default listing returned");
       Assertions.assertEquals(
-          metaA.getNoncurrentAt(),
-          includedByVersion.get(versionA).getNoncurrentAt(),
-          "noncurrentAt for a content version must not depend on the includeDeleteMarkers flag");
+          metaA.getArchivedAt(),
+          includedByVersion.get(versionA).getArchivedAt(),
+          "archivedAt for a content version must not depend on the includeArchived flag");
       Assertions.assertTrue(
           includedByVersion.size() >= defaultByVersion.size(),
           "Opt-in listing must not drop any entries relative to the default listing");
       Assertions.assertTrue(
           includedByVersion.values().stream()
-              .filter(BlobMetadata::isDeleteMarker)
+              .filter(BlobMetadata::isArchived)
               .allMatch(m -> key.equals(m.getKey())),
-          "Any surfaced delete marker must belong to the requested key");
+          "Any surfaced archived entry must belong to the requested key");
+
+      // Stores that model deletion as a standalone delete marker (rather than archiving a content
+      // generation) must actually surface that marker when the opt-in flag is set; otherwise the
+      // superset assertions above pass vacuously. GCS has no standalone marker to emit and is
+      // exempt.
+      boolean surfacesStandaloneDeleteMarkers = !GCP_PROVIDER_ID.equals(harness.getProviderId());
+      if (surfacesStandaloneDeleteMarkers) {
+        long archivedCount =
+            includedByVersion.values().stream().filter(BlobMetadata::isArchived).count();
+        Assertions.assertTrue(
+            archivedCount > 0,
+            "Opt-in listing must surface the delete marker created by the unqualified delete");
+        Assertions.assertTrue(
+            includedByVersion.size() > defaultByVersion.size(),
+            "Opt-in listing must add the delete marker on top of the content versions");
+      }
     } finally {
       try {
         List<BlobIdentifier> toDelete = new ArrayList<>();
         Iterator<BlobMetadata> allEntries =
             bucketClient.listBlobVersions(
-                ListBlobVersionsRequest.builder().withKey(key).withIncludeDeleteMarkers(true)
+                ListBlobVersionsRequest.builder().withKey(key).withIncludeArchived(true)
                     .build());
         allEntries.forEachRemaining(
             v -> toDelete.add(new BlobIdentifier(v.getKey(), v.getVersionId())));
@@ -6442,12 +6458,12 @@ public abstract class AbstractBlobStoreIT {
   }
 
   private static Map<String, BlobMetadata> collectByVersionId(
-      BucketClient bucketClient, String key, boolean includeDeleteMarkers) {
+      BucketClient bucketClient, String key, boolean includeArchived) {
     Iterator<BlobMetadata> iterator =
         bucketClient.listBlobVersions(
             ListBlobVersionsRequest.builder()
                 .withKey(key)
-                .withIncludeDeleteMarkers(includeDeleteMarkers)
+                .withIncludeArchived(includeArchived)
                 .build());
     Map<String, BlobMetadata> byVersion = new HashMap<>();
     iterator.forEachRemaining(v -> byVersion.put(v.getVersionId(), v));

--- a/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
+++ b/blob/blob-client/src/test/java/com/salesforce/multicloudj/blob/client/AbstractBlobStoreIT.java
@@ -6330,6 +6330,131 @@ public abstract class AbstractBlobStoreIT {
   }
 
   @Test
+  public void testListBlobVersions_deleteMarkerTimeline() throws IOException {
+    // Ali delete-marker support for listBlobVersions is tracked under a separate work item and is
+    // out of scope here; skip until that provider work lands and recordings are captured.
+    Assumptions.assumeFalse(ALI_PROVIDER_ID.equals(harness.getProviderId()));
+    AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
+    BucketClient bucketClient = new BucketClient(blobStore);
+    String key = "conformance-tests/list-object-versions/delete-marker-timeline-blob";
+
+    try {
+      // Canonical timeline: PUT A -> DELETE (unqualified) -> PUT B. This exercises supersession by
+      // a deletion, which every versioned store must reflect in the cloud-neutral validity window.
+      byte[] contentA = "content-A".getBytes(StandardCharsets.UTF_8);
+      String versionA;
+      try (InputStream in = new ByteArrayInputStream(contentA)) {
+        versionA =
+            bucketClient
+                .upload(
+                    new UploadRequest.Builder().withKey(key).withContentLength(contentA.length)
+                        .build(),
+                    in)
+                .getVersionId();
+      }
+      Assertions.assertTrue(StringUtils.isNotBlank(versionA), "PUT A should return a versionId");
+
+      // Unqualified delete removes the live object; prior content versions remain listable.
+      bucketClient.delete(key, null);
+
+      byte[] contentB = "content-B".getBytes(StandardCharsets.UTF_8);
+      String versionB;
+      try (InputStream in = new ByteArrayInputStream(contentB)) {
+        versionB =
+            bucketClient
+                .upload(
+                    new UploadRequest.Builder().withKey(key).withContentLength(contentB.length)
+                        .build(),
+                    in)
+                .getVersionId();
+      }
+      Assertions.assertTrue(StringUtils.isNotBlank(versionB), "PUT B should return a versionId");
+
+      // Default listing (flag omitted) must be backward-compatible: only content versions, no
+      // delete markers. Both A and B remain present and downloadable.
+      Map<String, BlobMetadata> defaultByVersion =
+          collectByVersionId(bucketClient, key, false);
+      Assertions.assertTrue(
+          defaultByVersion.containsKey(versionA), "Default listing should include version A");
+      Assertions.assertTrue(
+          defaultByVersion.containsKey(versionB), "Default listing should include version B");
+      Assertions.assertTrue(
+          defaultByVersion.values().stream().noneMatch(BlobMetadata::isDeleteMarker),
+          "Default listing must not surface delete markers");
+
+      // Point-in-time semantics: A was superseded (has a noncurrentAt), B is current (has none).
+      BlobMetadata metaA = defaultByVersion.get(versionA);
+      BlobMetadata metaB = defaultByVersion.get(versionB);
+      Assertions.assertNotNull(
+          metaA.getNoncurrentAt(), "Superseded version A should report a noncurrentAt instant");
+      Assertions.assertNull(
+          metaB.getNoncurrentAt(), "Current version B should not report a noncurrentAt instant");
+      if (metaA.getCreatedTime() != null) {
+        Assertions.assertFalse(
+            metaA.getNoncurrentAt().isBefore(metaA.getCreatedTime()),
+            "Validity interval [createdTime, noncurrentAt) must be non-negative");
+      }
+
+      // Both content versions must be downloadable by their versionIds.
+      for (String versionId : new String[] {versionA, versionB}) {
+        DownloadResponse response =
+            bucketClient.download(
+                new DownloadRequest.Builder().withKey(key).withVersionId(versionId).build(),
+                new ByteArray());
+        Assertions.assertNotNull(response, "Content version should be downloadable: " + versionId);
+      }
+
+      // Opt-in listing is a superset: the same content versions plus any store-native delete
+      // markers. Stores that do not model standalone delete markers simply add nothing here.
+      Map<String, BlobMetadata> includedByVersion =
+          collectByVersionId(bucketClient, key, true);
+      Assertions.assertTrue(
+          includedByVersion.keySet().containsAll(defaultByVersion.keySet()),
+          "Opt-in listing should contain every content version the default listing returned");
+      Assertions.assertEquals(
+          metaA.getNoncurrentAt(),
+          includedByVersion.get(versionA).getNoncurrentAt(),
+          "noncurrentAt for a content version must not depend on the includeDeleteMarkers flag");
+      Assertions.assertTrue(
+          includedByVersion.size() >= defaultByVersion.size(),
+          "Opt-in listing must not drop any entries relative to the default listing");
+      Assertions.assertTrue(
+          includedByVersion.values().stream()
+              .filter(BlobMetadata::isDeleteMarker)
+              .allMatch(m -> key.equals(m.getKey())),
+          "Any surfaced delete marker must belong to the requested key");
+    } finally {
+      try {
+        List<BlobIdentifier> toDelete = new ArrayList<>();
+        Iterator<BlobMetadata> allEntries =
+            bucketClient.listBlobVersions(
+                ListBlobVersionsRequest.builder().withKey(key).withIncludeDeleteMarkers(true)
+                    .build());
+        allEntries.forEachRemaining(
+            v -> toDelete.add(new BlobIdentifier(v.getKey(), v.getVersionId())));
+        if (!toDelete.isEmpty()) {
+          bucketClient.delete(toDelete);
+        }
+      } catch (Throwable t) {
+        // Best effort cleanup - ignore failures
+      }
+    }
+  }
+
+  private static Map<String, BlobMetadata> collectByVersionId(
+      BucketClient bucketClient, String key, boolean includeDeleteMarkers) {
+    Iterator<BlobMetadata> iterator =
+        bucketClient.listBlobVersions(
+            ListBlobVersionsRequest.builder()
+                .withKey(key)
+                .withIncludeDeleteMarkers(includeDeleteMarkers)
+                .build());
+    Map<String, BlobMetadata> byVersion = new HashMap<>();
+    iterator.forEachRemaining(v -> byVersion.put(v.getVersionId(), v));
+    return byVersion;
+  }
+
+  @Test
   public void testListBlobVersions_nullKey() {
     AbstractBlobStore blobStore = harness.createBlobStore(true, true, true);
     BucketClient bucketClient = new BucketClient(blobStore);

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -593,8 +593,8 @@ public class GcpBlobStore extends AbstractBlobStore {
    * <p>GCS represents a deletion of the live object by archiving the current generation and setting
    * its time-deleted; there is no separate delete-marker object. Each returned generation therefore
    * carries its creation time and, when it is no longer current, the time it stopped being current
-   * as {@code noncurrentAt}. The {@code includeDeleteMarkers} request flag has no extra entries to
-   * surface here because GCS does not produce standalone delete markers.
+   * as {@code archivedAt}. The {@code includeArchived} request flag has no extra entries to surface
+   * here because GCS does not produce standalone delete markers.
    */
   @Override
   protected Iterator<BlobMetadata> doListBlobVersions(ListBlobVersionsRequest request) {
@@ -618,13 +618,11 @@ public class GcpBlobStore extends AbstractBlobStore {
       @Override
       public BlobMetadata next() {
         Blob blob = blobIterator.next();
-        java.time.OffsetDateTime versionTimestamp = blob.getCreateTimeOffsetDateTime();
-        java.time.Instant createdTime =
-            versionTimestamp != null ? versionTimestamp.toInstant() : null;
+        OffsetDateTime versionTimestamp = blob.getCreateTimeOffsetDateTime();
+        Instant createdTime = versionTimestamp != null ? versionTimestamp.toInstant() : null;
         // A generation that is no longer current reports the instant it was superseded/deleted.
-        java.time.OffsetDateTime deletedTimestamp = blob.getDeleteTimeOffsetDateTime();
-        java.time.Instant noncurrentAt =
-            deletedTimestamp != null ? deletedTimestamp.toInstant() : null;
+        OffsetDateTime deletedTimestamp = blob.getDeleteTimeOffsetDateTime();
+        Instant archivedAt = deletedTimestamp != null ? deletedTimestamp.toInstant() : null;
         return BlobMetadata.builder()
             .key(blob.getName())
             .versionId(blob.getGeneration() != null ? blob.getGeneration().toString() : null)
@@ -632,7 +630,7 @@ public class GcpBlobStore extends AbstractBlobStore {
             .objectSize(blob.getSize() != null ? blob.getSize() : 0L)
             .lastModified(createdTime)
             .createdTime(createdTime)
-            .noncurrentAt(noncurrentAt)
+            .archivedAt(archivedAt)
             .build();
       }
     };

--- a/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
+++ b/blob/blob-gcp/src/main/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStore.java
@@ -589,6 +589,12 @@ public class GcpBlobStore extends AbstractBlobStore {
    * over-fetch sibling keys (for example, {@code key-1} when searching for {@code key}). To avoid
    * that, this uses {@code [key, key + '\0')} bounds and still applies an exact-name filter as a
    * defensive guard.
+   *
+   * <p>GCS represents a deletion of the live object by archiving the current generation and setting
+   * its time-deleted; there is no separate delete-marker object. Each returned generation therefore
+   * carries its creation time and, when it is no longer current, the time it stopped being current
+   * as {@code noncurrentAt}. The {@code includeDeleteMarkers} request flag has no extra entries to
+   * surface here because GCS does not produce standalone delete markers.
    */
   @Override
   protected Iterator<BlobMetadata> doListBlobVersions(ListBlobVersionsRequest request) {
@@ -613,12 +619,20 @@ public class GcpBlobStore extends AbstractBlobStore {
       public BlobMetadata next() {
         Blob blob = blobIterator.next();
         java.time.OffsetDateTime versionTimestamp = blob.getCreateTimeOffsetDateTime();
+        java.time.Instant createdTime =
+            versionTimestamp != null ? versionTimestamp.toInstant() : null;
+        // A generation that is no longer current reports the instant it was superseded/deleted.
+        java.time.OffsetDateTime deletedTimestamp = blob.getDeleteTimeOffsetDateTime();
+        java.time.Instant noncurrentAt =
+            deletedTimestamp != null ? deletedTimestamp.toInstant() : null;
         return BlobMetadata.builder()
             .key(blob.getName())
             .versionId(blob.getGeneration() != null ? blob.getGeneration().toString() : null)
             .eTag(blob.getEtag())
             .objectSize(blob.getSize() != null ? blob.getSize() : 0L)
-            .lastModified(versionTimestamp != null ? versionTimestamp.toInstant() : null)
+            .lastModified(createdTime)
+            .createdTime(createdTime)
+            .noncurrentAt(noncurrentAt)
             .build();
       }
     };

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -897,6 +897,87 @@ class GcpBlobStoreTest {
   }
 
   @Test
+  void testDoListBlobVersions_mapsCreatedAndNoncurrentAt() {
+    // Given: two generations of the same key. The newer one is still current (no delete time);
+    // the older one was superseded and carries a delete time that maps to noncurrentAt.
+    Instant currentCreated = Instant.parse("2024-01-03T00:00:00Z");
+    Instant olderCreated = Instant.parse("2024-01-01T00:00:00Z");
+    Instant olderDeleted = Instant.parse("2024-01-03T00:00:00Z");
+
+    Blob currentGen = mock(Blob.class);
+    when(currentGen.getName()).thenReturn(TEST_KEY);
+    when(currentGen.getGeneration()).thenReturn(2L);
+    when(currentGen.getEtag()).thenReturn("etag-2");
+    when(currentGen.getSize()).thenReturn(200L);
+    when(currentGen.getCreateTimeOffsetDateTime())
+        .thenReturn(currentCreated.atOffset(java.time.ZoneOffset.UTC));
+    when(currentGen.getDeleteTimeOffsetDateTime()).thenReturn(null);
+
+    Blob olderGen = mock(Blob.class);
+    when(olderGen.getName()).thenReturn(TEST_KEY);
+    when(olderGen.getGeneration()).thenReturn(1L);
+    when(olderGen.getEtag()).thenReturn("etag-1");
+    when(olderGen.getSize()).thenReturn(100L);
+    when(olderGen.getCreateTimeOffsetDateTime())
+        .thenReturn(olderCreated.atOffset(java.time.ZoneOffset.UTC));
+    when(olderGen.getDeleteTimeOffsetDateTime())
+        .thenReturn(olderDeleted.atOffset(java.time.ZoneOffset.UTC));
+
+    Page mockPage = mock(Page.class);
+    when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
+        .thenReturn(mockPage);
+    when(mockPage.iterateAll()).thenReturn(Arrays.asList(currentGen, olderGen));
+
+    // When
+    var iterator =
+        gcpBlobStore.doListBlobVersions(
+            ListBlobVersionsRequest.builder().withKey(TEST_KEY).build());
+
+    // Then
+    assertTrue(iterator.hasNext());
+    BlobMetadata current = iterator.next();
+    assertEquals("2", current.getVersionId());
+    assertEquals(currentCreated, current.getCreatedTime());
+    assertNull(current.getNoncurrentAt());
+    assertFalse(current.isDeleteMarker());
+
+    assertTrue(iterator.hasNext());
+    BlobMetadata older = iterator.next();
+    assertEquals("1", older.getVersionId());
+    assertEquals(olderCreated, older.getCreatedTime());
+    assertEquals(olderDeleted, older.getNoncurrentAt());
+    assertFalse(older.isDeleteMarker());
+
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void testDoListBlobVersions_filtersSiblingKeys() {
+    // GCS prefix listing can over-fetch; only the exact key must be returned.
+    Blob exact = mock(Blob.class);
+    when(exact.getName()).thenReturn(TEST_KEY);
+    when(exact.getGeneration()).thenReturn(1L);
+    when(exact.getCreateTimeOffsetDateTime())
+        .thenReturn(Instant.parse("2024-01-01T00:00:00Z").atOffset(java.time.ZoneOffset.UTC));
+
+    Blob sibling = mock(Blob.class);
+    lenient().when(sibling.getName()).thenReturn(TEST_KEY + "-extra");
+
+    Page mockPage = mock(Page.class);
+    when(mockStorage.list(eq(TEST_BUCKET), any(Storage.BlobListOption[].class)))
+        .thenReturn(mockPage);
+    when(mockPage.iterateAll()).thenReturn(Arrays.asList(exact, sibling));
+
+    var iterator =
+        gcpBlobStore.doListBlobVersions(
+            ListBlobVersionsRequest.builder().withKey(TEST_KEY).build());
+
+    assertTrue(iterator.hasNext());
+    assertEquals(TEST_KEY, iterator.next().getKey());
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
   void testDoList_WithPrefixAndDelimiter() {
     // Given
     ListBlobsRequest request =

--- a/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
+++ b/blob/blob-gcp/src/test/java/com/salesforce/multicloudj/blob/gcp/GcpBlobStoreTest.java
@@ -897,9 +897,9 @@ class GcpBlobStoreTest {
   }
 
   @Test
-  void testDoListBlobVersions_mapsCreatedAndNoncurrentAt() {
+  void testDoListBlobVersions_mapsCreatedAndArchivedAt() {
     // Given: two generations of the same key. The newer one is still current (no delete time);
-    // the older one was superseded and carries a delete time that maps to noncurrentAt.
+    // the older one was superseded and carries a delete time that maps to archivedAt.
     Instant currentCreated = Instant.parse("2024-01-03T00:00:00Z");
     Instant olderCreated = Instant.parse("2024-01-01T00:00:00Z");
     Instant olderDeleted = Instant.parse("2024-01-03T00:00:00Z");
@@ -938,15 +938,15 @@ class GcpBlobStoreTest {
     BlobMetadata current = iterator.next();
     assertEquals("2", current.getVersionId());
     assertEquals(currentCreated, current.getCreatedTime());
-    assertNull(current.getNoncurrentAt());
-    assertFalse(current.isDeleteMarker());
+    assertNull(current.getArchivedAt());
+    assertFalse(current.isArchived());
 
     assertTrue(iterator.hasNext());
     BlobMetadata older = iterator.next();
     assertEquals("1", older.getVersionId());
     assertEquals(olderCreated, older.getCreatedTime());
-    assertEquals(olderDeleted, older.getNoncurrentAt());
-    assertFalse(older.isDeleteMarker());
+    assertEquals(olderDeleted, older.getArchivedAt());
+    assertFalse(older.isArchived());
 
     assertFalse(iterator.hasNext());
   }

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-delete-11.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-delete-11.json
@@ -1,0 +1,25 @@
+{
+  "id" : "e9080230-c1ce-48a7-b963-24b357adea46",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-DELETE-11",
+  "request" : {
+    "url" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob",
+    "method" : "DELETE"
+  },
+  "response" : {
+    "status" : 204,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AJjja9ZffrdRZsuP2M3MvsDyEpeDnNLXxKKZVMa5clmtxQLtbuosx_TxCpF49nTwtUSJW6gNIBLOLbs",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 07 Sep 2026 06:53:57 GMT",
+      "Content-Type" : "application/json"
+    }
+  },
+  "uuid" : "e9080230-c1ce-48a7-b963-24b357adea46",
+  "persistent" : true,
+  "insertionIndex" : 1523
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-1.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-1.json
@@ -1,0 +1,42 @@
+{
+  "id" : "3ef71abb-476b-48ed-b296-12c350aee2ec",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-1",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"nextPageToken\": \"CjNjb25mb3JtYW5jZS10ZXN0cy9kaXJlY3Rvcnktb2JqZWN0bG9jay90ZXN0LXVwbG9hZC8=\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/directory-objectlock/test-upload//1777501182573890\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Fdirectory-objectlock%2Ftest-upload%2F?generation=1777501182573890&alt=media\",\n      \"name\": \"conformance-tests/directory-objectlock/test-upload/\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1777501182573890\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"0\",\n      \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg==\",\n      \"crc32c\": \"AAAAAA==\",\n      \"etag\": \"CML6zPSLlJQDEAE=\",\n      \"temporaryHold\": true,\n      \"retentionExpirationTime\": \"2027-04-30T00:00:00.000Z\",\n      \"retention\": {\n        \"retainUntilTime\": \"2027-04-30T00:00:00.000Z\",\n        \"mode\": \"Unlocked\"\n      },\n      \"timeCreated\": \"2026-04-29T22:19:42.620Z\",\n      \"updated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeStorageClassUpdated\": \"2026-04-29T22:19:42.620Z\",\n      \"timeFinalized\": \"2026-04-29T22:19:42.620Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AJjja9bUZIsbHarBuCqFMzJnmxJwP5EQbtfIOF-Ymn5fL00LhOyoVvtPmFR5PnMekDhdNBzO3LSzmbk",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 07 Sep 2026 06:54:00 GMT",
+      "Date" : "Mon, 07 Sep 2026 06:54:00 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "3ef71abb-476b-48ed-b296-12c350aee2ec",
+  "persistent" : true,
+  "insertionIndex" : 1513
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-12.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-12.json
@@ -1,0 +1,47 @@
+{
+  "id" : "8e58a814-b43a-4390-85a3-624e29826af3",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-12",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "maxResults" : {
+        "hasExactly" : [ {
+          "equalTo" : "1"
+        } ]
+      },
+      "prefix" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob/1788764036083713\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764036083713&alt=media\",\n      \"name\": \"conformance-tests/list-object-versions/delete-marker-timeline-blob\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1788764036083713\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"9\",\n      \"md5Hash\": \"+9F93vJ26hUlLkubkXWCZw==\",\n      \"crc32c\": \"zQar2A==\",\n      \"etag\": \"CIHg1Kfx25YDEAE=\",\n      \"timeCreated\": \"2026-09-07T06:53:56.158Z\",\n      \"updated\": \"2026-09-07T06:53:56.158Z\",\n      \"timeStorageClassUpdated\": \"2026-09-07T06:53:56.158Z\",\n      \"timeFinalized\": \"2026-09-07T06:53:56.158Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AJjja9ZOLGCFGiOYtGzHohdKc5VPeuF5QwvGAwOn9f1oiELOJIMngT5AZM3HffwXuPjVBvEpM495NC0",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 07 Sep 2026 06:53:56 GMT",
+      "Date" : "Mon, 07 Sep 2026 06:53:56 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "8e58a814-b43a-4390-85a3-624e29826af3",
+  "persistent" : true,
+  "insertionIndex" : 1524
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-2.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-2.json
@@ -1,0 +1,54 @@
+{
+  "id" : "48f89f32-c447-4864-9a0d-e03f3237d77a",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-2",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "4"
+      }
+    },
+    "queryParameters" : {
+      "endOffset" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob\u0000"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      },
+      "startOffset" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob"
+        } ]
+      },
+      "versions" : {
+        "hasExactly" : [ {
+          "equalTo" : "true"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob/1788764036083713\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764036083713&alt=media\",\n      \"name\": \"conformance-tests/list-object-versions/delete-marker-timeline-blob\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1788764036083713\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"9\",\n      \"md5Hash\": \"+9F93vJ26hUlLkubkXWCZw==\",\n      \"crc32c\": \"zQar2A==\",\n      \"etag\": \"CIHg1Kfx25YDEAE=\",\n      \"timeCreated\": \"2026-09-07T06:53:56.158Z\",\n      \"updated\": \"2026-09-07T06:53:56.158Z\",\n      \"timeDeleted\": \"2026-09-07T06:53:57.089Z\",\n      \"timeStorageClassUpdated\": \"2026-09-07T06:53:56.158Z\",\n      \"timeFinalized\": \"2026-09-07T06:53:56.158Z\"\n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob/1788764037934591\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764037934591&alt=media\",\n      \"name\": \"conformance-tests/list-object-versions/delete-marker-timeline-blob\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1788764037934591\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"9\",\n      \"md5Hash\": \"8SWyLPJXwux1DHpZfhHJJA==\",\n      \"crc32c\": \"3lZYLA==\",\n      \"etag\": \"CP/bxajx25YDEAE=\",\n      \"timeCreated\": \"2026-09-07T06:53:58.007Z\",\n      \"updated\": \"2026-09-07T06:53:58.007Z\",\n      \"timeStorageClassUpdated\": \"2026-09-07T06:53:58.007Z\",\n      \"timeFinalized\": \"2026-09-07T06:53:58.007Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AJjja9a5yU5neagDtlnsiNVkvPbxU2D7zUfqAQJH6Z2HMiXfW1WPTD7gfKgBQuwZXeYQWJbJk210Znw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 07 Sep 2026 06:54:00 GMT",
+      "Date" : "Mon, 07 Sep 2026 06:54:00 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "48f89f32-c447-4864-9a0d-e03f3237d77a",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-3",
+  "insertionIndex" : 1514
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-3.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-3.json
@@ -1,0 +1,55 @@
+{
+  "id" : "739da561-6af1-4823-ab0a-ddbb0a3c9630",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-3",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "4"
+      }
+    },
+    "queryParameters" : {
+      "endOffset" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob\u0000"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      },
+      "startOffset" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob"
+        } ]
+      },
+      "versions" : {
+        "hasExactly" : [ {
+          "equalTo" : "true"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob/1788764036083713\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764036083713&alt=media\",\n      \"name\": \"conformance-tests/list-object-versions/delete-marker-timeline-blob\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1788764036083713\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"9\",\n      \"md5Hash\": \"+9F93vJ26hUlLkubkXWCZw==\",\n      \"crc32c\": \"zQar2A==\",\n      \"etag\": \"CIHg1Kfx25YDEAE=\",\n      \"timeCreated\": \"2026-09-07T06:53:56.158Z\",\n      \"updated\": \"2026-09-07T06:53:56.158Z\",\n      \"timeDeleted\": \"2026-09-07T06:53:57.089Z\",\n      \"timeStorageClassUpdated\": \"2026-09-07T06:53:56.158Z\",\n      \"timeFinalized\": \"2026-09-07T06:53:56.158Z\"\n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob/1788764037934591\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764037934591&alt=media\",\n      \"name\": \"conformance-tests/list-object-versions/delete-marker-timeline-blob\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1788764037934591\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"9\",\n      \"md5Hash\": \"8SWyLPJXwux1DHpZfhHJJA==\",\n      \"crc32c\": \"3lZYLA==\",\n      \"etag\": \"CP/bxajx25YDEAE=\",\n      \"timeCreated\": \"2026-09-07T06:53:58.007Z\",\n      \"updated\": \"2026-09-07T06:53:58.007Z\",\n      \"timeStorageClassUpdated\": \"2026-09-07T06:53:58.007Z\",\n      \"timeFinalized\": \"2026-09-07T06:53:58.007Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AJjja9aBGQ1vyeDeQiJGs2YiMfw49aLwqKRsk_RUiFqbWIyTDUUYZpFXt5tz4Adz8iKjbANeRU7qoNI",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 07 Sep 2026 06:54:00 GMT",
+      "Date" : "Mon, 07 Sep 2026 06:54:00 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "739da561-6af1-4823-ab0a-ddbb0a3c9630",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
+  "requiredScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-2",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-3",
+  "insertionIndex" : 1515
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-4.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-4.json
@@ -1,0 +1,52 @@
+{
+  "id" : "20a8f6f7-c0cd-412f-a02d-a2864fb02d10",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-4",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      },
+      "generation" : {
+        "hasExactly" : [ {
+          "equalTo" : "1788764037934591"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "Y29udGVudC1C",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1788764037934591",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Mon, 07 Sep 2026 06:53:58 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Mon, 07 Sep 2026 06:53:59 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=3lZYLA==,md5=8SWyLPJXwux1DHpZfhHJJA==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CP/bxajx25YDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AJjja9Zpyg_Z1UVZLgKFckjZLn8Cej_YD8wktUw_MEal1g6HARGUcgjmt7kYvCJuw__wZNNvcCGbwKI",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "9",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "20a8f6f7-c0cd-412f-a02d-a2864fb02d10",
+  "persistent" : true,
+  "insertionIndex" : 1516
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-5.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-5.json
@@ -1,0 +1,43 @@
+{
+  "id" : "b12f4780-6085-4475-a312-bb2f1215f6cc",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-5",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "generation" : {
+        "hasExactly" : [ {
+          "equalTo" : "1788764037934591"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob/1788764037934591\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764037934591&alt=media\",\n  \"name\": \"conformance-tests/list-object-versions/delete-marker-timeline-blob\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1788764037934591\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"9\",\n  \"md5Hash\": \"8SWyLPJXwux1DHpZfhHJJA==\",\n  \"crc32c\": \"3lZYLA==\",\n  \"etag\": \"CP/bxajx25YDEAE=\",\n  \"timeCreated\": \"2026-09-07T06:53:58.007Z\",\n  \"updated\": \"2026-09-07T06:53:58.007Z\",\n  \"timeStorageClassUpdated\": \"2026-09-07T06:53:58.007Z\",\n  \"timeFinalized\": \"2026-09-07T06:53:58.007Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CP/bxajx25YDEAE=",
+      "X-GUploader-UploadID" : "AJjja9ZIFNILJ2NKMw7o0HZdNO_GRHeiFOMTPTyX3QtU_7UqZEaa4XRE6EGLNUZ12EfgCOuj",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 07 Sep 2026 06:53:59 GMT",
+      "Date" : "Mon, 07 Sep 2026 06:53:59 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "b12f4780-6085-4475-a312-bb2f1215f6cc",
+  "persistent" : true,
+  "insertionIndex" : 1517
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-6.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-6.json
@@ -1,0 +1,52 @@
+{
+  "id" : "8328bbb7-7549-45d2-b0c6-d0c40b1cc162",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-6",
+  "request" : {
+    "urlPath" : "/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "alt" : {
+        "hasExactly" : [ {
+          "equalTo" : "media"
+        } ]
+      },
+      "generation" : {
+        "hasExactly" : [ {
+          "equalTo" : "1788764036083713"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "Y29udGVudC1B",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "X-Goog-Generation" : "1788764036083713",
+      "Pragma" : "no-cache",
+      "Last-Modified" : "Mon, 07 Sep 2026 06:53:56 GMT",
+      "X-Goog-Metageneration" : "1",
+      "Date" : "Mon, 07 Sep 2026 06:53:59 GMT",
+      "X-Goog-Stored-Content-Encoding" : "identity",
+      "X-Goog-Hash" : "crc32c=zQar2A==,md5=+9F93vJ26hUlLkubkXWCZw==",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CIHg1Kfx25YDEAE=",
+      "Content-Disposition" : "attachment",
+      "X-Goog-Storage-Class" : "STANDARD",
+      "X-GUploader-UploadID" : "AJjja9aG2hoGwDXVP_qDMfIEVMengkvOfDQtOx_1QxnZxQykqKgTGFdcccmYA1ivevuuNS0l4UWfdRw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Stored-Content-Length" : "9",
+      "Content-Type" : "application/octet-stream"
+    }
+  },
+  "uuid" : "8328bbb7-7549-45d2-b0c6-d0c40b1cc162",
+  "persistent" : true,
+  "insertionIndex" : 1518
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-7.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-7.json
@@ -1,0 +1,43 @@
+{
+  "id" : "067e2345-b5b3-4c84-87a3-fdc81be826f8",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-7",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "generation" : {
+        "hasExactly" : [ {
+          "equalTo" : "1788764036083713"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob/1788764036083713\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764036083713&alt=media\",\n  \"name\": \"conformance-tests/list-object-versions/delete-marker-timeline-blob\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1788764036083713\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"9\",\n  \"md5Hash\": \"+9F93vJ26hUlLkubkXWCZw==\",\n  \"crc32c\": \"zQar2A==\",\n  \"etag\": \"CIHg1Kfx25YDEAE=\",\n  \"timeCreated\": \"2026-09-07T06:53:56.158Z\",\n  \"updated\": \"2026-09-07T06:53:56.158Z\",\n  \"timeDeleted\": \"2026-09-07T06:53:57.089Z\",\n  \"timeStorageClassUpdated\": \"2026-09-07T06:53:56.158Z\",\n  \"timeFinalized\": \"2026-09-07T06:53:56.158Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "ETag" : "CIHg1Kfx25YDEAE=",
+      "X-GUploader-UploadID" : "AJjja9a6a6lSeK2on0u_yVcGuzcP_j3uf-7C4Byzp4jJ4tU7232x2CwozG-Lp0AtngZtVYWIzOjBnSM",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 07 Sep 2026 06:53:58 GMT",
+      "Date" : "Mon, 07 Sep 2026 06:53:58 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "067e2345-b5b3-4c84-87a3-fdc81be826f8",
+  "persistent" : true,
+  "insertionIndex" : 1519
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-8.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-get-8.json
@@ -1,0 +1,55 @@
+{
+  "id" : "0c8b50a0-db6f-46f3-8d18-20861be2e16b",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-GET-8",
+  "request" : {
+    "urlPath" : "/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "GET",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "4"
+      }
+    },
+    "queryParameters" : {
+      "endOffset" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob\u0000"
+        } ]
+      },
+      "projection" : {
+        "hasExactly" : [ {
+          "equalTo" : "full"
+        } ]
+      },
+      "startOffset" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob"
+        } ]
+      },
+      "versions" : {
+        "hasExactly" : [ {
+          "equalTo" : "true"
+        } ]
+      }
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob/1788764036083713\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764036083713&alt=media\",\n      \"name\": \"conformance-tests/list-object-versions/delete-marker-timeline-blob\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1788764036083713\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"9\",\n      \"md5Hash\": \"+9F93vJ26hUlLkubkXWCZw==\",\n      \"crc32c\": \"zQar2A==\",\n      \"etag\": \"CIHg1Kfx25YDEAE=\",\n      \"timeCreated\": \"2026-09-07T06:53:56.158Z\",\n      \"updated\": \"2026-09-07T06:53:56.158Z\",\n      \"timeDeleted\": \"2026-09-07T06:53:57.089Z\",\n      \"timeStorageClassUpdated\": \"2026-09-07T06:53:56.158Z\",\n      \"timeFinalized\": \"2026-09-07T06:53:56.158Z\"\n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob/1788764037934591\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob\",\n      \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764037934591&alt=media\",\n      \"name\": \"conformance-tests/list-object-versions/delete-marker-timeline-blob\",\n      \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n      \"generation\": \"1788764037934591\",\n      \"metageneration\": \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\": \"STANDARD\",\n      \"size\": \"9\",\n      \"md5Hash\": \"8SWyLPJXwux1DHpZfhHJJA==\",\n      \"crc32c\": \"3lZYLA==\",\n      \"etag\": \"CP/bxajx25YDEAE=\",\n      \"timeCreated\": \"2026-09-07T06:53:58.007Z\",\n      \"updated\": \"2026-09-07T06:53:58.007Z\",\n      \"timeStorageClassUpdated\": \"2026-09-07T06:53:58.007Z\",\n      \"timeFinalized\": \"2026-09-07T06:53:58.007Z\"\n    }\n  ]\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "private, max-age=0, must-revalidate, no-transform",
+      "X-GUploader-UploadID" : "AJjja9Yki7bMa5HjdCReOt1KjEm8yvBj5u8GPoFT4IV7n_P4s21galq8WZjoB9z_xN7nKIvROSTvaH8",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 07 Sep 2026 06:53:58 GMT",
+      "Date" : "Mon, 07 Sep 2026 06:53:58 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "0c8b50a0-db6f-46f3-8d18-20861be2e16b",
+  "persistent" : true,
+  "scenarioName" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-1-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-2",
+  "insertionIndex" : 1520
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-post-0.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-post-0.json
@@ -1,0 +1,31 @@
+{
+  "id" : "b94793b1-213e-4026-8f65-692187f9622e",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-POST-0",
+  "request" : {
+    "url" : "/batch/storage/v1",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "matches" : "(?s)\\Q\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Length: 662\r\nContent-Type: application/http\r\ncontent-id: 1\r\ncontent-transfer-encoding: binary\r\n\r\nDELETE https://storage.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764036083713 HTTP/1.1\r\nAuthorization: Bearer REDACTED_OAUTH_TOKEN\r\nx-goog-api-client: gl-java/21.0.8 gdcl/2.7.2 mac-os-x/26.6.2\r\nx-goog-user-project: substrate-sdk-gcp-poc1\r\nx-goog-gcs-idempotency-token: d34f0e54-e457-4587-b7f7-05e4ae4d300d\r\n\r\n\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q\r\nContent-Length: 662\r\nContent-Type: application/http\r\ncontent-id: 2\r\ncontent-transfer-encoding: binary\r\n\r\nDELETE https://storage.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764037934591 HTTP/1.1\r\nAuthorization: Bearer REDACTED_OAUTH_TOKEN\r\nx-goog-api-client: gl-java/21.0.8 gdcl/2.7.2 mac-os-x/26.6.2\r\nx-goog-user-project: substrate-sdk-gcp-poc1\r\nx-goog-gcs-idempotency-token: 06bd95ca-1832-4bf1-b4df-d2db035f0ff7\r\n\r\n\r\n\\E--__END_OF_PART__[a-f0-9-]+__\\Q--\r\n\\E"
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "base64Body" : "LS1iYXRjaF9DZS1fUkxlWU9NUnhYVnJqWVVqdWxQbzR3V05rMjBSQg0KQ29udGVudC1UeXBlOiBhcHBsaWNhdGlvbi9odHRwDQpDb250ZW50LUlEOiByZXNwb25zZS0xDQoNCkhUVFAvMS4xIDIwNCBObyBDb250ZW50DQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2pzb24NCkRhdGU6IE1vbiwgMDcgU2VwIDIwMjYgMDY6NTQ6MDEgR01UDQpDYWNoZS1Db250cm9sOiBuby1jYWNoZSwgbm8tc3RvcmUsIG1heC1hZ2U9MCwgbXVzdC1yZXZhbGlkYXRlDQpFeHBpcmVzOiBNb24sIDAxIEphbiAxOTkwIDAwOjAwOjAwIEdNVA0KQ29udGVudC1MZW5ndGg6IDANCg0KDQotLWJhdGNoX0NlLV9STGVZT01SeFhWcmpZVWp1bFBvNHdXTmsyMFJCDQpDb250ZW50LVR5cGU6IGFwcGxpY2F0aW9uL2h0dHANCkNvbnRlbnQtSUQ6IHJlc3BvbnNlLTINCg0KSFRUUC8xLjEgMjA0IE5vIENvbnRlbnQNCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbg0KRGF0ZTogTW9uLCAwNyBTZXAgMjAyNiAwNjo1NDowMSBHTVQNCkNhY2hlLUNvbnRyb2w6IG5vLWNhY2hlLCBuby1zdG9yZSwgbWF4LWFnZT0wLCBtdXN0LXJldmFsaWRhdGUNCkV4cGlyZXM6IE1vbiwgMDEgSmFuIDE5OTAgMDA6MDA6MDAgR01UDQpDb250ZW50LUxlbmd0aDogMA0KDQoNCi0tYmF0Y2hfQ2UtX1JMZVlPTVJ4WFZyallVanVsUG80d1dOazIwUkItLQ0K",
+    "headers" : {
+      "X-Frame-Options" : "SAMEORIGIN",
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Cache-Control" : "private, max-age=0",
+      "Server" : "Upload Server",
+      "X-Content-Type-Options" : "nosniff",
+      "X-GUploader-UploadID" : "AJjja9ba6sqM-T1zdbyBFoC0M3V9VM3dDO2OQwIib39GJVVFonXic-rChGk4bA6JJuIuFKlolrFHLg",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Expires" : "Mon, 07 Sep 2026 06:54:01 GMT",
+      "X-XSS-Protection" : "1; mode=block",
+      "Date" : "Mon, 07 Sep 2026 06:54:01 GMT",
+      "Content-Type" : "multipart/mixed; boundary=batch_Ce-_RLeYOMRxXVrjYUjulPo4wWNk20RB"
+    }
+  },
+  "uuid" : "b94793b1-213e-4026-8f65-692187f9622e",
+  "persistent" : true,
+  "insertionIndex" : 1512
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-post-10.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-post-10.json
@@ -1,0 +1,50 @@
+{
+  "id" : "efbf630e-4eec-41b2-89b4-608b4cdd9c7f",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-POST-10",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/list-object-versions/delete-marker-timeline-blob\"}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AJjja9Y7q8hw9hSSJqIY-7MPdCbShvUtepdHme9NfzqERmW_EqvqDqZQ6qYHpxGhCrpSpbDLeb_PO2xBauES9QxrPooGyJS6SdQMPmzcbqEceiY",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 07 Sep 2026 06:53:57 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/list-object-versions/delete-marker-timeline-blob&uploadType=resumable&upload_id=AJjja9Y7q8hw9hSSJqIY-7MPdCbShvUtepdHme9NfzqERmW_EqvqDqZQ6qYHpxGhCrpSpbDLeb_PO2xBauES9QxrPooGyJS6SdQMPmzcbqEceiY",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "efbf630e-4eec-41b2-89b4-608b4cdd9c7f",
+  "persistent" : true,
+  "scenarioName" : "scenario-2-upload-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
+  "requiredScenarioState" : "scenario-2-upload-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-2",
+  "insertionIndex" : 1522
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-post-14.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-post-14.json
@@ -1,0 +1,51 @@
+{
+  "id" : "ca242c21-18e4-401f-a187-2e8f434ecc69",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-POST-14",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "POST",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "2"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalToJson" : "{\"bucket\":\"substrate-sdk-gcp-poc1-test-bucket-versioned\",\"metadata\":{},\"name\":\"conformance-tests/list-object-versions/delete-marker-timeline-blob\"}",
+      "ignoreArrayOrder" : true,
+      "ignoreExtraElements" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "X-GUploader-UploadID" : "AJjja9bWGGoJG7k7-7u4f26alodpABvt0AKcUt_-qT_PSog5PoNp3A1re30yAbFKwCh-MML_IuO9O19V7_nWbYtp2OTxm5EUzJL_SrCHjcWWkFw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 07 Sep 2026 06:53:55 GMT",
+      "Location" : "https://storage.googleapis.com/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o?name=conformance-tests/list-object-versions/delete-marker-timeline-blob&uploadType=resumable&upload_id=AJjja9bWGGoJG7k7-7u4f26alodpABvt0AKcUt_-qT_PSog5PoNp3A1re30yAbFKwCh-MML_IuO9O19V7_nWbYtp2OTxm5EUzJL_SrCHjcWWkFw",
+      "Content-Type" : "text/plain; charset=utf-8"
+    }
+  },
+  "uuid" : "ca242c21-18e4-401f-a187-2e8f434ecc69",
+  "persistent" : true,
+  "scenarioName" : "scenario-2-upload-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o",
+  "requiredScenarioState" : "Started",
+  "newScenarioState" : "scenario-2-upload-storage-v1-b-substrate-sdk-gcp-poc1-test-bucket-versioned-o-2",
+  "insertionIndex" : 1526
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-put-13.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-put-13.json
@@ -1,0 +1,54 @@
+{
+  "id" : "80b392d8-5290-4349-8298-fa922a6e6705",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-PUT-13",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AJjja9bWGGoJG7k7-7u4f26alodpABvt0AKcUt_-qT_PSog5PoNp3A1re30yAbFKwCh-MML_IuO9O19V7_nWbYtp2OTxm5EUzJL_SrCHjcWWkFw"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "content-A",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob/1788764036083713\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764036083713&alt=media\",\n  \"name\": \"conformance-tests/list-object-versions/delete-marker-timeline-blob\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1788764036083713\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"9\",\n  \"md5Hash\": \"+9F93vJ26hUlLkubkXWCZw==\",\n  \"crc32c\": \"zQar2A==\",\n  \"etag\": \"CIHg1Kfx25YDEAE=\",\n  \"timeCreated\": \"2026-09-07T06:53:56.158Z\",\n  \"updated\": \"2026-09-07T06:53:56.158Z\",\n  \"timeStorageClassUpdated\": \"2026-09-07T06:53:56.158Z\",\n  \"timeFinalized\": \"2026-09-07T06:53:56.158Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CIHg1Kfx25YDEAE=",
+      "X-GUploader-UploadID" : "AJjja9bWGGoJG7k7-7u4f26alodpABvt0AKcUt_-qT_PSog5PoNp3A1re30yAbFKwCh-MML_IuO9O19V7_nWbYtp2OTxm5EUzJL_SrCHjcWWkFw",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "X-Goog-Gcs-Base-Ts" : "1a07aa51c7e",
+      "Date" : "Mon, 07 Sep 2026 06:53:56 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "80b392d8-5290-4349-8298-fa922a6e6705",
+  "persistent" : true,
+  "insertionIndex" : 1525
+}

--- a/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-put-9.json
+++ b/blob/blob-gcp/src/test/resources/mappings/gcpblobstoreit_testlistblobversions_deletemarkertimeline-put-9.json
@@ -1,0 +1,53 @@
+{
+  "id" : "ce4eb63e-dac3-492a-969b-92b10c530804",
+  "name" : "GcpBlobStoreIT_testListBlobVersions_deleteMarkerTimeline-PUT-9",
+  "request" : {
+    "urlPath" : "/upload/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o",
+    "method" : "PUT",
+    "headers" : {
+      "X-Query-Param-Count" : {
+        "equalTo" : "3"
+      }
+    },
+    "queryParameters" : {
+      "name" : {
+        "hasExactly" : [ {
+          "equalTo" : "conformance-tests/list-object-versions/delete-marker-timeline-blob"
+        } ]
+      },
+      "uploadType" : {
+        "hasExactly" : [ {
+          "equalTo" : "resumable"
+        } ]
+      },
+      "upload_id" : {
+        "hasExactly" : [ {
+          "equalTo" : "AJjja9Y7q8hw9hSSJqIY-7MPdCbShvUtepdHme9NfzqERmW_EqvqDqZQ6qYHpxGhCrpSpbDLeb_PO2xBauES9QxrPooGyJS6SdQMPmzcbqEceiY"
+        } ]
+      }
+    },
+    "bodyPatterns" : [ {
+      "equalTo" : "content-B",
+      "caseInsensitive" : false
+    } ]
+  },
+  "response" : {
+    "status" : 200,
+    "body" : "{\n  \"kind\": \"storage#object\",\n  \"id\": \"substrate-sdk-gcp-poc1-test-bucket-versioned/conformance-tests/list-object-versions/delete-marker-timeline-blob/1788764037934591\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob\",\n  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/substrate-sdk-gcp-poc1-test-bucket-versioned/o/conformance-tests%2Flist-object-versions%2Fdelete-marker-timeline-blob?generation=1788764037934591&alt=media\",\n  \"name\": \"conformance-tests/list-object-versions/delete-marker-timeline-blob\",\n  \"bucket\": \"substrate-sdk-gcp-poc1-test-bucket-versioned\",\n  \"generation\": \"1788764037934591\",\n  \"metageneration\": \"1\",\n  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\": \"9\",\n  \"md5Hash\": \"8SWyLPJXwux1DHpZfhHJJA==\",\n  \"crc32c\": \"3lZYLA==\",\n  \"etag\": \"CP/bxajx25YDEAE=\",\n  \"timeCreated\": \"2026-09-07T06:53:58.007Z\",\n  \"updated\": \"2026-09-07T06:53:58.007Z\",\n  \"timeStorageClassUpdated\": \"2026-09-07T06:53:58.007Z\",\n  \"timeFinalized\": \"2026-09-07T06:53:58.007Z\"\n}\n",
+    "headers" : {
+      "Alt-Svc" : "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Server" : "UploadServer",
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "ETag" : "CP/bxajx25YDEAE=",
+      "X-GUploader-UploadID" : "AJjja9Y7q8hw9hSSJqIY-7MPdCbShvUtepdHme9NfzqERmW_EqvqDqZQ6qYHpxGhCrpSpbDLeb_PO2xBauES9QxrPooGyJS6SdQMPmzcbqEceiY",
+      "Vary" : [ "Origin", "X-Origin" ],
+      "Pragma" : "no-cache",
+      "Expires" : "Mon, 01 Jan 1990 00:00:00 GMT",
+      "Date" : "Mon, 07 Sep 2026 06:53:58 GMT",
+      "Content-Type" : "application/json; charset=UTF-8"
+    }
+  },
+  "uuid" : "ce4eb63e-dac3-492a-969b-92b10c530804",
+  "persistent" : true,
+  "insertionIndex" : 1521
+}

--- a/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
+++ b/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
@@ -16,6 +16,7 @@ import com.salesforce.multicloudj.blob.driver.CopyRequest;
 import com.salesforce.multicloudj.blob.driver.CopyResponse;
 import com.salesforce.multicloudj.blob.driver.DownloadRequest;
 import com.salesforce.multicloudj.blob.driver.DownloadResponse;
+import com.salesforce.multicloudj.blob.driver.ListBlobVersionsRequest;
 import com.salesforce.multicloudj.blob.driver.ListBlobsPageRequest;
 import com.salesforce.multicloudj.blob.driver.ListBlobsPageResponse;
 import com.salesforce.multicloudj.blob.driver.ListBlobsRequest;
@@ -108,6 +109,25 @@ public class InMemoryBlobStore extends AbstractBlobStore {
       new ConcurrentHashMap<>();
   // Track bucket metadata - key is bucket name
   static final Map<String, BucketMetadata> BUCKETS = new ConcurrentHashMap<>();
+  // Persisted delete markers per key - key is "bucket:key", value is the ordered history of markers
+  private static final Map<String, List<DeleteMarker>> DELETE_MARKERS = new ConcurrentHashMap<>();
+
+  /**
+   * Monotonic clock source shared across all instances. Version and delete-marker creation times
+   * must be strictly increasing so a version listing has a total, deterministic order even when
+   * operations happen within the same wall-clock millisecond. Each call returns an instant strictly
+   * greater than the previous one while still tracking real time when it advances.
+   */
+  private static final java.util.concurrent.atomic.AtomicReference<Instant> CLOCK =
+      new java.util.concurrent.atomic.AtomicReference<>(Instant.EPOCH);
+
+  private static Instant nextInstant() {
+    return CLOCK.updateAndGet(
+        previous -> {
+          Instant now = Instant.now();
+          return now.isAfter(previous) ? now : previous.plusNanos(1);
+        });
+  }
 
   public InMemoryBlobStore() {
     this(new Builder());
@@ -194,7 +214,7 @@ public class InMemoryBlobStore extends AbstractBlobStore {
 
     StoredBlob blob =
         new StoredBlob(
-            content, etag, versionId, Instant.now(), metadata, uploadRequest.getContentType());
+            content, etag, versionId, nextInstant(), metadata, uploadRequest.getContentType());
 
     STORAGE.put(versionedKey, blob);
     LATEST_VERSIONS.put(baseKey, versionId);
@@ -422,13 +442,29 @@ public class InMemoryBlobStore extends AbstractBlobStore {
       TAGS.remove(versionedKey);
       OBJECT_LOCKS.remove(versionedKey);
 
+      // A version-specific delete can also target a delete marker; remove it from the history so
+      // callers can clean up markers surfaced by listBlobVersions.
+      List<DeleteMarker> markers = DELETE_MARKERS.get(baseKey);
+      if (markers != null) {
+        markers.removeIf(marker -> versionId.equals(marker.getVersionId()));
+        if (markers.isEmpty()) {
+          DELETE_MARKERS.remove(baseKey);
+        }
+      }
+
       // If deleting the latest version, clear the latest version tracker
       String latestVersion = LATEST_VERSIONS.get(baseKey);
       if (versionId.equals(latestVersion)) {
         LATEST_VERSIONS.remove(baseKey);
       }
     } else {
-      // Simulate a delete marker: remove from LATEST_VERSIONS but keep data in STORAGE
+      // Unqualified delete: record a delete marker that becomes the newest entry for this key and
+      // clear the current-version tracker so the object reads as absent. Prior content versions are
+      // retained in STORAGE and remain listable.
+      String markerVersionId = UUID.randomUUID().toString();
+      DELETE_MARKERS
+          .computeIfAbsent(baseKey, ignored -> new java.util.concurrent.CopyOnWriteArrayList<>())
+          .add(new DeleteMarker(markerVersionId, nextInstant()));
       LATEST_VERSIONS.remove(baseKey);
     }
   }
@@ -477,7 +513,7 @@ public class InMemoryBlobStore extends AbstractBlobStore {
             sourceBlob.getData().clone(),
             sourceBlob.getEtag(),
             newVersionId,
-            Instant.now(),
+            nextInstant(),
             sourceBlob.getMetadata(),
             sourceBlob.getContentType());
 
@@ -525,7 +561,7 @@ public class InMemoryBlobStore extends AbstractBlobStore {
             sourceBlob.getData().clone(),
             sourceBlob.getEtag(),
             newVersionId,
-            Instant.now(),
+            nextInstant(),
             sourceBlob.getMetadata(),
             sourceBlob.getContentType());
 
@@ -574,6 +610,85 @@ public class InMemoryBlobStore extends AbstractBlobStore {
         .objectLockInfo(OBJECT_LOCKS.get(versionedKey))
         .checksum(toDriverChecksum(blob.getData()))
         .build();
+  }
+
+  /**
+   * Lists every version of an exact key on a single timeline. Content versions and, when requested,
+   * delete markers are ordered newest-first. Delete markers are always considered when computing
+   * each entry's supersession time so that a content version's {@code noncurrentAt} reflects the
+   * moment it stopped being current even when the superseding entry is a delete marker; markers are
+   * emitted only when {@code includeDeleteMarkers} is set.
+   */
+  @Override
+  protected Iterator<BlobMetadata> doListBlobVersions(ListBlobVersionsRequest request) {
+    validateBucketExists();
+    String key = request.getKey();
+    String baseKey = getStorageKey(key);
+    String versionPrefix = baseKey + ":";
+
+    List<TimelineEntry> entries = new ArrayList<>();
+    for (Map.Entry<String, StoredBlob> stored : STORAGE.entrySet()) {
+      String storageKey = stored.getKey();
+      if (!storageKey.startsWith(versionPrefix)) {
+        continue;
+      }
+      // Exact-key guard: keys may contain ':', so require the remainder to be a bare versionId
+      // (UUIDs contain no ':'). This excludes sibling keys such as "key:child".
+      String remainder = storageKey.substring(versionPrefix.length());
+      if (remainder.indexOf(':') >= 0) {
+        continue;
+      }
+      StoredBlob blob = stored.getValue();
+      entries.add(new TimelineEntry(blob.getLastModified(), false, blob.getVersionId(), blob));
+    }
+
+    List<DeleteMarker> markers = DELETE_MARKERS.get(baseKey);
+    if (markers != null) {
+      for (DeleteMarker marker : markers) {
+        entries.add(new TimelineEntry(marker.getCreatedTime(), true, marker.getVersionId(), null));
+      }
+    }
+
+    // Newest-first so each entry's supersession time is its immediate predecessor's creation time.
+    entries.sort(Comparator.comparing((TimelineEntry entry) -> entry.createdTime).reversed());
+
+    List<BlobMetadata> result = new ArrayList<>(entries.size());
+    for (int i = 0; i < entries.size(); i++) {
+      TimelineEntry entry = entries.get(i);
+      Instant noncurrentAt = (i == 0) ? null : entries.get(i - 1).createdTime;
+      if (entry.deleteMarker) {
+        if (!request.isIncludeDeleteMarkers()) {
+          continue;
+        }
+        result.add(
+            BlobMetadata.builder()
+                .key(key)
+                .versionId(entry.versionId)
+                .deleteMarker(true)
+                .lastModified(entry.createdTime)
+                .createdTime(entry.createdTime)
+                .noncurrentAt(noncurrentAt)
+                .build());
+      } else {
+        StoredBlob blob = entry.blob;
+        String versionedKey = versionPrefix + blob.getVersionId();
+        result.add(
+            BlobMetadata.builder()
+                .key(key)
+                .versionId(blob.getVersionId())
+                .eTag(blob.getEtag())
+                .objectSize((long) blob.getData().length)
+                .metadata(blob.getMetadata())
+                .lastModified(blob.getLastModified())
+                .createdTime(blob.getLastModified())
+                .contentType(blob.getContentType())
+                .objectLockInfo(OBJECT_LOCKS.get(versionedKey))
+                .checksum(toDriverChecksum(blob.getData()))
+                .noncurrentAt(noncurrentAt)
+                .build());
+      }
+    }
+    return result.iterator();
   }
 
   private Checksum toDriverChecksum(byte[] data) {
@@ -827,7 +942,7 @@ public class InMemoryBlobStore extends AbstractBlobStore {
       String versionedKey = baseKey + ":" + versionId;
       StoredBlob blob =
           new StoredBlob(
-              finalData, etag, versionId, Instant.now(), state.getMetadata(),
+              finalData, etag, versionId, nextInstant(), state.getMetadata(),
               state.getContentType());
 
       STORAGE.put(versionedKey, blob);
@@ -1268,6 +1383,37 @@ public class InMemoryBlobStore extends AbstractBlobStore {
     }
   }
 
+  /** A persisted delete marker: its own version id and the instant it was created. */
+  @Getter
+  private static class DeleteMarker {
+    private final String versionId;
+    private final Instant createdTime;
+
+    DeleteMarker(String versionId, Instant createdTime) {
+      this.versionId = versionId;
+      this.createdTime = createdTime;
+    }
+  }
+
+  /**
+   * A single point on a key's version timeline used only while resolving {@code
+   * doListBlobVersions}. Holds a content version's stored blob, or a delete marker when {@code
+   * deleteMarker} is set (in which case {@code blob} is {@code null}).
+   */
+  private static final class TimelineEntry {
+    private final Instant createdTime;
+    private final boolean deleteMarker;
+    private final String versionId;
+    private final StoredBlob blob;
+
+    TimelineEntry(Instant createdTime, boolean deleteMarker, String versionId, StoredBlob blob) {
+      this.createdTime = createdTime;
+      this.deleteMarker = deleteMarker;
+      this.versionId = versionId;
+      this.blob = blob;
+    }
+  }
+
   @Getter
   private static class StoredBlob {
     private final byte[] data;
@@ -1376,5 +1522,6 @@ public class InMemoryBlobStore extends AbstractBlobStore {
     OBJECT_LOCKS.clear();
     MULTIPART_UPLOADS.clear();
     BUCKETS.clear();
+    DELETE_MARKERS.clear();
   }
 }

--- a/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
+++ b/blob/blob-inmemory/src/main/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStore.java
@@ -615,9 +615,9 @@ public class InMemoryBlobStore extends AbstractBlobStore {
   /**
    * Lists every version of an exact key on a single timeline. Content versions and, when requested,
    * delete markers are ordered newest-first. Delete markers are always considered when computing
-   * each entry's supersession time so that a content version's {@code noncurrentAt} reflects the
+   * each entry's supersession time so that a content version's {@code archivedAt} reflects the
    * moment it stopped being current even when the superseding entry is a delete marker; markers are
-   * emitted only when {@code includeDeleteMarkers} is set.
+   * emitted only when {@code includeArchived} is set.
    */
   @Override
   protected Iterator<BlobMetadata> doListBlobVersions(ListBlobVersionsRequest request) {
@@ -655,19 +655,19 @@ public class InMemoryBlobStore extends AbstractBlobStore {
     List<BlobMetadata> result = new ArrayList<>(entries.size());
     for (int i = 0; i < entries.size(); i++) {
       TimelineEntry entry = entries.get(i);
-      Instant noncurrentAt = (i == 0) ? null : entries.get(i - 1).createdTime;
+      Instant archivedAt = (i == 0) ? null : entries.get(i - 1).createdTime;
       if (entry.deleteMarker) {
-        if (!request.isIncludeDeleteMarkers()) {
+        if (!request.isIncludeArchived()) {
           continue;
         }
         result.add(
             BlobMetadata.builder()
                 .key(key)
                 .versionId(entry.versionId)
-                .deleteMarker(true)
+                .archived(true)
                 .lastModified(entry.createdTime)
                 .createdTime(entry.createdTime)
-                .noncurrentAt(noncurrentAt)
+                .archivedAt(archivedAt)
                 .build());
       } else {
         StoredBlob blob = entry.blob;
@@ -684,7 +684,7 @@ public class InMemoryBlobStore extends AbstractBlobStore {
                 .contentType(blob.getContentType())
                 .objectLockInfo(OBJECT_LOCKS.get(versionedKey))
                 .checksum(toDriverChecksum(blob.getData()))
-                .noncurrentAt(noncurrentAt)
+                .archivedAt(archivedAt)
                 .build());
       }
     }

--- a/blob/blob-inmemory/src/test/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStoreIT.java
+++ b/blob/blob-inmemory/src/test/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStoreIT.java
@@ -29,13 +29,6 @@ public class InMemoryBlobStoreIT extends AbstractBlobStoreIT {
     Assumptions.assumeTrue(true, "testInvalidCredentials");
   }
 
-  @Test
-  @Override
-  public void testListBlobVersions_happy() {
-    // In-memory blob store does not implement listBlobVersions.
-    Assumptions.assumeTrue(false, "List object versions not supported by in-memory provider");
-  }
-
   @Override
   protected Harness createHarness() {
     return new HarnessImpl();

--- a/blob/blob-inmemory/src/test/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStoreListVersionsTest.java
+++ b/blob/blob-inmemory/src/test/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStoreListVersionsTest.java
@@ -1,0 +1,157 @@
+package com.salesforce.multicloudj.blob.inmemory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.salesforce.multicloudj.blob.driver.BlobMetadata;
+import com.salesforce.multicloudj.blob.driver.ListBlobVersionsRequest;
+import com.salesforce.multicloudj.blob.driver.UploadRequest;
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link InMemoryBlobStore#doListBlobVersions} covering the delete-marker timeline, the
+ * {@code includeDeleteMarkers} flag, and cloud-neutral {@code noncurrentAt} computation.
+ */
+class InMemoryBlobStoreListVersionsTest {
+
+  private static final String BUCKET = "bucket-versions";
+
+  private InMemoryBlobStore store;
+
+  @BeforeEach
+  void setUp() {
+    InMemoryBlobStore.clearStorage();
+    store = new InMemoryBlobStore.Builder().withBucket(BUCKET).withRegion("local").build();
+    InMemoryBlobStore.createBucket(BUCKET);
+  }
+
+  @AfterEach
+  void tearDown() {
+    InMemoryBlobStore.clearStorage();
+  }
+
+  private String upload(String key, String content) {
+    byte[] bytes = content.getBytes();
+    return store
+        .upload(
+            new UploadRequest.Builder().withKey(key).withContentLength(bytes.length).build(),
+            new ByteArrayInputStream(bytes))
+        .getVersionId();
+  }
+
+  private List<BlobMetadata> list(String key, boolean includeDeleteMarkers) {
+    Iterator<BlobMetadata> it =
+        store.listBlobVersions(
+            ListBlobVersionsRequest.builder()
+                .withKey(key)
+                .withIncludeDeleteMarkers(includeDeleteMarkers)
+                .build());
+    List<BlobMetadata> out = new ArrayList<>();
+    it.forEachRemaining(out::add);
+    return out;
+  }
+
+  @Test
+  void putDeletePut_flagOff_returnsOnlyContentVersionsNewestFirst() {
+    String key = "obj";
+    String vA = upload(key, "A");
+    store.delete(key, null); // unqualified delete creates a delete marker
+    String vB = upload(key, "B");
+
+    List<BlobMetadata> versions = list(key, false);
+
+    assertEquals(2, versions.size());
+    assertEquals(vB, versions.get(0).getVersionId());
+    assertEquals(vA, versions.get(1).getVersionId());
+    versions.forEach(v -> assertFalse(v.isDeleteMarker()));
+  }
+
+  @Test
+  void putDeletePut_flagOn_surfacesDeleteMarkerInTimeline() {
+    String key = "obj";
+    String vA = upload(key, "A");
+    store.delete(key, null);
+    String vB = upload(key, "B");
+
+    List<BlobMetadata> entries = list(key, true);
+
+    assertEquals(3, entries.size());
+    // Newest-first: B (current) -> delete marker -> A.
+    assertEquals(vB, entries.get(0).getVersionId());
+    assertFalse(entries.get(0).isDeleteMarker());
+
+    assertTrue(entries.get(1).isDeleteMarker());
+    assertNull(entries.get(1).getETag());
+
+    assertEquals(vA, entries.get(2).getVersionId());
+    assertFalse(entries.get(2).isDeleteMarker());
+  }
+
+  @Test
+  void noncurrentAt_reflectsSupersessionEvenWhenMarkerHidden() {
+    String key = "obj";
+    upload(key, "A");
+    store.delete(key, null);
+    upload(key, "B");
+
+    // With the marker hidden, the older version's noncurrentAt must still be the marker's
+    // creation time (the instant it stopped being current), not version B's creation time.
+    List<BlobMetadata> hidden = list(key, false);
+    List<BlobMetadata> shown = list(key, true);
+
+    // Current version is never superseded.
+    assertNull(hidden.get(0).getNoncurrentAt());
+
+    BlobMetadata markerEntry = shown.get(1);
+    assertTrue(markerEntry.isDeleteMarker());
+
+    BlobMetadata oldestHidden = hidden.get(1);
+    assertNotNull(oldestHidden.getNoncurrentAt());
+    assertEquals(markerEntry.getCreatedTime(), oldestHidden.getNoncurrentAt());
+    // Validity interval is end-exclusive: version A's window ends exactly at the marker instant.
+    assertTrue(oldestHidden.getCreatedTime().isBefore(oldestHidden.getNoncurrentAt()));
+  }
+
+  @Test
+  void deleteSpecificVersion_removesMarkerHistoryForThatVersion() {
+    String key = "obj";
+    upload(key, "A");
+    store.delete(key, null); // create a marker
+
+    // The marker is visible before it is deleted by version id.
+    List<BlobMetadata> before = list(key, true);
+    String markerVersionId =
+        before.stream()
+            .filter(BlobMetadata::isDeleteMarker)
+            .map(BlobMetadata::getVersionId)
+            .findFirst()
+            .orElseThrow();
+
+    store.delete(key, markerVersionId);
+
+    List<BlobMetadata> after = list(key, true);
+    after.forEach(v -> assertFalse(v.isDeleteMarker()));
+  }
+
+  @Test
+  void exactKeyGuard_doesNotLeakSiblingKeys() {
+    // "obj:child" shares the "obj" storage prefix; the remainder past the prefix still contains a
+    // ':' so it must be excluded from an exact-key listing of "obj".
+    upload("obj", "A");
+    upload("obj:child", "child-A");
+
+    List<BlobMetadata> versions = list("obj", true);
+
+    assertEquals(1, versions.size());
+    assertEquals("obj", versions.get(0).getKey());
+  }
+}

--- a/blob/blob-inmemory/src/test/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStoreListVersionsTest.java
+++ b/blob/blob-inmemory/src/test/java/com/salesforce/multicloudj/blob/inmemory/InMemoryBlobStoreListVersionsTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link InMemoryBlobStore#doListBlobVersions} covering the delete-marker timeline, the
- * {@code includeDeleteMarkers} flag, and cloud-neutral {@code noncurrentAt} computation.
+ * {@code includeArchived} flag, and cloud-neutral {@code archivedAt} computation.
  */
 class InMemoryBlobStoreListVersionsTest {
 
@@ -48,12 +48,12 @@ class InMemoryBlobStoreListVersionsTest {
         .getVersionId();
   }
 
-  private List<BlobMetadata> list(String key, boolean includeDeleteMarkers) {
+  private List<BlobMetadata> list(String key, boolean includeArchived) {
     Iterator<BlobMetadata> it =
         store.listBlobVersions(
             ListBlobVersionsRequest.builder()
                 .withKey(key)
-                .withIncludeDeleteMarkers(includeDeleteMarkers)
+                .withIncludeArchived(includeArchived)
                 .build());
     List<BlobMetadata> out = new ArrayList<>();
     it.forEachRemaining(out::add);
@@ -72,7 +72,7 @@ class InMemoryBlobStoreListVersionsTest {
     assertEquals(2, versions.size());
     assertEquals(vB, versions.get(0).getVersionId());
     assertEquals(vA, versions.get(1).getVersionId());
-    versions.forEach(v -> assertFalse(v.isDeleteMarker()));
+    versions.forEach(v -> assertFalse(v.isArchived()));
   }
 
   @Test
@@ -87,38 +87,38 @@ class InMemoryBlobStoreListVersionsTest {
     assertEquals(3, entries.size());
     // Newest-first: B (current) -> delete marker -> A.
     assertEquals(vB, entries.get(0).getVersionId());
-    assertFalse(entries.get(0).isDeleteMarker());
+    assertFalse(entries.get(0).isArchived());
 
-    assertTrue(entries.get(1).isDeleteMarker());
+    assertTrue(entries.get(1).isArchived());
     assertNull(entries.get(1).getETag());
 
     assertEquals(vA, entries.get(2).getVersionId());
-    assertFalse(entries.get(2).isDeleteMarker());
+    assertFalse(entries.get(2).isArchived());
   }
 
   @Test
-  void noncurrentAt_reflectsSupersessionEvenWhenMarkerHidden() {
+  void archivedAt_reflectsSupersessionEvenWhenMarkerHidden() {
     String key = "obj";
     upload(key, "A");
     store.delete(key, null);
     upload(key, "B");
 
-    // With the marker hidden, the older version's noncurrentAt must still be the marker's
+    // With the marker hidden, the older version's archivedAt must still be the marker's
     // creation time (the instant it stopped being current), not version B's creation time.
     List<BlobMetadata> hidden = list(key, false);
     List<BlobMetadata> shown = list(key, true);
 
     // Current version is never superseded.
-    assertNull(hidden.get(0).getNoncurrentAt());
+    assertNull(hidden.get(0).getArchivedAt());
 
     BlobMetadata markerEntry = shown.get(1);
-    assertTrue(markerEntry.isDeleteMarker());
+    assertTrue(markerEntry.isArchived());
 
     BlobMetadata oldestHidden = hidden.get(1);
-    assertNotNull(oldestHidden.getNoncurrentAt());
-    assertEquals(markerEntry.getCreatedTime(), oldestHidden.getNoncurrentAt());
+    assertNotNull(oldestHidden.getArchivedAt());
+    assertEquals(markerEntry.getCreatedTime(), oldestHidden.getArchivedAt());
     // Validity interval is end-exclusive: version A's window ends exactly at the marker instant.
-    assertTrue(oldestHidden.getCreatedTime().isBefore(oldestHidden.getNoncurrentAt()));
+    assertTrue(oldestHidden.getCreatedTime().isBefore(oldestHidden.getArchivedAt()));
   }
 
   @Test
@@ -131,7 +131,7 @@ class InMemoryBlobStoreListVersionsTest {
     List<BlobMetadata> before = list(key, true);
     String markerVersionId =
         before.stream()
-            .filter(BlobMetadata::isDeleteMarker)
+            .filter(BlobMetadata::isArchived)
             .map(BlobMetadata::getVersionId)
             .findFirst()
             .orElseThrow();
@@ -139,7 +139,7 @@ class InMemoryBlobStoreListVersionsTest {
     store.delete(key, markerVersionId);
 
     List<BlobMetadata> after = list(key, true);
-    after.forEach(v -> assertFalse(v.isDeleteMarker()));
+    after.forEach(v -> assertFalse(v.isArchived()));
   }
 
   @Test


### PR DESCRIPTION
## Summary
Adds an opt-in `includeDeleteMarkers` flag to `listBlobVersions` and a cloud-neutral `noncurrentAt` timestamp on `BlobMetadata`, so callers can reconstruct an object's full version timeline (including delete markers) and reason about each content version's validity interval `[createdTime, noncurrentAt)` (end-exclusive). Default behavior is unchanged — the flag defaults to `false`.

## Changes
- `ListBlobVersionsRequest`: new `includeDeleteMarkers` flag (default `false`, backward compatible).
- `BlobMetadata`: new `deleteMarker` boolean and cloud-neutral `noncurrentAt` timestamp.
- **AWS**: two-pointer merge of S3 `ListObjectVersions` `versions()` and `deleteMarkers()` so delete markers always drive `noncurrentAt`, but are only emitted when the flag is set.
- **GCP**: map `getDeleteTimeOffsetDateTime()` to `noncurrentAt` across generations.
- **InMemory**: monotonic-clock delete-marker history with a descending timeline and end-exclusive `noncurrentAt`.
- Alibaba is out of scope and guarded in the conformance test.

## API Example
```java
Iterator<BlobMetadata> versions = bucketClient.listBlobVersions(
    ListBlobVersionsRequest.builder()
        .withKey("my-object")
        .withIncludeDeleteMarkers(true)
        .build());
// Each returned BlobMetadata exposes isDeleteMarker() and getNoncurrentAt().
```

## Testing
- AWS `BlobMetadataIteratorTest`: merge ordering and filtered-but-still-drives-`noncurrentAt`.
- GCP `GcpBlobStoreTest`: `createdTime`/`noncurrentAt` mapping and sibling-key filtering.
- InMemory `InMemoryBlobStoreListVersionsTest`: flag on/off, hidden-marker supersession, delete-by-version marker removal, exact-key guard.
- Conformance `testListBlobVersions_deleteMarkerTimeline` in `AbstractBlobStoreIT` (PUT → unqualified DELETE → PUT) with recorded AWS and GCP WireMock fixtures; passes in replay mode.

## Cross-Cloud Compatibility
- AWS: fully supported via `ListObjectVersions`.
- GCP: fully supported via generation listing.
- InMemory: fully supported.
- Alibaba: out of scope, tracked separately; guarded via assumption in the conformance test.