### PR TITLE
sts: cover AWS/Ali STS host regex accept and spoof-reject cases

### DIFF
--- a/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsVerifierTest.java
+++ b/sts/sts-ali/src/test/java/com/salesforce/multicloudj/sts/ali/AliStsVerifierTest.java
@@ -186,6 +186,92 @@ class AliStsVerifierTest {
     Assertions.assertEquals("123456789012", identity.getAccountId());
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  void vpcStsEndpointIsAccepted() throws Exception {
+    HttpClient httpClient = okClient();
+    String vpcIdentity =
+        "https://sts-vpc.cn-hangzhou.aliyuncs.com/?Action=GetCallerIdentity&Version=2015-04-01"
+            + "&Format=JSON";
+
+    CallerIdentity identity =
+        new AliStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(vpcIdentity);
+    Assertions.assertEquals("123456789012", identity.getAccountId());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void uppercaseHostIsAccepted() throws Exception {
+    // The host is untrusted input and may arrive in any case; it is lowercased before matching, so
+    // an uppercase STS host must still be accepted.
+    HttpClient httpClient = okClient();
+    String upperIdentity =
+        "https://STS.CN-HANGZHOU.ALIYUNCS.COM/?Action=GetCallerIdentity&Version=2015-04-01"
+            + "&Format=JSON";
+
+    CallerIdentity identity =
+        new AliStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(upperIdentity);
+    Assertions.assertEquals("123456789012", identity.getAccountId());
+  }
+
+  @Test
+  void lookAlikeHostWithStsSuffixIsRejected() {
+    // A host that merely ends in a genuine-looking segment but is rooted at an attacker domain must
+    // be rejected before any replay happens.
+    HttpClient httpClient = mock(HttpClient.class);
+    String forgedIdentity =
+        "https://sts.cn-hangzhou.aliyuncs.com.attacker.com/?Action=GetCallerIdentity"
+            + "&Version=2015-04-01&Format=JSON";
+
+    AliStsVerifier verifier = new AliStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(forgedIdentity));
+    Mockito.verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void hostWithStsPrefixOnAttackerDomainIsRejected() {
+    // "sts" appearing as a label inside an attacker-controlled domain must not be mistaken for a
+    // genuine STS endpoint.
+    HttpClient httpClient = mock(HttpClient.class);
+    String forgedIdentity =
+        "https://sts.aliyuncs.evil.com/?Action=GetCallerIdentity&Version=2015-04-01&Format=JSON";
+
+    AliStsVerifier verifier = new AliStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(forgedIdentity));
+    Mockito.verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void hostWithoutStsPrefixIsRejected() {
+    // A host under aliyuncs.com that is not an STS endpoint must be rejected.
+    HttpClient httpClient = mock(HttpClient.class);
+    String forgedIdentity =
+        "https://notsts.cn-hangzhou.aliyuncs.com/?Action=GetCallerIdentity&Version=2015-04-01"
+            + "&Format=JSON";
+
+    AliStsVerifier verifier = new AliStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(forgedIdentity));
+    Mockito.verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void hostWithExtraSubdomainIsRejected() {
+    // Only a single region label is permitted between the sts prefix and aliyuncs.com; extra labels
+    // must be rejected.
+    HttpClient httpClient = mock(HttpClient.class);
+    String forgedIdentity =
+        "https://sts.extra.cn-hangzhou.aliyuncs.com/?Action=GetCallerIdentity&Version=2015-04-01"
+            + "&Format=JSON";
+
+    AliStsVerifier verifier = new AliStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(forgedIdentity));
+    Mockito.verifyNoInteractions(httpClient);
+  }
+
   @SuppressWarnings("unchecked")
   private static HttpClient okClient() throws IOException, InterruptedException {
     HttpClient httpClient = mock(HttpClient.class);

--- a/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifierTest.java
+++ b/sts/sts-aws/src/test/java/com/salesforce/multicloudj/sts/aws/AwsStsVerifierTest.java
@@ -221,6 +221,100 @@ class AwsStsVerifierTest {
     Assertions.assertEquals("123456789012", identity.getAccountId());
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  void fipsStsEndpointIsAccepted() throws Exception {
+    HttpClient httpClient = okClient();
+    String fipsIdentity =
+        "https://sts-fips.us-west-2.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15";
+
+    CallerIdentity identity =
+        new AwsStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(fipsIdentity);
+    Assertions.assertEquals("123456789012", identity.getAccountId());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void chinaPartitionStsEndpointIsAccepted() throws Exception {
+    HttpClient httpClient = okClient();
+    String chinaIdentity =
+        "https://sts.cn-north-1.amazonaws.com.cn/?Action=GetCallerIdentity&Version=2011-06-15";
+
+    CallerIdentity identity =
+        new AwsStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(chinaIdentity);
+    Assertions.assertEquals("123456789012", identity.getAccountId());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void uppercaseHostIsAccepted() throws Exception {
+    // The host is untrusted input and may arrive in any case; it is lowercased before matching, so
+    // an uppercase STS host must still be accepted.
+    HttpClient httpClient = okClient();
+    String upperIdentity =
+        "https://STS.US-WEST-2.AMAZONAWS.COM/?Action=GetCallerIdentity&Version=2011-06-15";
+
+    CallerIdentity identity =
+        new AwsStsVerifier.Builder().build(httpClient).verifySignedAuthRequest(upperIdentity);
+    Assertions.assertEquals("123456789012", identity.getAccountId());
+  }
+
+  @Test
+  void lookAlikeHostWithStsSuffixIsRejected() {
+    // A host that merely ends in a genuine-looking segment but is rooted at an attacker domain must
+    // be rejected before any replay happens.
+    HttpClient httpClient = mock(HttpClient.class);
+    String forgedIdentity =
+        "https://sts.us-west-2.amazonaws.com.attacker.com/?Action=GetCallerIdentity"
+            + "&Version=2011-06-15";
+
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(forgedIdentity));
+    Mockito.verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void hostWithStsPrefixOnAttackerDomainIsRejected() {
+    // "sts" appearing as a label inside an attacker-controlled domain must not be mistaken for a
+    // genuine STS endpoint.
+    HttpClient httpClient = mock(HttpClient.class);
+    String forgedIdentity =
+        "https://sts.amazonaws.evil.com/?Action=GetCallerIdentity&Version=2011-06-15";
+
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(forgedIdentity));
+    Mockito.verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void hostWithoutStsPrefixIsRejected() {
+    // A host under amazonaws.com that is not an STS endpoint must be rejected.
+    HttpClient httpClient = mock(HttpClient.class);
+    String forgedIdentity =
+        "https://notsts.us-west-2.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15";
+
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(forgedIdentity));
+    Mockito.verifyNoInteractions(httpClient);
+  }
+
+  @Test
+  void hostWithExtraSubdomainIsRejected() {
+    // Only a single region label is permitted between the sts prefix and amazonaws.com; extra
+    // labels must be rejected.
+    HttpClient httpClient = mock(HttpClient.class);
+    String forgedIdentity =
+        "https://sts.extra.us-west-2.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15";
+
+    AwsStsVerifier verifier = new AwsStsVerifier.Builder().build(httpClient);
+    Assertions.assertThrows(
+        UnAuthorizedException.class, () -> verifier.verifySignedAuthRequest(forgedIdentity));
+    Mockito.verifyNoInteractions(httpClient);
+  }
+
   @SuppressWarnings("unchecked")
   private static HttpClient okClient() throws IOException, InterruptedException {
     HttpClient httpClient = mock(HttpClient.class);


### PR DESCRIPTION
## What

Adds the missing unit test coverage for the STS endpoint host regex validation in the AWS and Alibaba Cloud verifiers. The verifiers reject signed identities whose host is not a genuine STS endpoint (added in #620), but the tests only exercised one accepted endpoint plus the localhost/non-https rejection. The regex branches for partition variants and the spoof-rejection boundaries were uncovered.

## Tests added

**AWS (`AwsStsVerifierTest`)** — regex `^sts(-fips)?(\.[a-z0-9-]+)?\.amazonaws\.com(\.cn)?$`
- `fipsStsEndpointIsAccepted` — `sts-fips.us-west-2.amazonaws.com`
- `chinaPartitionStsEndpointIsAccepted` — `sts.cn-north-1.amazonaws.com.cn`
- `uppercaseHostIsAccepted` — exercises the `toLowerCase` path
- `lookAlikeHostWithStsSuffixIsRejected` — `sts.us-west-2.amazonaws.com.attacker.com`
- `hostWithStsPrefixOnAttackerDomainIsRejected` — `sts.amazonaws.evil.com`
- `hostWithoutStsPrefixIsRejected` — `notsts.us-west-2.amazonaws.com`
- `hostWithExtraSubdomainIsRejected` — `sts.extra.us-west-2.amazonaws.com`

**Ali (`AliStsVerifierTest`)** — regex `^sts(-vpc)?(\.[a-z0-9-]+)?\.aliyuncs\.com$`
- `vpcStsEndpointIsAccepted` — `sts-vpc.cn-hangzhou.aliyuncs.com`
- `uppercaseHostIsAccepted`
- `lookAlikeHostWithStsSuffixIsRejected` — `sts.cn-hangzhou.aliyuncs.com.attacker.com`
- `hostWithStsPrefixOnAttackerDomainIsRejected` — `sts.aliyuncs.evil.com`
- `hostWithoutStsPrefixIsRejected` — `notsts.cn-hangzhou.aliyuncs.com`
- `hostWithExtraSubdomainIsRejected` — `sts.extra.cn-hangzhou.aliyuncs.com`

Rejection tests assert `verifyNoInteractions(httpClient)` so a spoofed host never triggers a replay.

## Verification

- `AwsStsVerifierTest`: 23 tests pass (was 16)
- `AliStsVerifierTest`: 20 tests pass (was 14)
- checkstyle passes on both modules

Test-only change; no production code touched.