### PR TITLE
sts: pin STS verifier replay to trusted https endpoints

### DIFF
--- a/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliStsVerifier.java
+++ b/sts/sts-ali/src/main/java/com/salesforce/multicloudj/sts/ali/AliStsVerifier.java
@@ -19,7 +19,9 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Alibaba Cloud implementation of the STS verifier. It validates a signed identity by replaying the
@@ -30,9 +32,23 @@ import java.util.Map;
  * every signed parameter, and the RPC signature. Alibaba Cloud RPC signatures cover the HTTP
  * method, so the request is replayed with the same GET method used to sign it; STS then validates
  * the signature and returns the identity of the credentials that produced it.
+ *
+ * <p>The URL host is untrusted input, so before replaying, the verifier requires an https scheme
+ * and confirms the host is a genuine Alibaba Cloud STS endpoint. This prevents a crafted signed
+ * identity from redirecting the replay to an attacker-controlled server that could return a forged
+ * identity.
  */
 @AutoService(AbstractStsVerifier.class)
 public class AliStsVerifier extends AbstractStsVerifier {
+  private static final String HTTPS_SCHEME = "https";
+
+  // Alibaba Cloud STS endpoint hostnames: the central sts.aliyuncs.com, regional
+  // sts.<region>.aliyuncs.com, and their VPC variants. The signed identity carries a host, but it
+  // is untrusted input; the request is only replayed when the host is a genuine STS endpoint so a
+  // crafted URL cannot redirect the replay to an attacker-controlled server.
+  private static final Pattern STS_HOST_PATTERN =
+      Pattern.compile("^sts(-vpc)?(\\.[a-z0-9-]+)?\\.aliyuncs\\.com$");
+
   private final HttpClient httpClient;
 
   public AliStsVerifier() {
@@ -63,6 +79,7 @@ public class AliStsVerifier extends AbstractStsVerifier {
     }
 
     URI identityUri = URI.create(signedIdentity);
+    verifyStsEndpoint(identityUri);
     Map<String, String> params = parseQuery(identityUri.getRawQuery());
     verifyExpectedCustomHeaders(params, options);
 
@@ -84,6 +101,19 @@ public class AliStsVerifier extends AbstractStsVerifier {
     }
 
     return parseCallerIdentity(response.body());
+  }
+
+  private static void verifyStsEndpoint(URI identityUri) {
+    String scheme = identityUri.getScheme();
+    if (scheme == null || !HTTPS_SCHEME.equalsIgnoreCase(scheme)) {
+      throw new UnAuthorizedException(
+          "signed identity must target an https STS endpoint, got scheme: " + scheme);
+    }
+    String host = identityUri.getHost();
+    if (host == null || !STS_HOST_PATTERN.matcher(host.toLowerCase(Locale.ROOT)).matches()) {
+      throw new UnAuthorizedException(
+          "signed identity does not target a recognized Alibaba Cloud STS endpoint: " + host);
+    }
   }
 
   private static void verifyExpectedCustomHeaders(

--- a/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsVerifierTest.java
+++ b/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsVerifierTest.java
@@ -15,6 +15,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class AliStsVerifierTest {
 
@@ -143,6 +144,46 @@ class AliStsVerifierTest {
     AliStsVerifier verifier = new AliStsVerifier.Builder().build(httpClient);
     Assertions.assertThrows(
         UnknownException.class, () -> verifier.verifySignedAuthRequest(IDENTITY));
+  }
+
+  @Test
+  void untrustedHostIsRejectedWithoutReplay() {
+    // A crafted signed identity pointing at an attacker-controlled host that would happily return a
+    // well-formed identity response must be rejected before any replay happens, otherwise the
+    // attacker forges an identity. The client is never touched.
+    HttpClient httpClient = mock(HttpClient.class);
+    String forgedIdentity =
+        "https://localhost:9999/?Action=GetCallerIdentity&Version=2015-04-01&Format=JSON";
+
+    AliStsVerifier verifier = new AliStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(forgedIdentity));
+    Mockito.verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void nonHttpsSchemeIsRejected() {
+    HttpClient httpClient = mock(HttpClient.class);
+    String insecureIdentity =
+        "http://sts.cn-hangzhou.aliyuncs.com/?Action=GetCallerIdentity&Version=2015-04-01"
+            + "&Format=JSON";
+
+    AliStsVerifier verifier = new AliStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(insecureIdentity));
+    Mockito.verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void centralStsEndpointIsAccepted() throws Exception {
+    HttpClient httpClient = okClient();
+    String centralIdentity =
+        "https://sts.aliyuncs.com/?Action=GetCallerIdentity&Version=2015-04-01&Format=JSON";
+
+    CallerIdentity identity =
+        new AliStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(centralIdentity);
+    Assertions.assertEquals("123456789012", identity.getAccountId());
   }
 
   @SuppressWarnings("unchecked")

--- a/sts/sts-aws/src/main/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifier.java
+++ b/sts/sts-aws/src/main/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifier.java
@@ -18,7 +18,9 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
@@ -32,6 +34,10 @@ import org.xml.sax.InputSource;
  * <p>The signed identity is a URL rooted at the STS endpoint whose query string carries the STS
  * action, version, and every signed request header. Replaying that request lets AWS STS validate
  * the SigV4 signature and return the identity of the credentials that produced it.
+ *
+ * <p>The URL host is untrusted input, so before replaying, the verifier requires an https scheme
+ * and confirms the host is a genuine AWS STS endpoint. This prevents a crafted signed identity from
+ * redirecting the replay to an attacker-controlled server that could return a forged identity.
  */
 @AutoService(AbstractStsVerifier.class)
 public class AwsStsVerifier extends AbstractStsVerifier {
@@ -39,6 +45,14 @@ public class AwsStsVerifier extends AbstractStsVerifier {
   private static final String VERSION_PARAM = "Version";
   private static final String DEFAULT_API_ACTION_NAME = "GetCallerIdentity";
   private static final String DEFAULT_API_VERSION = "2011-06-15";
+  private static final String HTTPS_SCHEME = "https";
+
+  // AWS STS endpoint hostnames: the global sts.amazonaws.com, regional sts.<region>.amazonaws.com,
+  // their FIPS variants, and the China partition (.amazonaws.com.cn). The signed identity carries a
+  // host, but it is untrusted input; the request is only replayed when the host is a genuine STS
+  // endpoint so a crafted URL cannot redirect the replay to an attacker-controlled server.
+  private static final Pattern STS_HOST_PATTERN =
+      Pattern.compile("^sts(-fips)?(\\.[a-z0-9-]+)?\\.amazonaws\\.com(\\.cn)?$");
 
   private final HttpClient httpClient;
 
@@ -70,6 +84,7 @@ public class AwsStsVerifier extends AbstractStsVerifier {
     }
 
     URI identityUri = URI.create(signedIdentity);
+    verifyStsEndpoint(identityUri);
     Map<String, String> params = parseQuery(identityUri.getRawQuery());
 
     // The signed request carries its headers as query parameters. Custom headers are validated
@@ -116,6 +131,19 @@ public class AwsStsVerifier extends AbstractStsVerifier {
     }
 
     return parseCallerIdentity(response.body());
+  }
+
+  private static void verifyStsEndpoint(URI identityUri) {
+    String scheme = identityUri.getScheme();
+    if (scheme == null || !HTTPS_SCHEME.equalsIgnoreCase(scheme)) {
+      throw new UnAuthorizedException(
+          "signed identity must target an https STS endpoint, got scheme: " + scheme);
+    }
+    String host = identityUri.getHost();
+    if (host == null || !STS_HOST_PATTERN.matcher(host.toLowerCase(Locale.ROOT)).matches()) {
+      throw new UnAuthorizedException(
+          "signed identity does not target a recognized AWS STS endpoint: " + host);
+    }
   }
 
   private static void verifyExpectedCustomHeaders(

--- a/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifierTest.java
+++ b/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifierTest.java
@@ -15,6 +15,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class AwsStsVerifierTest {
 
@@ -178,6 +179,45 @@ class AwsStsVerifierTest {
 
     CallerIdentity identity =
         new AwsStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(identityWithHost);
+    Assertions.assertEquals("123456789012", identity.getAccountId());
+  }
+
+  @Test
+  void untrustedHostIsRejectedWithoutReplay() {
+    // A crafted signed identity pointing at an attacker-controlled host that would happily return a
+    // well-formed GetCallerIdentity response must be rejected before any replay happens, otherwise
+    // the attacker forges an identity. The client is never touched.
+    HttpClient httpClient = mock(HttpClient.class);
+    String forgedIdentity =
+        "https://localhost:9999/?Action=GetCallerIdentity&Version=2011-06-15";
+
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(forgedIdentity));
+    Mockito.verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void nonHttpsSchemeIsRejected() {
+    HttpClient httpClient = mock(HttpClient.class);
+    String insecureIdentity =
+        "http://sts.us-west-2.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15";
+
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(insecureIdentity));
+    Mockito.verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void globalStsEndpointIsAccepted() throws Exception {
+    HttpClient httpClient = okClient();
+    String globalIdentity =
+        "https://sts.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15";
+
+    CallerIdentity identity =
+        new AwsStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(globalIdentity);
     Assertions.assertEquals("123456789012", identity.getAccountId());
   }
 


### PR DESCRIPTION
## Summary
Pins the AWS and Alibaba Cloud STS verifier replay to trusted, HTTPS STS endpoints. Both verifiers replay the presigned `GetCallerIdentity` request and trust the HTTP 200 response as the caller identity. The replay target host came straight from the (untrusted) signed identity, so a crafted identity pointing at an attacker-controlled server that returns a well-formed response could forge an identity. This change validates the scheme and host before any replay happens.

## Changes
- `AwsStsVerifier` / `AliStsVerifier`: before replaying, require an `https` scheme and confirm the host matches a genuine STS endpoint allowlist; otherwise throw `UnAuthorizedException` without touching the HTTP client.
  - AWS pattern: `sts.amazonaws.com`, regional `sts.<region>.amazonaws.com`, FIPS variants, and the China partition (`.amazonaws.com.cn`).
  - Alibaba pattern: central `sts.aliyuncs.com`, regional `sts.<region>.aliyuncs.com`, and VPC variants.
- Added regression tests for each provider: untrusted host is rejected without replay (`verifyNoInteractions`), non-HTTPS scheme is rejected, and the global/central endpoint is accepted.

## Why GCP is unaffected
The GCP verifier does not use the replay model. It fetches Google's JWKS from a hardcoded host and verifies the JWT signature cryptographically, so the token cannot redirect it to an attacker-controlled server. No change was required.

## Testing
- `mvn test -pl sts/sts-aws,sts/sts-ali -Dtest=AwsStsVerifierTest,AliStsVerifierTest` — 16 AWS + 14 Ali tests pass.
